### PR TITLE
[#176458169] Use different date format for bonus dismission

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -34,10 +34,7 @@ import {
 } from "@pagopa/io-spid-commons";
 
 import { rights } from "fp-ts/lib/Array";
-import {
-  DateFromString,
-  UTCISODateFromString
-} from "italia-ts-commons/lib/dates";
+import { DateFromString } from "italia-ts-commons/lib/dates";
 import {
   AbortableFetch,
   setFetchTimeout,

--- a/src/config.ts
+++ b/src/config.ts
@@ -34,7 +34,10 @@ import {
 } from "@pagopa/io-spid-commons";
 
 import { rights } from "fp-ts/lib/Array";
-import { UTCISODateFromString } from "italia-ts-commons/lib/dates";
+import {
+  DateFromString,
+  UTCISODateFromString
+} from "italia-ts-commons/lib/dates";
 import {
   AbortableFetch,
   setFetchTimeout,
@@ -325,7 +328,7 @@ export const BONUS_API_CLIENT = BonusAPIClient(
   httpApiFetch
 );
 // the date until a user can request a bonus
-export const BONUS_REQUEST_LIMIT_DATE = UTCISODateFromString.decode(
+export const BONUS_REQUEST_LIMIT_DATE = DateFromString.decode(
   process.env.BONUS_REQUEST_LIMIT_DATE
 ).getOrElseL(errs => {
   log.error(


### PR DESCRIPTION
#### Description
Use a less-specific date format to decode `BONUS_REQUEST_LIMIT_DATE` env variable.

#### Motivation and Context
There is a known issue on the infrastructure: when applying a change, environment variables which are date string, are converted unexpectedly. UTC ISO date format is exposed to such issue, thus `BONUS_REQUEST_LIMIT_DATE` may be in an unexpected format causing the application boot to fail.
As a mitigation, we allow for weaker format control so we can set plain timestamps in the infra specification.

#### How Has This Been Tested?
⚠️ not yet

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Chore
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
