### PR TITLE
[#173241768] Add securityDefinitions in bonus API spec

### DIFF
--- a/api_bonus.yaml
+++ b/api_bonus.yaml
@@ -201,3 +201,4 @@ securityDefinitions:
       type: apiKey
       name: Authorization
       in: header
+      

--- a/api_bonus.yaml
+++ b/api_bonus.yaml
@@ -201,4 +201,3 @@ securityDefinitions:
       type: apiKey
       name: Authorization
       in: header
-      

--- a/api_bonus.yaml
+++ b/api_bonus.yaml
@@ -196,3 +196,8 @@ definitions:
     allOf:
       - $ref: '#/definitions/BonusActivation'
       - $ref: '#/definitions/QrCode'
+securityDefinitions:
+  Bearer:
+      type: apiKey
+      name: Authorization
+      in: header


### PR DESCRIPTION
This PR adds the missing section **securityDefinitions**

```yaml
securityDefinitions:
  Bearer:
      type: apiKey
      name: Authorization
      in: header
```