### PR TITLE
[#176559282] [#176559344] Fix wrong definition on pagopa api and public api specifications

### DIFF
--- a/api_pagopa.yaml
+++ b/api_pagopa.yaml
@@ -26,7 +26,7 @@ paths:
         "200":
           description: Found.
           schema:
-            - $ref: "#/definitions/PagoPAUser"
+            $ref: "#/definitions/PagoPAUser"
           examples:
             application/json:
               email: "email@example.com"

--- a/api_public.yaml
+++ b/api_public.yaml
@@ -98,7 +98,7 @@ definitions:
     properties:
       token:
         type: string
-        minLenght: 1
+        minLength: 1
     required:
       - token
 consumes:

--- a/src/controllers/authenticationController.ts
+++ b/src/controllers/authenticationController.ts
@@ -30,7 +30,7 @@ import { UrlFromString } from "italia-ts-commons/lib/url";
 import { NewProfile } from "generated/io-api/NewProfile";
 
 import { errorsToReadableMessages } from "italia-ts-commons/lib/reporters";
-import { FiscalCode } from "italia-ts-commons/lib/strings";
+import { FiscalCode, NonEmptyString } from "italia-ts-commons/lib/strings";
 import UsersLoginLogService from "src/services/usersLoginLogService";
 import { SuccessResponse } from "../../generated/auth/SuccessResponse";
 import { UserIdentity } from "../../generated/auth/UserIdentity";
@@ -276,7 +276,7 @@ export default class AuthenticationController {
           return left(new Error("Unexpected redirection url"));
         })
         .chain(token =>
-          SessionToken.decode(token).mapLeft(
+          NonEmptyString.decode(token).mapLeft(
             err => new Error(`Decode Error: [${errorsToReadableMessages(err)}]`)
           )
         )


### PR DESCRIPTION
We found that the following api specification weren't valid OpenAPI documents:
* api_pagopa
* api_public

As we generate definitions from such files, build has to be fixed in order for types to match.