### PR TITLE
[#176257846] Disable bonus requests at a given date

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,7 @@ API_BASE_PATH="/api/v1"
 BONUS_API_KEY=put_your_api_key_here
 BONUS_API_URL=http://host.docker.internal:7072/api/v1
 BONUS_API_BASE_PATH="/bonus/api/v1"
+BONUS_REQUEST_LIMIT_DATE="2020-12-30T22:59:59Z"
 CLIENT_REDIRECTION_URL=/profile.html?token={token}
 CLIENT_ERROR_REDIRECTION_URL=/error.html
 PORT=80

--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ Those are all Environment variables needed by the application:
 | BONUS_API_KEY                          | The key used to authenticate to the io-functions-bonus API                        | string |
 | BONUS_API_URL                          | The io-functions-bonus  URL                                                       | string |
 | BONUS_API_BASE_PATH                    | The root path for the backend bonus api endpoints                                 | string |
+| BONUS_REQUEST_LIMIT_DATE               | The date until a user can request a bonus, in UTC ISO format                      | string |
 | CLIENT_REDIRECTION_URL                 | The path where the user will be redirected after a successful SPID login          | string |
 | CLIENT_ERROR_REDIRECTION_URL           | The path where the user will be redirected when en error occurs during SPID login | string |
 | PORT                                   | The HTTP port the Express server is listening to                                  | int    |

--- a/src/app.ts
+++ b/src/app.ts
@@ -91,6 +91,7 @@ import { User } from "./types/user";
 import { attachTrackingData } from "./utils/appinsights";
 import { getRequiredENVVar } from "./utils/container";
 import { toExpressHandler } from "./utils/express";
+import { dueDateMiddleware } from "./utils/middleware/dueDate";
 import { expressErrorMiddleware } from "./utils/middleware/express";
 import {
   getCurrentBackendVersion,
@@ -101,7 +102,6 @@ import {
   createSimpleRedisClient
 } from "./utils/redis";
 import { makeSpidLogCallback } from "./utils/spid";
-import { dueDateMiddleware } from "./utils/middleware/dueDate";
 
 const defaultModule = {
   newApp

--- a/src/app.ts
+++ b/src/app.ts
@@ -6,6 +6,7 @@ import {
   API_CLIENT,
   appConfig,
   BONUS_API_CLIENT,
+  BONUS_REQUEST_LIMIT_DATE,
   CACHE_MAX_AGE_SECONDS,
   ENABLE_NOTICE_EMAIL_CACHE,
   ENV,
@@ -100,6 +101,7 @@ import {
   createSimpleRedisClient
 } from "./utils/redis";
 import { makeSpidLogCallback } from "./utils/spid";
+import { dueDateMiddleware } from "./utils/middleware/dueDate";
 
 const defaultModule = {
   newApp
@@ -372,7 +374,8 @@ export function newApp({
           app,
           BonusAPIBasePath,
           BONUS_SERVICE,
-          authMiddlewares.bearerSession
+          authMiddlewares.bearerSession,
+          BONUS_REQUEST_LIMIT_DATE
         );
       }
       registerPagoPARoutes(
@@ -790,12 +793,14 @@ function registerBonusAPIRoutes(
   basePath: string,
   bonusService: BonusService,
   // tslint:disable-next-line: no-any
-  bearerSessionTokenAuth: any
+  bearerSessionTokenAuth: any,
+  requestLimitDate: Date
 ): void {
   const bonusController: BonusController = new BonusController(bonusService);
 
   app.post(
     `${basePath}/bonus/vacanze/eligibility`,
+    dueDateMiddleware(requestLimitDate),
     bearerSessionTokenAuth,
     toExpressHandler(
       bonusController.startBonusEligibilityCheck,
@@ -826,6 +831,7 @@ function registerBonusAPIRoutes(
 
   app.post(
     `${basePath}/bonus/vacanze/activations`,
+    dueDateMiddleware(requestLimitDate),
     bearerSessionTokenAuth,
     toExpressHandler(
       bonusController.startBonusActivationProcedure,

--- a/src/config.ts
+++ b/src/config.ts
@@ -46,6 +46,7 @@ import { Millisecond, Second } from "italia-ts-commons/lib/units";
 import { STRINGS_RECORD } from "./types/commons";
 import { SpidLevelArray } from "./types/spidLevel";
 import { decodeCIDRs } from "./utils/cidrs";
+import { UTCISODateFromString } from "italia-ts-commons/lib/dates";
 
 // Without this, the environment variables loaded by dotenv aren't available in
 // this file.
@@ -323,6 +324,17 @@ export const BONUS_API_CLIENT = BonusAPIClient(
   BONUS_API_URL,
   httpApiFetch
 );
+// the date until a user can request a bonus
+export const BONUS_REQUEST_LIMIT_DATE = UTCISODateFromString.decode(
+  process.env.BONUS_REQUEST_LIMIT_DATE
+).getOrElseL(errs => {
+  log.error(
+    `Missing or invalid BONUS_REQUEST_LIMIT_DATE environment variable: ${readableReport(
+      errs
+    )}`
+  );
+  return process.exit(1);
+});
 
 // Set default session duration to 30 days
 const DEFAULT_TOKEN_DURATION_IN_SECONDS = 3600 * 24 * 30;

--- a/src/config.ts
+++ b/src/config.ts
@@ -34,6 +34,7 @@ import {
 } from "@pagopa/io-spid-commons";
 
 import { rights } from "fp-ts/lib/Array";
+import { UTCISODateFromString } from "italia-ts-commons/lib/dates";
 import {
   AbortableFetch,
   setFetchTimeout,
@@ -46,7 +47,6 @@ import { Millisecond, Second } from "italia-ts-commons/lib/units";
 import { STRINGS_RECORD } from "./types/commons";
 import { SpidLevelArray } from "./types/spidLevel";
 import { decodeCIDRs } from "./utils/cidrs";
-import { UTCISODateFromString } from "italia-ts-commons/lib/dates";
 
 // Without this, the environment variables loaded by dotenv aren't available in
 // this file.

--- a/src/utils/middleware/__tests__/dueDate.test.ts
+++ b/src/utils/middleware/__tests__/dueDate.test.ts
@@ -1,0 +1,61 @@
+import { dueDateMiddleware } from "../dueDate";
+import * as request from "supertest";
+import * as express from "express";
+
+const currentDate = new Date();
+const RealDate = Date;
+// @ts-ignore override Date constructor to have fixed date
+Date = function(...options): Date {
+  if (options.length) {
+    return new RealDate(...options);
+  }
+
+  return currentDate;
+};
+Date.now = () => currentDate.getTime();
+
+const aPastDate = new Date(currentDate.getTime() - 1);
+const aFutureDate = new Date(currentDate.getTime() + 1);
+
+const mockHandlerStatusCode = 200;
+const mockHandler = jest.fn((_, res) => {
+  res.status(mockHandlerStatusCode).send();
+});
+
+describe("dueDateMiddleware", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+  it("should block the operation if the due date is past", async () => {
+    const app = express();
+    app.use(dueDateMiddleware(aPastDate));
+    app.get("/test", mockHandler);
+
+    await request(app)
+      .get("/test")
+      .expect(404);
+    expect(mockHandler).not.toHaveBeenCalled();
+  });
+
+  it("should execute the operation if the date is future", async () => {
+    const app = express();
+    app.use(dueDateMiddleware(aFutureDate));
+    app.get("/test", mockHandler);
+
+    await request(app)
+      .get("/test")
+      .expect(mockHandlerStatusCode);
+    expect(mockHandler).toHaveBeenCalled();
+  });
+
+  it("should execute the operation if the date is the very same millisecond", async () => {
+    const app = express();
+    app.use(dueDateMiddleware(currentDate));
+    app.get("/test", mockHandler);
+
+    await request(app)
+      .get("/test")
+      .expect(mockHandlerStatusCode);
+    expect(mockHandler).toHaveBeenCalled();
+  });
+});

--- a/src/utils/middleware/dueDate.ts
+++ b/src/utils/middleware/dueDate.ts
@@ -1,0 +1,36 @@
+import { NextFunction, Request, Response } from "express";
+import { UTCISODateFromString } from "italia-ts-commons/lib/dates";
+import { ResponseErrorNotFound } from "italia-ts-commons/lib/responses";
+import { log } from "../logger";
+
+/**
+ * Due Date Middleware Factory
+ * To be applied to endpoint which are available only until a certain date.
+ * If the check fails, a 404 Not Found error is returned, meaning the resource is no longer available
+ *
+ * @param dueDate date until the resource is valid
+ */
+export function dueDateMiddleware(
+  dueDate: Date
+): (req: Request, res: Response, next: NextFunction) => void {
+  return (req, res, next) => {
+    const now = new Date();
+    if (now.getTime() > dueDate.getTime()) {
+      log.warn(
+        `An ${req.method.toUpperCase()} ${
+          req.path
+        } request has landed at ${UTCISODateFromString.encode(
+          now
+        )} although it was supposed to expire at ${UTCISODateFromString.encode(
+          dueDate
+        )}.`
+      );
+      ResponseErrorNotFound(
+        "Expired resource",
+        "The resource you asked for is no longer available"
+      ).apply(res);
+    } else {
+      next();
+    }
+  };
+}


### PR DESCRIPTION
As users cannot request Bonus Vacanza after a given date, we introduce a middleware prior to `startBonusEligibilityCheck` and `startBonusActivationProcedure` operations that makes them unavailable after such date.
Reading operations are kept available.

### Environment
| Variable name                          | Description                                                                       | type   |
|----------------------------------------|-----------------------------------------------------------------------------------|--------|
| BONUS_REQUEST_LIMIT_DATE               | The date until a user can request a bonus, in UTC ISO format                      | string |