### PR TITLE
[#173017529] Add bonus activation detail endpoint

### DIFF
--- a/src/__mocks__/request.ts
+++ b/src/__mocks__/request.ts
@@ -5,7 +5,11 @@
  * @returns {{header, accepts, acceptsEncodings, acceptsEncoding, acceptsCharsets, acceptsCharset, acceptsLanguages, acceptsLanguage, range, param, is, reset: resetMock}}
  */
 
-export default function mockReq(): any {
+export default function mockReq({
+  params = {},
+  body = {},
+  query = {}
+}: any = {}): any {
   const request = {
     accepts: jest.fn(),
     acceptsCharset: jest.fn(),
@@ -14,10 +18,12 @@ export default function mockReq(): any {
     acceptsEncodings: jest.fn(),
     acceptsLanguage: jest.fn(),
     acceptsLanguages: jest.fn(),
+    body,
     header: jest.fn(),
     is: jest.fn(),
     param: jest.fn(),
-    query: {},
+    params,
+    query,
     range: jest.fn(),
     reset: resetMock
   };
@@ -31,7 +37,9 @@ export default function mockReq(): any {
   request.acceptsLanguages.mockImplementation(() => request);
   request.acceptsLanguage.mockImplementation(() => request);
   request.range.mockImplementation(() => request);
-  request.param.mockImplementation(() => request);
+  request.param.mockImplementation(name => {
+    return { ...params, ...body, ...query }[name];
+  });
   request.is.mockImplementation(() => request);
 
   return request;

--- a/src/app.ts
+++ b/src/app.ts
@@ -618,6 +618,15 @@ function registerBonusAPIRoutes(
     bearerSessionTokenAuth,
     toExpressHandler(bonusController.getBonusEligibilityCheck, bonusController)
   );
+
+  app.get(
+    `${basePath}/bonus/vacanze/activations/:bonus_id`,
+    bearerSessionTokenAuth,
+    toExpressHandler(
+      bonusController.getLatestBonusActivationById,
+      bonusController
+    )
+  );
 }
 
 function registerAuthenticationRoutes(

--- a/src/services/__tests__/bonusService.test.ts
+++ b/src/services/__tests__/bonusService.test.ts
@@ -197,7 +197,7 @@ describe("BonusService#getBonusEligibilityCheck", () => {
 
     const service = new BonusService(api);
 
-    const res = await service.startBonusEligibilityCheck(mockedUser);
+    const res = await service.getBonusEligibilityCheck(mockedUser);
 
     expect(res).toMatchObject({
       kind: "IResponseErrorInternal"
@@ -210,7 +210,7 @@ describe("BonusService#getBonusEligibilityCheck", () => {
     );
     const service = new BonusService(api);
 
-    const res = await service.startBonusEligibilityCheck(mockedUser);
+    const res = await service.getBonusEligibilityCheck(mockedUser);
 
     expect(res).toMatchObject({
       kind: "IResponseErrorInternal"
@@ -223,7 +223,7 @@ describe("BonusService#getBonusEligibilityCheck", () => {
     });
     const service = new BonusService(api);
 
-    const res = await service.startBonusEligibilityCheck(mockedUser);
+    const res = await service.getBonusEligibilityCheck(mockedUser);
 
     expect(res).toMatchObject({
       kind: "IResponseErrorInternal"

--- a/src/services/bonusService.ts
+++ b/src/services/bonusService.ts
@@ -155,7 +155,8 @@ export default class BonusService {
       return withValidatedOrInternalError(validated, response => {
         switch (response.status) {
           case 200:
-            // TODO: aggiungere qr code
+            // TODO: add qr code
+            // https://www.pivotaltracker.com/story/show/173079501
             return ResponseSuccessJson(response.value);
           case 404:
             return ResponseErrorNotFound(


### PR DESCRIPTION
### What's inside:
* implemented proxy endpoint for bonus' `getLatestBonusActivationById`
* fixed some wrong tests for `getBonusEligibilityCheck`
* updated to last version of bonus API spec
* updated mocks

### What's not implemented:
`getLatestBonusActivationById` should return a `BonusActivationWithQrCode`, but so far it returns just a `BonusActivation` as the qrcode generation part isn't implemented yet