### PR TITLE
[#176003320] Return 500 instead of 401 on system errors

### DIFF
--- a/src/utils/strategies.ts
+++ b/src/utils/strategies.ts
@@ -21,7 +21,7 @@ export function fulfill(
   done: StrategyDoneFunction
 ): void {
   errorOrUser.fold(
-    error => done(undefined, false, error.message),
+    error => done(error.message),
     user => done(undefined, user.isNone() ? false : user.value)
   );
 }

--- a/src/utils/strategies.ts
+++ b/src/utils/strategies.ts
@@ -21,7 +21,7 @@ export function fulfill(
   done: StrategyDoneFunction
 ): void {
   errorOrUser.fold(
-    error => done(error.message),
+    error => done(error),
     user => done(undefined, user.isNone() ? false : user.value)
   );
 }


### PR DESCRIPTION
Atm the passport middleware returns 401 in case of system errors; it must return 500 otherwise the user is logged out.

Draft since it needs unit and integration tests.