### PR TITLE
[#171154124] fix local development

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,3 +26,4 @@ SPID_TESTENV_URL=https://spid-testenv2:8088
 IDP_METADATA_URL=https://registry.spid.gov.it/metadata/idp/spid-entities-idps.xml
 SHUTDOWN_SIGNALS="SIGINT SIGTERM"
 SHUTDOWN_TIMEOUT_MILLIS=30000
+GITHUB_TOKEN=<mygithubtoken>

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ COPY /api_backend.yaml /usr/src/app/api_backend.yaml
 COPY /api_pagopa.yaml /usr/src/app/api_pagopa.yaml
 COPY /api_public.yaml /usr/src/app/api_public.yaml
 
+COPY /.npmrc /usr/src/app/.npmrc
 RUN sudo chmod -R 777 /usr/src/app \
   && yarn install \
   && yarn generate:proxy-models \

--- a/README.md
+++ b/README.md
@@ -105,8 +105,8 @@ A Linux/macOS environment is required at the moment.
 9. edit your `/etc/hosts` file by adding:
 
     ```
-    localhost    spid-testenv2
-    localhost    italia-backend
+    127.0.0.1    spid-testenv2
+    127.0.0.1    italia-backend
     ```
 
 12. copy `.env.example` to `.env` and fill the variables with your values
@@ -158,6 +158,7 @@ Those are all Environment variables needed by the application:
 | CACHE_MAX_AGE_SECONDS                  | The value in seconds for duration of in-memory api cache                          | int |
 | APICACHE_DEBUG                         | When is `true` enable the apicache debug mode                                     | boolean |
 | ALLOW_MULTIPLE_SESSIONS                | When is `true` allow multiple sessions for an user (default `false`)              | boolean |
+| GITHUB_TOKEN                           | The value of your Github Api Key, used in build phase  | string |
 
 ### Logs
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,13 +9,14 @@ services:
     environment:
       - NODE_ENV=dev
       - REDIS_URL=redis://redis
+      - GITHUB_TOKEN
     expose:
       - "443"
     ports:
       - "443:443"
     image: node:10.14.2-alpine
     volumes:
-      - ".env:/usr/src/app/.env:delegated"
+      - ".env:/usr/src/app/.env"
       - "./certs:/usr/src/app/certs:delegated"
 
   spid-testenv2:


### PR DESCRIPTION
npmrc instructions are missing
docker-compose doesn't mount .env file using :delegated
Dockerfile does not have step for copying npmrc file into docker image
/etc/hosts mapping should be based on ip instead of 'localhost'