### PR TITLE
[#176077315] Get client ip from x-forwarded-for header

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   "homepage": "https://github.com/pagopa/io-backend#readme",
   "dependencies": {
     "@azure/storage-queue": "^12.0.0",
-    "@pagopa/io-spid-commons": "^4.9.0",
+    "@pagopa/io-spid-commons": "^4.10.0",
     "apicache": "^1.4.0",
     "applicationinsights": "^1.7.4",
     "body-parser": "^1.18.3",

--- a/package.json
+++ b/package.json
@@ -83,7 +83,6 @@
     "range_check": "^1.4.0",
     "redis": "^2.8.0",
     "redis-clustr": "^1.6.0",
-    "request-ip": "^2.1.1",
     "ulid": "^2.2.2",
     "validator": "^10.8.0",
     "winston": "^3.0.0",

--- a/src/__tests__/app.test.ts
+++ b/src/__tests__/app.test.ts
@@ -123,7 +123,8 @@ describe("Success app start", () => {
         .post("/api/v1/notify?token=12345")
         .send(aValidNotification)
         .set(X_FORWARDED_PROTO_HEADER, "https")
-        .set("X-Client-Ip", "192.168.1.2")
+        .set("X-Client-Ip", "1.1.1.1")
+        .set("X-Forwarded-For", "192.168.1.2")
         .expect(200);
     });
 

--- a/src/utils/middleware/checkIP.ts
+++ b/src/utils/middleware/checkIP.ts
@@ -6,7 +6,6 @@ import * as express from "express";
 import { isLeft } from "fp-ts/lib/Either";
 import { CIDR, IPString } from "italia-ts-commons/lib/strings";
 import * as rangeCheck from "range_check";
-import * as requestIp from "request-ip";
 import { log } from "../logger";
 
 export default function checkIP(
@@ -21,8 +20,10 @@ export default function checkIP(
     res: express.Response,
     next: express.NextFunction
   ) => {
-    const clientIp = requestIp.getClientIp(req);
-    const errorOrIPString = IPString.decode(clientIp);
+    // when the boolean flag "trust proxy" is enabled
+    // express takes this from the leftmost value
+    // contained in the x-forwarded-for header
+    const errorOrIPString = IPString.decode(req.ip);
 
     if (isLeft(errorOrIPString)) {
       log.error(`Bad request: ${errorOrIPString.value}.`);

--- a/yarn.lock
+++ b/yarn.lock
@@ -259,10 +259,10 @@
   resolved "https://registry.yarnpkg.com/@opentelemetry/types/-/types-0.2.0.tgz#2a0afd40fa7026e39ea56a454642bda72b172f80"
   integrity sha512-GtwNB6BNDdsIPAYEdpp3JnOGO/3AJxjPvny53s3HERBdXSJTGQw8IRhiaTEX0b3w9P8+FwFZde4k+qkjn67aVw==
 
-"@pagopa/io-spid-commons@^4.9.0":
-  version "4.9.0"
-  resolved "https://npm.pkg.github.com/download/@pagopa/io-spid-commons/4.9.0/4204cf3d8dd4df4d0ddabfbe081174fa8712ac3134be63cc9dee4098cafb8459#89f3394301a70e4a6a1da68159e22e534e4ce5fe"
-  integrity sha512-MmCQjYk/e0TxQ9OYv8xxXZRIIxOV43I0FXPbrS5gNbXf2kSMBHELGK78cIIoD4SgF41C+Ko03UVl/wcVomE7WA==
+"@pagopa/io-spid-commons@^4.10.0":
+  version "4.10.0"
+  resolved "https://npm.pkg.github.com/download/@pagopa/io-spid-commons/4.10.0/901311cc5c60d3997fe4a584092269c9968914428faf8d0c84b9834f38fec7df#45cfd4c48cd1618e5cb4d7b3c5ce4b294fb88b6f"
+  integrity sha512-meCGRypKHe+106gjGqozSvJVD6hpc2G79iDJJYf+LJ5C9g97/15w4jJVkvG+DjGXYgQsm7VwwPI/U0Yub/OpqQ==
   dependencies:
     "@types/redis" "^2.8.14"
     date-fns "^1.30.1"
@@ -275,7 +275,6 @@
     passport "^0.4.1"
     passport-saml "1.2.0"
     redis "^2.8.0"
-    request-ip "^2.1.3"
     winston "^3.0.0"
     xml-crypto "^1.4.0"
     xml2js "^0.4.23"
@@ -3801,11 +3800,6 @@ is-yarn-global@^0.3.0:
   resolved "https://registry.yarnpkg.com/is-yarn-global/-/is-yarn-global-0.3.0.tgz#d502d3382590ea3004893746754c89139973e232"
   integrity sha512-VjSeb/lHmkoyd8ryPVIKvOCn4D1koMqY+vqyjjUfc3xyKtP4dYOxM44sZrnqQSzSds3xyOrUTLTC9LVCVgLngw==
 
-is_js@^0.9.0:
-  version "0.9.0"
-  resolved "https://registry.yarnpkg.com/is_js/-/is_js-0.9.0.tgz#0ab94540502ba7afa24c856aa985561669e9c52d"
-  integrity sha1-CrlFQFArp6+iTIVqqYVWFmnpxS0=
-
 isarray@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
@@ -6214,13 +6208,6 @@ repeating@^2.0.0:
   integrity sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=
   dependencies:
     is-finite "^1.0.0"
-
-request-ip@^2.1.3:
-  version "2.1.3"
-  resolved "https://registry.yarnpkg.com/request-ip/-/request-ip-2.1.3.tgz#99ab2bafdeaf2002626e28083cb10597511d9e14"
-  integrity sha512-J3qdE/IhVM3BXkwMIVO4yFrvhJlU3H7JH16+6yHucadT4fePnR8dyh+vEs6FIx0S2x5TCt2ptiPfHcn0sqhbYQ==
-  dependencies:
-    is_js "^0.9.0"
 
 request-promise-core@1.1.3:
   version "1.1.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6215,7 +6215,7 @@ repeating@^2.0.0:
   dependencies:
     is-finite "^1.0.0"
 
-request-ip@^2.1.1, request-ip@^2.1.3:
+request-ip@^2.1.3:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/request-ip/-/request-ip-2.1.3.tgz#99ab2bafdeaf2002626e28083cb10597511d9e14"
   integrity sha512-J3qdE/IhVM3BXkwMIVO4yFrvhJlU3H7JH16+6yHucadT4fePnR8dyh+vEs6FIx0S2x5TCt2ptiPfHcn0sqhbYQ==


### PR DESCRIPTION
Actually, the source IP we got from x-client-ip is the one of the application gateway (10.x.x.x). 
This PR takes it from the original client instead.