### PR TITLE
[#168929351] fix installationId to last device

### DIFF
--- a/src/services/__tests__/notificationService.test.ts
+++ b/src/services/__tests__/notificationService.test.ts
@@ -9,12 +9,14 @@ import { MessageSubject } from "../../../generated/backend/MessageSubject";
 import { PlatformEnum } from "../../../generated/backend/Platform";
 import { APNSPushType } from "../../types/notification";
 import NotificationService, {
-  NotificationServiceOptions
+  NotificationServiceOptions,
+  toNotificationTag
 } from "../notificationService";
 
 const aFiscalCode = "GRBGPP87L04L741X" as FiscalCode;
 const aFiscalCodeHash =
   "d3f70202fd4d5bd995d6fe996337c1b77b0a4a631203048dafba121d2715ea52";
+const aNotificationTag = toNotificationTag(aFiscalCode);
 const anInstallationID = "550e8400-e29b-41d4-a716-446655440000" as InstallationID;
 const aPushChannel =
   "fLKP3EATnBI:APA91bEy4go681jeSEpLkNqhtIrdPnEKu6Dfi-STtUiEnQn8RwMfBiPGYaqdWrmzJyXIh5Yms4017MYRS9O1LGPZwA4sOLCNIoKl4Fwg7cSeOkliAAtlQ0rVg71Kr5QmQiLlDJyxcq3p";
@@ -196,7 +198,7 @@ describe("NotificationService#notify", () => {
       value: { message: "ok" }
     });
     expect(mockSend).toBeCalledWith(
-      aFiscalCodeHash,
+      aNotificationTag,
       {
         message: aValidNotification.message.content.subject,
         message_id: aValidNotification.message.id,
@@ -224,7 +226,7 @@ describe("NotificationService#notify", () => {
       kind: "IResponseErrorInternal"
     });
     expect(mockSend).toBeCalledWith(
-      aFiscalCodeHash,
+      aNotificationTag,
       {
         message: aValidNotification.message.content.subject,
         message_id: aValidNotification.message.id,

--- a/src/services/notificationService.ts
+++ b/src/services/notificationService.ts
@@ -53,6 +53,12 @@ export type NotificationServiceOptions = t.TypeOf<
   typeof NotificationServiceOptions
 >;
 
+// send the push notification only to the last
+// device that set the installationId
+// see https://docs.microsoft.com/en-us/azure/notification-hubs/notification-hubs-push-notification-registration-management#installations
+export const toNotificationTag = (fiscalCode: FiscalCode) =>
+  `$InstallationId:{${toFiscalCodeHash(fiscalCode)}}`;
+
 export default class NotificationService {
   private notificationHubService: azure.NotificationHubService;
   constructor(
@@ -81,7 +87,7 @@ export default class NotificationService {
           )
         };
         this.notificationHubService.send(
-          toFiscalCodeHash(notification.message.fiscal_code),
+          toNotificationTag(notification.message.fiscal_code),
           payload,
           {
             // Add required headers for APNS notification to iOS 13


### PR DESCRIPTION
When sending push notification target only the last device that set the installationId (in other words, the last device where the user logged in successfully). This limits sending push notification to just one device owned by the user.