### PR TITLE
[#176782092] Add Get Cgn Activation API

### DIFF
--- a/api_cgn.yaml
+++ b/api_cgn.yaml
@@ -66,6 +66,25 @@ paths:
           description: Service unavailable.
           schema:
             $ref: "#/definitions/ProblemJson"
+    get:
+      operationId: getCgnActivation
+      summary: |
+        Get CGN activation process' status
+      description: |
+        Get informations about a CGN activation process
+      responses:
+        "200":
+            description: Cgn activation details.
+            schema:
+              $ref: "#/definitions/CgnActivationDetail"
+        "401":
+          description: Bearer token null or expired.
+        "404":
+          description: No CGN activation process found.
+        "500":
+          description: Service unavailable.
+          schema:
+            $ref: "#/definitions/ProblemJson"
 
 definitions:
   Timestamp:
@@ -75,7 +94,7 @@ definitions:
   ProblemJson:
     $ref: "https://raw.githubusercontent.com/pagopa/io-functions-commons/v17.3.0/openapi/definitions.yaml#/ProblemJson"
   InstanceId:
-    $ref: "https://raw.githubusercontent.com/pagopa/io-functions-cgn/175908973_add_revoke_api/openapi/index.yaml#/definitions/InstanceId"
+    $ref: "https://raw.githubusercontent.com/pagopa/io-functions-cgn/master/openapi/index.yaml#/definitions/InstanceId"
   CgnPendingStatus:
     $ref: "https://raw.githubusercontent.com/pagopa/io-functions-cgn/master/openapi/index.yaml#/definitions/CgnPendingStatus"
   CgnActivatedStatus:
@@ -86,7 +105,9 @@ definitions:
     $ref: "https://raw.githubusercontent.com/pagopa/io-functions-cgn/master/openapi/index.yaml#/definitions/CgnExpiredStatus"
   CgnStatus:
     $ref: "https://raw.githubusercontent.com/pagopa/io-functions-cgn/master/openapi/index.yaml#/definitions/CgnStatus"
-  
+  CgnActivationDetail:
+    $ref: "https://raw.githubusercontent.com/pagopa/io-functions-cgn/176782092_add_get_activation_status_api/openapi/index.yaml#/definitions/CgnActivationDetail"
+    
 securityDefinitions:
   Bearer:
     type: apiKey

--- a/api_cgn.yaml
+++ b/api_cgn.yaml
@@ -69,7 +69,7 @@ paths:
     get:
       operationId: getCgnActivation
       summary: |
-        Get CGN activation process' status
+        Get CGN activation process status
       description: |
         Get informations about a CGN activation process
       responses:

--- a/api_cgn.yaml
+++ b/api_cgn.yaml
@@ -106,7 +106,7 @@ definitions:
   CgnStatus:
     $ref: "https://raw.githubusercontent.com/pagopa/io-functions-cgn/master/openapi/index.yaml#/definitions/CgnStatus"
   CgnActivationDetail:
-    $ref: "https://raw.githubusercontent.com/pagopa/io-functions-cgn/176782092_add_get_activation_status_api/openapi/index.yaml#/definitions/CgnActivationDetail"
+    $ref: "https://raw.githubusercontent.com/pagopa/io-functions-cgn/master/openapi/index.yaml#/definitions/CgnActivationDetail"
     
 securityDefinitions:
   Bearer:

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "generate:proxy:bonus-models": "rimraf generated/bonus && gen-api-models --api-spec api_bonus.yaml --out-dir generated/bonus",
     "generate:proxy:cgn-models": "rimraf generated/cgn && gen-api-models --api-spec api_cgn.yaml --out-dir generated/cgn",
     "generate:api:io-bonus": "rimraf generated/io-bonus-api && gen-api-models --api-spec https://raw.githubusercontent.com/pagopa/io-functions-bonus/master/openapi/index.yaml --no-strict --out-dir generated/io-bonus-api --request-types --response-decoders --client",
-    "generate:api:io-cgn": "rimraf generated/io-cgn-api && gen-api-models --api-spec https://raw.githubusercontent.com/pagopa/io-functions-cgn/master/openapi/index.yaml --no-strict --out-dir generated/io-cgn-api --request-types --response-decoders --client",
+    "generate:api:io-cgn": "rimraf generated/io-cgn-api && gen-api-models --api-spec https://raw.githubusercontent.com/pagopa/io-functions-cgn/176782092_add_get_activation_status_api/openapi/index.yaml --no-strict --out-dir generated/io-cgn-api --request-types --response-decoders --client",
     "generate:api:pagopaproxy": "rimraf generated/pagopa-proxy && gen-api-models --api-spec https://raw.githubusercontent.com/pagopa/io-pagopa-proxy/v0.8.6/api_pagopa.yaml --no-strict --out-dir generated/pagopa-proxy --request-types --response-decoders --client",
     "generate:test-certs": "./scripts/generate-test-certs.sh certs",
     "postversion": "git push && git push --tags",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "generate:proxy:bonus-models": "rimraf generated/bonus && gen-api-models --api-spec api_bonus.yaml --out-dir generated/bonus",
     "generate:proxy:cgn-models": "rimraf generated/cgn && gen-api-models --api-spec api_cgn.yaml --out-dir generated/cgn",
     "generate:api:io-bonus": "rimraf generated/io-bonus-api && gen-api-models --api-spec https://raw.githubusercontent.com/pagopa/io-functions-bonus/master/openapi/index.yaml --no-strict --out-dir generated/io-bonus-api --request-types --response-decoders --client",
-    "generate:api:io-cgn": "rimraf generated/io-cgn-api && gen-api-models --api-spec https://raw.githubusercontent.com/pagopa/io-functions-cgn/176782092_add_get_activation_status_api/openapi/index.yaml --no-strict --out-dir generated/io-cgn-api --request-types --response-decoders --client",
+    "generate:api:io-cgn": "rimraf generated/io-cgn-api && gen-api-models --api-spec https://raw.githubusercontent.com/pagopa/io-functions-cgn/master/openapi/index.yaml --no-strict --out-dir generated/io-cgn-api --request-types --response-decoders --client",
     "generate:api:pagopaproxy": "rimraf generated/pagopa-proxy && gen-api-models --api-spec https://raw.githubusercontent.com/pagopa/io-pagopa-proxy/v0.8.6/api_pagopa.yaml --no-strict --out-dir generated/pagopa-proxy --request-types --response-decoders --client",
     "generate:test-certs": "./scripts/generate-test-certs.sh certs",
     "postversion": "git push && git push --tags",

--- a/src/controllers/cgnController.ts
+++ b/src/controllers/cgnController.ts
@@ -15,9 +15,10 @@ import {
   IResponseSuccessRedirectToResource
 } from "italia-ts-commons/lib/responses";
 
-import { CgnStatus } from "generated/io-cgn-api/CgnStatus";
+import { CgnStatus } from "generated/cgn/CgnStatus";
 import CgnService from "src/services/cgnService";
-import { InstanceId } from "generated/io-cgn-api/InstanceId";
+import { InstanceId } from "generated/cgn/InstanceId";
+import { CgnActivationDetail } from "generated/cgn/CgnActivationDetail";
 import { withUserFromRequest } from "../types/user";
 
 export default class CgnController {
@@ -52,4 +53,17 @@ export default class CgnController {
     | IResponseSuccessAccepted
   > =>
     withUserFromRequest(req, user => this.cgnService.startCgnActivation(user));
+
+  /**
+   * Cget Cgn activation's proces status for the current user.
+   */
+  public readonly getCgnActivation = (
+    req: express.Request
+  ): Promise<
+    // tslint:disable-next-line:max-union-size
+    | IResponseErrorInternal
+    | IResponseErrorValidation
+    | IResponseErrorNotFound
+    | IResponseSuccessJson<CgnActivationDetail>
+  > => withUserFromRequest(req, user => this.cgnService.getCgnActivation(user));
 }

--- a/src/controllers/cgnController.ts
+++ b/src/controllers/cgnController.ts
@@ -15,11 +15,11 @@ import {
   IResponseSuccessRedirectToResource
 } from "italia-ts-commons/lib/responses";
 
-import { CgnStatus } from "generated/cgn/CgnStatus";
-import CgnService from "src/services/cgnService";
-import { InstanceId } from "generated/cgn/InstanceId";
-import { CgnActivationDetail } from "generated/cgn/CgnActivationDetail";
+import { CgnStatus } from "../../generated/cgn/CgnStatus";
+import CgnService from "../../src/services/cgnService";
+import { InstanceId } from "../../generated/cgn/InstanceId";
 import { withUserFromRequest } from "../types/user";
+import { CgnActivationDetail } from "../../generated/io-cgn-api/CgnActivationDetail";
 
 export default class CgnController {
   constructor(private readonly cgnService: CgnService) {}
@@ -30,7 +30,6 @@ export default class CgnController {
   public readonly getCgnStatus = (
     req: express.Request
   ): Promise<
-    // tslint:disable-next-line:max-union-size
     | IResponseErrorInternal
     | IResponseErrorValidation
     | IResponseErrorNotFound
@@ -44,7 +43,6 @@ export default class CgnController {
   public readonly startCgnActivation = (
     req: express.Request
   ): Promise<
-    // tslint:disable-next-line:max-union-size
     | IResponseErrorInternal
     | IResponseErrorValidation
     | IResponseErrorForbiddenNotAuthorized
@@ -55,12 +53,11 @@ export default class CgnController {
     withUserFromRequest(req, user => this.cgnService.startCgnActivation(user));
 
   /**
-   * Cget Cgn activation's proces status for the current user.
+   * Get Cgn activation's process status for the current user.
    */
   public readonly getCgnActivation = (
     req: express.Request
   ): Promise<
-    // tslint:disable-next-line:max-union-size
     | IResponseErrorInternal
     | IResponseErrorValidation
     | IResponseErrorNotFound

--- a/src/services/__tests__/cgnService.test.ts
+++ b/src/services/__tests__/cgnService.test.ts
@@ -16,14 +16,12 @@ const mockGetCgnStatus = jest.fn();
 const mockStartCgnActivation = jest.fn();
 const mockGetCgnActivation = jest.fn();
 
-const mockCgnAPIClient = {
+const api = {
   getCgnActivation: mockGetCgnActivation,
   getCgnStatus: mockGetCgnStatus,
   startCgnActivation: mockStartCgnActivation,
   upsertCgnStatus: jest.fn()
 } as ReturnType<CgnAPIClient>;
-
-const api = mockCgnAPIClient;
 
 const mockedUser: User = {
     created_at: 1183518855,
@@ -249,7 +247,7 @@ describe("CgnService#startCgnActivation", () => {
     );
     const service = new CgnService(api);
 
-    const res = await service.getCgnStatus(mockedUser);
+    const res = await service.startCgnActivation(mockedUser);
 
     expect(res).toMatchObject({
       kind: "IResponseErrorInternal"
@@ -262,7 +260,7 @@ describe("CgnService#startCgnActivation", () => {
     });
     const service = new CgnService(api);
 
-    const res = await service.getCgnStatus(mockedUser);
+    const res = await service.startCgnActivation(mockedUser);
 
     expect(res).toMatchObject({
       kind: "IResponseErrorInternal"

--- a/src/services/__tests__/cgnService.test.ts
+++ b/src/services/__tests__/cgnService.test.ts
@@ -356,7 +356,7 @@ describe("CgnService#getCgnActivation", () => {
   });
 
   it("should return an error if the api call thows", async () => {
-      mockGetCgnStatus.mockImplementationOnce(() => {
+    mockGetCgnActivation.mockImplementationOnce(() => {
       throw new Error();
     });
     const service = new CgnService(api);

--- a/src/services/__tests__/cgnService.test.ts
+++ b/src/services/__tests__/cgnService.test.ts
@@ -16,6 +16,22 @@ const mockGetCgnStatus = jest.fn();
 const mockStartCgnActivation = jest.fn();
 const mockGetCgnActivation = jest.fn();
 
+mockGetCgnStatus.mockImplementation(() =>
+  t.success({status: 200, value:aPendingCgnStatus})
+);
+
+mockStartCgnActivation.mockImplementation(() =>
+  t.success({status: 201, headers: {Location: "/api/v1/cgn/activation"}, value: {
+    id: {
+      id: "AnInstanceId"
+    }
+  }})
+);
+
+mockGetCgnActivation.mockImplementation(() =>
+  t.success({status: 200})
+);
+
 const api = {
   getCgnActivation: mockGetCgnActivation,
   getCgnStatus: mockGetCgnStatus,
@@ -54,9 +70,6 @@ describe("CgnService#getCgnStatus", () => {
     });
   
     it("should handle a success response", async () => {
-        mockGetCgnStatus.mockImplementation(() =>
-        t.success({status: 200, value:aPendingCgnStatus})
-      );
   
       const service = new CgnService(api);
   
@@ -68,7 +81,7 @@ describe("CgnService#getCgnStatus", () => {
     });
 
     it("should handle an internal error when the client returns 401", async () => {
-        mockGetCgnStatus.mockImplementation(() =>
+        mockGetCgnStatus.mockImplementationOnce(() =>
         t.success({ status: 401 })
       );
   
@@ -82,7 +95,7 @@ describe("CgnService#getCgnStatus", () => {
     });
   
     it("should handle a not found error when the CGN is not found", async () => {
-        mockGetCgnStatus.mockImplementation(() =>
+        mockGetCgnStatus.mockImplementationOnce(() =>
         t.success({ status: 404 })
       );
   
@@ -97,7 +110,7 @@ describe("CgnService#getCgnStatus", () => {
   
     it("should handle an internal error response", async () => {
       const aGenericProblem = {};
-      mockGetCgnStatus.mockImplementation(() =>
+      mockGetCgnStatus.mockImplementationOnce(() =>
         t.success({ status: 500, value: aGenericProblem })
       );
   
@@ -111,7 +124,7 @@ describe("CgnService#getCgnStatus", () => {
     });
   
     it("should return an error for unhandled response status code", async () => {
-        mockGetCgnStatus.mockImplementation(() =>
+        mockGetCgnStatus.mockImplementationOnce(() =>
         t.success({ status: 123 })
       );
       const service = new CgnService(api);
@@ -124,7 +137,7 @@ describe("CgnService#getCgnStatus", () => {
     });
   
     it("should return an error if the api call thows", async () => {
-        mockGetCgnStatus.mockImplementation(() => {
+        mockGetCgnStatus.mockImplementationOnce(() => {
         throw new Error();
       });
       const service = new CgnService(api);
@@ -153,13 +166,6 @@ describe("CgnService#startCgnActivation", () => {
   });
 
   it("should handle a success redirect to resource response", async () => {
-    mockStartCgnActivation.mockImplementation(() =>
-      t.success({status: 201, headers: {Location: "/api/v1/cgn/activation"}, value: {
-        id: {
-          id: "AnInstanceId"
-        }
-      }})
-    );
 
     const service = new CgnService(api);
 
@@ -171,7 +177,7 @@ describe("CgnService#startCgnActivation", () => {
   });
 
   it("should handle a success Accepted response", async () => {
-    mockStartCgnActivation.mockImplementation(() =>
+    mockStartCgnActivation.mockImplementationOnce(() =>
     t.success({status: 202})
   );
 
@@ -185,10 +191,9 @@ describe("CgnService#startCgnActivation", () => {
 });
 
   it("should handle an internal error when the client returns 401", async () => {
-    mockStartCgnActivation.mockImplementation(() =>
-      t.success({ status: 401 })
-    );
-
+    mockStartCgnActivation.mockImplementationOnce(() =>
+    t.success({status: 401})
+  );
     const service = new CgnService(api);
 
     const res = await service.startCgnActivation(mockedUser);
@@ -199,7 +204,7 @@ describe("CgnService#startCgnActivation", () => {
   });
 
   it("should handle a Forbidden error if the user is ineligible for a CGN", async () => {
-    mockStartCgnActivation.mockImplementation(() =>
+    mockStartCgnActivation.mockImplementationOnce(() =>
       t.success({ status: 403 })
     );
 
@@ -213,7 +218,7 @@ describe("CgnService#startCgnActivation", () => {
   });
 
   it("should handle a conflict error when the CGN is already activated", async () => {
-    mockStartCgnActivation.mockImplementation(() =>
+    mockStartCgnActivation.mockImplementationOnce(() =>
       t.success({ status: 409 })
     );
 
@@ -228,7 +233,7 @@ describe("CgnService#startCgnActivation", () => {
 
   it("should handle an internal error response", async () => {
     const aGenericProblem = {};
-    mockStartCgnActivation.mockImplementation(() =>
+    mockStartCgnActivation.mockImplementationOnce(() =>
       t.success({ status: 500, value: aGenericProblem })
     );
 
@@ -242,7 +247,7 @@ describe("CgnService#startCgnActivation", () => {
   });
 
   it("should return an error for unhandled response status code", async () => {
-      mockGetCgnStatus.mockImplementation(() =>
+    mockStartCgnActivation.mockImplementationOnce(() =>
       t.success({ status: 123 })
     );
     const service = new CgnService(api);
@@ -255,7 +260,7 @@ describe("CgnService#startCgnActivation", () => {
   });
 
   it("should return an error if the api call thows", async () => {
-      mockGetCgnStatus.mockImplementation(() => {
+    mockStartCgnActivation.mockImplementationOnce(() => {
       throw new Error();
     });
     const service = new CgnService(api);
@@ -284,9 +289,6 @@ describe("CgnService#getCgnActivation", () => {
   });
 
   it("should handle a success redirect to resource response", async () => {
-    mockGetCgnActivation.mockImplementation(() =>
-      t.success({status: 200})
-    );
 
     const service = new CgnService(api);
 
@@ -298,7 +300,7 @@ describe("CgnService#getCgnActivation", () => {
   });
 
   it("should handle an internal error when the client returns 401", async () => {
-    mockGetCgnActivation.mockImplementation(() =>
+    mockGetCgnActivation.mockImplementationOnce(() =>
       t.success({ status: 401 })
     );
 
@@ -312,7 +314,7 @@ describe("CgnService#getCgnActivation", () => {
   });
 
   it("should handle a Not Found Error when no CGN activation infos are found", async () => {
-    mockGetCgnActivation.mockImplementation(() =>
+    mockGetCgnActivation.mockImplementationOnce(() =>
       t.success({ status: 404 })
     );
 
@@ -327,7 +329,7 @@ describe("CgnService#getCgnActivation", () => {
 
   it("should handle an internal error response", async () => {
     const aGenericProblem = {};
-    mockGetCgnActivation.mockImplementation(() =>
+    mockGetCgnActivation.mockImplementationOnce(() =>
       t.success({ status: 500, value: aGenericProblem })
     );
 
@@ -341,7 +343,7 @@ describe("CgnService#getCgnActivation", () => {
   });
 
   it("should return an error for unhandled response status code", async () => {
-    mockGetCgnActivation.mockImplementation(() =>
+    mockGetCgnActivation.mockImplementationOnce(() =>
       t.success({ status: 123 })
     );
     const service = new CgnService(api);
@@ -354,7 +356,7 @@ describe("CgnService#getCgnActivation", () => {
   });
 
   it("should return an error if the api call thows", async () => {
-      mockGetCgnStatus.mockImplementation(() => {
+      mockGetCgnStatus.mockImplementationOnce(() => {
       throw new Error();
     });
     const service = new CgnService(api);

--- a/src/services/bonusService.ts
+++ b/src/services/bonusService.ts
@@ -27,23 +27,14 @@ import { BonusAPIClient } from "../clients/bonus";
 import { User } from "../types/user";
 import { withQrcode } from "../utils/qrcode";
 import {
-  unhandledResponseStatus,
+  ResponseErrorStatusNotDefinedInSpec,
+  ResponseErrorUnexpectedAuthProblem,
   withCatchAsInternalError,
   withValidatedOrInternalError
 } from "../utils/responses";
 
 const readableProblem = (problem: ProblemJson) =>
   `${problem.title} (${problem.type || "no problem type specified"})`;
-
-const ResponseErrorStatusNotDefinedInSpec = (response: never) =>
-  // This case should not happen, so response is of type never.
-  // However, the underlying api may not follow the specs so we might trace the unhandled status
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  unhandledResponseStatus((response as any).status);
-
-const ResponseErrorUnexpectedAuthProblem = () =>
-  // This case can only happen because of misconfiguration, thus it might be considered an error
-  ResponseErrorInternal("Underlying API fails with an unexpected 401");
 
 export default class BonusService {
   constructor(private readonly bonusApiClient: ReturnType<BonusAPIClient>) {}

--- a/src/services/bonusService.ts
+++ b/src/services/bonusService.ts
@@ -8,7 +8,6 @@ import {
   IResponseErrorNotFound,
   IResponseSuccessAccepted,
   IResponseSuccessJson,
-  ProblemJson,
   ResponseErrorGone,
   ResponseErrorInternal,
   ResponseErrorNotFound,
@@ -32,10 +31,7 @@ import {
   withCatchAsInternalError,
   withValidatedOrInternalError
 } from "../utils/responses";
-
-const readableProblem = (problem: ProblemJson) =>
-  `${problem.title} (${problem.type || "no problem type specified"})`;
-
+import { readableProblem } from "../../src/utils/errorsFormatter";
 export default class BonusService {
   constructor(private readonly bonusApiClient: ReturnType<BonusAPIClient>) {}
 

--- a/src/services/cgnService.ts
+++ b/src/services/cgnService.ts
@@ -21,30 +21,21 @@ import {
   ResponseSuccessRedirectToResource
 } from "italia-ts-commons/lib/responses";
 
-import { CgnStatus } from "generated/io-cgn-api/CgnStatus";
-import { CgnAPIClient } from "src/clients/cgn";
-import { InstanceId } from "generated/io-cgn-api/InstanceId";
 import { fromNullable } from "fp-ts/lib/Option";
-import { CgnActivationDetail } from "generated/cgn/CgnActivationDetail";
+import { InstanceId } from "../../generated/io-cgn-api/InstanceId";
+import { CgnActivationDetail } from "../../generated/io-cgn-api/CgnActivationDetail";
+import { CgnAPIClient } from "../../src/clients/cgn";
+import { CgnStatus } from "../../generated/io-cgn-api/CgnStatus";
 import { User } from "../types/user";
 import {
-  unhandledResponseStatus,
+  ResponseErrorStatusNotDefinedInSpec,
+  ResponseErrorUnexpectedAuthProblem,
   withCatchAsInternalError,
   withValidatedOrInternalError
 } from "../utils/responses";
 
 const readableProblem = (problem: ProblemJson) =>
   `${problem.title} (${problem.type || "no problem type specified"})`;
-
-const ResponseErrorStatusNotDefinedInSpec = (response: never) =>
-  // This case should not happen, so response is of type never.
-  // However, the underlying api may not follow the specs so we might trace the unhandled status
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  unhandledResponseStatus((response as any).status);
-
-const ResponseErrorUnexpectedAuthProblem = () =>
-  // This case can only happen because of misconfiguration, thus it might be considered an error
-  ResponseErrorInternal("Underlying API fails with an unexpected 401");
 export default class CgnService {
   constructor(private readonly cgnApiClient: ReturnType<CgnAPIClient>) {}
 
@@ -54,7 +45,6 @@ export default class CgnService {
   public readonly getCgnStatus = (
     user: User
   ): Promise<
-    // tslint:disable-next-line: max-union-size
     | IResponseErrorInternal
     | IResponseErrorValidation
     | IResponseErrorNotFound
@@ -88,7 +78,6 @@ export default class CgnService {
   public readonly startCgnActivation = (
     user: User
   ): Promise<
-    // tslint:disable-next-line: max-union-size
     | IResponseErrorInternal
     | IResponseErrorValidation
     | IResponseErrorForbiddenNotAuthorized
@@ -135,7 +124,6 @@ export default class CgnService {
   public readonly getCgnActivation = (
     user: User
   ): Promise<
-    // tslint:disable-next-line: max-union-size
     | IResponseErrorInternal
     | IResponseErrorValidation
     | IResponseErrorNotFound

--- a/src/services/cgnService.ts
+++ b/src/services/cgnService.ts
@@ -11,7 +11,6 @@ import {
   IResponseSuccessAccepted,
   IResponseSuccessJson,
   IResponseSuccessRedirectToResource,
-  ProblemJson,
   ResponseErrorConflict,
   ResponseErrorForbiddenNotAuthorized,
   ResponseErrorInternal,
@@ -33,9 +32,7 @@ import {
   withCatchAsInternalError,
   withValidatedOrInternalError
 } from "../utils/responses";
-
-const readableProblem = (problem: ProblemJson) =>
-  `${problem.title} (${problem.type || "no problem type specified"})`;
+import { readableProblem } from "../../src/utils/errorsFormatter";
 export default class CgnService {
   constructor(private readonly cgnApiClient: ReturnType<CgnAPIClient>) {}
 

--- a/src/utils/errorsFormatter.ts
+++ b/src/utils/errorsFormatter.ts
@@ -1,5 +1,6 @@
 import { Errors } from "io-ts";
 import { errorsToReadableMessages } from "italia-ts-commons/lib/reporters";
+import { ProblemJson } from "italia-ts-commons/lib/responses";
 
 /**
  * Merge into one single Error several errors provided in input and add a context description
@@ -19,3 +20,6 @@ export function multipleErrorsFormatter(
 
 export const errorsToError = (errors: Errors): Error =>
   new Error(errorsToReadableMessages(errors).join(" / "));
+
+export const readableProblem = (problem: ProblemJson) =>
+  `${problem.title} (${problem.type || "no problem type specified"})`;

--- a/src/utils/responses.ts
+++ b/src/utils/responses.ts
@@ -107,3 +107,13 @@ export function ResponseErrorUnauthorizedForLegalReasons(
     }
   };
 }
+
+export const ResponseErrorStatusNotDefinedInSpec = (response: never) =>
+  // This case should not happen, so response is of type never.
+  // However, the underlying api may not follow the specs so we might trace the unhandled status
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  unhandledResponseStatus((response as any).status);
+
+export const ResponseErrorUnexpectedAuthProblem = () =>
+  // This case can only happen because of misconfiguration, thus it might be considered an error
+  ResponseErrorInternal("Underlying API fails with an unexpected 401");


### PR DESCRIPTION
#### List of Changes
- Add `getCgnActivation` API implementation
- Add API specs
- Add tests

#### Motivation and Context
Provide an IO Backend proxying and implementation of the `getCgnActivation` [API](https://github.com/pagopa/io-functions-cgn/pull/14). It is used to provide a polling endpoint and let know to IO App, the status of an activation process. See the related Pivotal [story](https://www.pivotaltracker.com/story/show/176782092) for further informations.

#### How Has This Been Tested?
It has been tested by performing unit tests.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.