### PR TITLE
[proposal] move routing within controllers

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -100,7 +100,6 @@ import {
   createSimpleRedisClient
 } from "./utils/redis";
 import { makeSpidLogCallback } from "./utils/spid";
-import e = require("express");
 
 const defaultModule = {
   newApp
@@ -593,9 +592,9 @@ function registerAPIRoutes(
     tokenService
   );
 
-  const router = e.Router();
-  profileController.setupRouting(router);
-  app.use(basePath, bearerSessionTokenAuth, router);
+  const router = express.Router();
+  profileController.setupRouting(router, bearerSessionTokenAuth);
+  app.use(`${basePath}`, router);
 
   app.get(
     `${basePath}/user-metadata`,

--- a/src/app.ts
+++ b/src/app.ts
@@ -592,32 +592,7 @@ function registerAPIRoutes(
     tokenService
   );
 
-  app.get(
-    `${basePath}/profile`,
-    bearerSessionTokenAuth,
-    toExpressHandler(profileController.getProfile, profileController)
-  );
-
-  app.get(
-    `${basePath}/api-profile`,
-    bearerSessionTokenAuth,
-    toExpressHandler(profileController.getApiProfile, profileController)
-  );
-
-  app.post(
-    `${basePath}/profile`,
-    bearerSessionTokenAuth,
-    toExpressHandler(profileController.updateProfile, profileController)
-  );
-
-  app.post(
-    `${basePath}/email-validation-process`,
-    bearerSessionTokenAuth,
-    toExpressHandler(
-      profileController.startEmailValidationProcess,
-      profileController
-    )
-  );
+  profileController.setupRouting(app, basePath, bearerSessionTokenAuth);
 
   app.get(
     `${basePath}/user-metadata`,

--- a/src/app.ts
+++ b/src/app.ts
@@ -100,6 +100,7 @@ import {
   createSimpleRedisClient
 } from "./utils/redis";
 import { makeSpidLogCallback } from "./utils/spid";
+import e = require("express");
 
 const defaultModule = {
   newApp
@@ -592,7 +593,9 @@ function registerAPIRoutes(
     tokenService
   );
 
-  profileController.setupRouting(app, basePath, bearerSessionTokenAuth);
+  const router = e.Router();
+  profileController.setupRouting(router);
+  app.use(basePath, bearerSessionTokenAuth, router);
 
   app.get(
     `${basePath}/user-metadata`,

--- a/src/controllers/IBackendController.ts
+++ b/src/controllers/IBackendController.ts
@@ -2,15 +2,14 @@ import { Express } from "express";
 import { ParamsDictionary, RequestHandler } from "express-serve-static-core";
 
 /*
- * Standard interface for Backend controllers
+ * Standard interface for Controllers
  */
 export interface IBackendController {
   /**
-   * Method used for seting up routing for Controller
+   * Method used for setting up routing for Controller
    */
 
-  // tslint:disable-next-line: no-any
-  readonly setupRouting: <ResBody = any, ReqBody = any>(
+  readonly setupRouting: <ResBody = unknown, ReqBody = unknown>(
     app: Express,
     basePath: string,
     ...handlers: ReadonlyArray<

--- a/src/controllers/IBackendController.ts
+++ b/src/controllers/IBackendController.ts
@@ -1,4 +1,5 @@
-import { Router } from "express";
+import { Express } from "express";
+import { ParamsDictionary, RequestHandler } from "express-serve-static-core";
 
 /*
  * Standard interface for Controllers
@@ -6,8 +7,14 @@ import { Router } from "express";
 export interface IBackendController {
   /**
    * Method used for setting up routing for Controller
-   * @param router An Express app router
-   * @returns router
+   * @param app The Express app
+   * @param handlers A list of middlewares to be called before the Controller's functions
+   * @returns The router with paths for Controller
    */
-  readonly setupRouting: (app: Router) => void;
+  readonly setupRouting: <ResBody = unknown, ReqBody = unknown>(
+    app: Express,
+    ...handlers: ReadonlyArray<
+      RequestHandler<ParamsDictionary, ResBody, ReqBody>
+    >
+  ) => void;
 }

--- a/src/controllers/IBackendController.ts
+++ b/src/controllers/IBackendController.ts
@@ -7,8 +7,10 @@ import { ParamsDictionary, RequestHandler } from "express-serve-static-core";
 export interface IBackendController {
   /**
    * Method used for setting up routing for Controller
+   * @param app The Express app
+   * @param basePath The base path of the api. NOTE: Do not include trailing slash
+   * @param handlers A list of middlewares to be called before the Controller's functions
    */
-
   readonly setupRouting: <ResBody = unknown, ReqBody = unknown>(
     app: Express,
     basePath: string,

--- a/src/controllers/IBackendController.ts
+++ b/src/controllers/IBackendController.ts
@@ -1,0 +1,11 @@
+import { Express } from "express";
+
+/*
+ * Standard interface for Backend controllers
+ */
+export interface IBackendController {
+  /**
+   * Method used for seting up routing for Controller
+   */
+  setupRouting(app: Express, basePath: string, ...middlewares: any): void;
+}

--- a/src/controllers/IBackendController.ts
+++ b/src/controllers/IBackendController.ts
@@ -1,4 +1,5 @@
 import { Express } from "express";
+import { ParamsDictionary, RequestHandler } from "express-serve-static-core";
 
 /*
  * Standard interface for Backend controllers
@@ -7,5 +8,13 @@ export interface IBackendController {
   /**
    * Method used for seting up routing for Controller
    */
-  setupRouting(app: Express, basePath: string, ...middlewares: any): void;
+
+  // tslint:disable-next-line: no-any
+  readonly setupRouting: <ResBody = any, ReqBody = any>(
+    app: Express,
+    basePath: string,
+    ...handlers: ReadonlyArray<
+      RequestHandler<ParamsDictionary, ResBody, ReqBody>
+    >
+  ) => void;
 }

--- a/src/controllers/IBackendController.ts
+++ b/src/controllers/IBackendController.ts
@@ -1,5 +1,4 @@
-import { Express } from "express";
-import { ParamsDictionary, RequestHandler } from "express-serve-static-core";
+import { Router } from "express";
 
 /*
  * Standard interface for Controllers
@@ -7,15 +6,8 @@ import { ParamsDictionary, RequestHandler } from "express-serve-static-core";
 export interface IBackendController {
   /**
    * Method used for setting up routing for Controller
-   * @param app The Express app
-   * @param basePath The base path of the api. NOTE: Do not include trailing slash
-   * @param handlers A list of middlewares to be called before the Controller's functions
+   * @param router An Express app router
+   * @returns router
    */
-  readonly setupRouting: <ResBody = unknown, ReqBody = unknown>(
-    app: Express,
-    basePath: string,
-    ...handlers: ReadonlyArray<
-      RequestHandler<ParamsDictionary, ResBody, ReqBody>
-    >
-  ) => void;
+  readonly setupRouting: (app: Router) => void;
 }

--- a/src/controllers/profileController.ts
+++ b/src/controllers/profileController.ts
@@ -14,6 +14,7 @@ import {
   IResponseSuccessJson
 } from "italia-ts-commons/lib/responses";
 import { ISessionStorage } from "src/services/ISessionStorage";
+import { toExpressHandler } from "../utils/express";
 
 import { InitializedProfile } from "../../generated/backend/InitializedProfile";
 import { Profile } from "../../generated/backend/Profile";
@@ -24,11 +25,45 @@ import { profileMissingErrorResponse } from "../types/profile";
 import { withUserFromRequest } from "../types/user";
 import { withValidatedOrValidationError } from "../utils/responses";
 
-export default class ProfileController {
+import { IBackendController } from "./IBackendController";
+
+export default class ProfileController implements IBackendController {
   constructor(
     private readonly profileService: ProfileService,
     private readonly sessionStorage: ISessionStorage
   ) {}
+
+  public setupRouting(
+    app: express.Express,
+    basePath: string,
+    ...middlewares: any
+  ): void {
+    app.get(
+      `${basePath}/profile`,
+      middlewares,
+      toExpressHandler(this.getProfile, this)
+    );
+
+    app.get(
+      `${basePath}/api-profile`,
+      middlewares,
+      toExpressHandler(this.getApiProfile, this)
+    );
+
+    app.post(
+      `${basePath}/profile`,
+      middlewares,
+      toExpressHandler(this.updateProfile, this)
+    );
+
+    app.post(
+      `${basePath}/email-validation-process`,
+      middlewares,
+      toExpressHandler(this.startEmailValidationProcess, this)
+    );
+
+    console.log("CI SONO");
+  }
 
   /**
    * Returns the profile for the user identified by the provided fiscal

--- a/src/controllers/profileController.ts
+++ b/src/controllers/profileController.ts
@@ -34,6 +34,12 @@ export default class ProfileController implements IBackendController {
     private readonly sessionStorage: ISessionStorage
   ) {}
 
+  /**
+   * Method used for setting up routing for Controller
+   * @param app The Express app
+   * @param basePath The base path of the api. NOTE: Do not include trailing slash
+   * @param handlers A list of middlewares to be called before the Controller's functions
+   */
   public setupRouting<ResBody = unknown, ReqBody = unknown>(
     app: express.Express,
     basePath: string,

--- a/src/controllers/profileController.ts
+++ b/src/controllers/profileController.ts
@@ -61,8 +61,6 @@ export default class ProfileController implements IBackendController {
       middlewares,
       toExpressHandler(this.startEmailValidationProcess, this)
     );
-
-    console.log("CI SONO");
   }
 
   /**

--- a/src/controllers/profileController.ts
+++ b/src/controllers/profileController.ts
@@ -26,7 +26,6 @@ import ProfileService from "../services/profileService";
 import { profileMissingErrorResponse } from "../types/profile";
 import { withUserFromRequest } from "../types/user";
 import { withValidatedOrValidationError } from "../utils/responses";
-
 import { IBackendController } from "./IBackendController";
 
 export default class ProfileController implements IBackendController {
@@ -35,8 +34,7 @@ export default class ProfileController implements IBackendController {
     private readonly sessionStorage: ISessionStorage
   ) {}
 
-  // tslint:disable-next-line: no-any
-  public setupRouting<ResBody = any, ReqBody = any>(
+  public setupRouting<ResBody = unknown, ReqBody = unknown>(
     app: express.Express,
     basePath: string,
     ...handlers: ReadonlyArray<

--- a/src/controllers/profileController.ts
+++ b/src/controllers/profileController.ts
@@ -4,6 +4,8 @@
  */
 
 import * as express from "express";
+import { ParamsDictionary, RequestHandler } from "express-serve-static-core";
+
 import {
   IResponseErrorConflict,
   IResponseErrorInternal,
@@ -33,32 +35,35 @@ export default class ProfileController implements IBackendController {
     private readonly sessionStorage: ISessionStorage
   ) {}
 
-  public setupRouting(
+  // tslint:disable-next-line: no-any
+  public setupRouting<ResBody = any, ReqBody = any>(
     app: express.Express,
     basePath: string,
-    ...middlewares: any
+    ...handlers: ReadonlyArray<
+      RequestHandler<ParamsDictionary, ResBody, ReqBody>
+    >
   ): void {
     app.get(
       `${basePath}/profile`,
-      middlewares,
+      ...handlers,
       toExpressHandler(this.getProfile, this)
     );
 
     app.get(
       `${basePath}/api-profile`,
-      middlewares,
+      ...handlers,
       toExpressHandler(this.getApiProfile, this)
     );
 
     app.post(
       `${basePath}/profile`,
-      middlewares,
+      ...handlers,
       toExpressHandler(this.updateProfile, this)
     );
 
     app.post(
       `${basePath}/email-validation-process`,
-      middlewares,
+      ...handlers,
       toExpressHandler(this.startEmailValidationProcess, this)
     );
   }

--- a/src/controllers/profileController.ts
+++ b/src/controllers/profileController.ts
@@ -4,7 +4,6 @@
  */
 
 import * as express from "express";
-import { ParamsDictionary, RequestHandler } from "express-serve-static-core";
 
 import {
   IResponseErrorConflict,
@@ -36,40 +35,19 @@ export default class ProfileController implements IBackendController {
 
   /**
    * Method used for setting up routing for Controller
-   * @param app The Express app
-   * @param basePath The base path of the api. NOTE: Do not include trailing slash
-   * @param handlers A list of middlewares to be called before the Controller's functions
+   * @param router An Express app router
+   * @returns The router with paths for Controller
    */
-  public setupRouting<ResBody = unknown, ReqBody = unknown>(
-    app: express.Express,
-    basePath: string,
-    ...handlers: ReadonlyArray<
-      RequestHandler<ParamsDictionary, ResBody, ReqBody>
-    >
-  ): void {
-    app.get(
-      `${basePath}/profile`,
-      ...handlers,
-      toExpressHandler(this.getProfile, this)
-    );
-
-    app.get(
-      `${basePath}/api-profile`,
-      ...handlers,
-      toExpressHandler(this.getApiProfile, this)
-    );
-
-    app.post(
-      `${basePath}/profile`,
-      ...handlers,
-      toExpressHandler(this.updateProfile, this)
-    );
-
-    app.post(
-      `${basePath}/email-validation-process`,
-      ...handlers,
+  public setupRouting(router: express.Router): express.Router {
+    router.get(`/profile`, toExpressHandler(this.getProfile, this));
+    router.get(`/api-profile`, toExpressHandler(this.getApiProfile, this));
+    router.post(`/profile`, toExpressHandler(this.updateProfile, this));
+    router.post(
+      `/email-validation-process`,
       toExpressHandler(this.startEmailValidationProcess, this)
     );
+
+    return router;
   }
 
   /**

--- a/src/controllers/profileController.ts
+++ b/src/controllers/profileController.ts
@@ -27,6 +27,8 @@ import { withUserFromRequest } from "../types/user";
 import { withValidatedOrValidationError } from "../utils/responses";
 import { IBackendController } from "./IBackendController";
 
+import { ParamsDictionary, RequestHandler } from "express-serve-static-core";
+
 export default class ProfileController implements IBackendController {
   constructor(
     private readonly profileService: ProfileService,
@@ -36,14 +38,33 @@ export default class ProfileController implements IBackendController {
   /**
    * Method used for setting up routing for Controller
    * @param router An Express app router
+   * @param handlers A list of middlewares to be called before the Controller's functions
    * @returns The router with paths for Controller
    */
-  public setupRouting(router: express.Router): express.Router {
-    router.get(`/profile`, toExpressHandler(this.getProfile, this));
-    router.get(`/api-profile`, toExpressHandler(this.getApiProfile, this));
-    router.post(`/profile`, toExpressHandler(this.updateProfile, this));
+  public setupRouting<ResBody = unknown, ReqBody = unknown>(
+    router: express.Router,
+    ...handlers: ReadonlyArray<
+      RequestHandler<ParamsDictionary, ResBody, ReqBody>
+    >
+  ): express.Router {
+    router.get(
+      `/profile`,
+      ...handlers,
+      toExpressHandler(this.getProfile, this)
+    );
+    router.get(
+      `/api-profile`,
+      ...handlers,
+      toExpressHandler(this.getApiProfile, this)
+    );
+    router.post(
+      `/profile`,
+      ...handlers,
+      toExpressHandler(this.updateProfile, this)
+    );
     router.post(
       `/email-validation-process`,
+      ...handlers,
       toExpressHandler(this.startEmailValidationProcess, this)
     );
 


### PR DESCRIPTION
The idea is to cleanup a bit the _app.ts_ file, moving the routing definition outside of it. 
I thought to move it in the controllers themself, by creating a common interface Controllers interface, **IBackendController**,  with a _"setupRouting"_ method that all of them need to implement. 

Pros: 
- each controller is responsible for defining its own routing,
- the app.ts file over time would tend to have more and more lines, this would avoid the problem
- having such an interface or even a base class can be useful for sharing code.

Cons:
- each controller is responsible for defining its own routing, two controllers could potentially declare the same routing (I didn't check how Express will manage a situation like this)
- while creating a new controller, we need to remember to implements the interface.