### PR TITLE
[#175679733] Rename GetSupport Token endpoint

### DIFF
--- a/api_backend.yaml
+++ b/api_backend.yaml
@@ -476,7 +476,7 @@ paths:
           description: Unavailable service
           schema:
             $ref: "#/definitions/ProblemJson"
-  "/token":
+  "/token/support":
     x-swagger-router-controller: SupportController
     get:
       operationId: getSupportToken

--- a/src/app.ts
+++ b/src/app.ts
@@ -735,7 +735,7 @@ function registerAPIRoutes(
   );
 
   app.get(
-    `${basePath}/token`,
+    `${basePath}/token/support`,
     bearerSessionTokenAuth,
     toExpressHandler(supportController.getSupportToken, supportController)
   );


### PR DESCRIPTION
This PR includes a minor refactoring of `GetSupportToken` endpoint. It will be changed from `/token` to `/token/support`.