### PR TITLE
[proposal] create toExpressHandlerWithUser that decode user and pass to Controllers

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -90,7 +90,7 @@ import { localStrategy } from "./strategies/localStrategy";
 import { User } from "./types/user";
 import { attachTrackingData } from "./utils/appinsights";
 import { getRequiredENVVar } from "./utils/container";
-import { toExpressHandler } from "./utils/express";
+import { toExpressHandler, toExpressHandlerWithUser } from "./utils/express";
 import { dueDateMiddleware } from "./utils/middleware/dueDate";
 import { expressErrorMiddleware } from "./utils/middleware/express";
 import {
@@ -598,25 +598,25 @@ function registerAPIRoutes(
   app.get(
     `${basePath}/profile`,
     bearerSessionTokenAuth,
-    toExpressHandler(profileController.getProfile, profileController)
+    toExpressHandlerWithUser(profileController.getProfile, profileController)
   );
 
   app.get(
     `${basePath}/api-profile`,
     bearerSessionTokenAuth,
-    toExpressHandler(profileController.getApiProfile, profileController)
+    toExpressHandlerWithUser(profileController.getApiProfile, profileController)
   );
 
   app.post(
     `${basePath}/profile`,
     bearerSessionTokenAuth,
-    toExpressHandler(profileController.updateProfile, profileController)
+    toExpressHandlerWithUser(profileController.updateProfile, profileController)
   );
 
   app.post(
     `${basePath}/email-validation-process`,
     bearerSessionTokenAuth,
-    toExpressHandler(
+    toExpressHandlerWithUser(
       profileController.startEmailValidationProcess,
       profileController
     )

--- a/src/utils/express.ts
+++ b/src/utils/express.ts
@@ -3,6 +3,7 @@ import {
   IResponse,
   ResponseErrorInternal
 } from "italia-ts-commons/lib/responses";
+import { User, withUserFromRequest } from "../types/user";
 
 /**
  * Convenience method that transforms a function (handler),
@@ -17,6 +18,27 @@ export function toExpressHandler<T, P>(
     handler
       .call(object, req)
       .catch(ResponseErrorInternal)
+      .then(response => {
+        // tslint:disable-next-line:no-object-mutation
+        res.locals.detail = response.detail;
+        response.apply(res);
+      });
+}
+
+/**
+ * Convenience method that transforms a function (handler),
+ * which takes an express.Request as input and returns an IResponse,
+ * into an express controller.
+ */
+export function toExpressHandlerWithUser<T, P>(
+  handler: (user: User, req: express.Request) => Promise<IResponse<T>>,
+  object?: P
+): (req: express.Request, res: express.Response) => void {
+  return (req, res) =>
+    withUserFromRequest(req, user => handler.call(object, user, req))
+      .catch(err => {
+        return ResponseErrorInternal(err);
+      })
       .then(response => {
         // tslint:disable-next-line:no-object-mutation
         res.locals.detail = response.detail;


### PR DESCRIPTION
Idea: remove _withUserFromRequest_ from within Controllers and move it into a new _toExpressHandlerWithUser_ method, that takes an handler with two parameters instead of one:  
`handler: (user: User, req: express.Request) => Promise<IResponse<T>>`