### PR TITLE
[#176561900] Fix bons api OpenAPI specification

### DIFF
--- a/api_bonus.yaml
+++ b/api_bonus.yaml
@@ -170,8 +170,6 @@ definitions:
         type: array
         items:
           $ref: "#/definitions/QrCodeImage"
-        required:
-          - items
     required:
       - qr_code
 


### PR DESCRIPTION
There is no need to define the `items` attribute of an array field to be required, but this makes the specification not valid