### PR TITLE
[#176924316] Add EYCA activation API

### DIFF
--- a/api_cgn.yaml
+++ b/api_cgn.yaml
@@ -121,6 +121,25 @@ paths:
           description: Service unavailable.
           schema:
             $ref: "#/definitions/ProblemJson"
+    get:
+      operationId: getEycaActivation
+      summary: |
+        Get EYCA activation process' status
+      description: |
+        Get informations about an EYCA activation process
+      responses:
+        "200":
+            description: Eyca Card activation details.
+            schema:
+              $ref: "#/definitions/EycaActivationDetail"
+        "401":
+          description: Wrong or missing function key.
+        "404":
+          description: No EYCA Card activation process found.
+        "500":
+          description: Service unavailable.
+          schema:
+            $ref: "#/definitions/ProblemJson"
 definitions:
   Timestamp:
     $ref: "https://raw.githubusercontent.com/pagopa/io-functions-commons/v17.3.0/openapi/definitions.yaml#/Timestamp"
@@ -144,6 +163,8 @@ definitions:
     $ref: "https://raw.githubusercontent.com/pagopa/io-functions-cgn/master/openapi/index.yaml#/definitions/Card"
   CgnActivationDetail:
     $ref: "https://raw.githubusercontent.com/pagopa/io-functions-cgn/master/openapi/index.yaml#/definitions/CgnActivationDetail"
+  EycaActivationDetail:
+    $ref: "https://raw.githubusercontent.com/pagopa/io-functions-cgn/176924316_add_start_eyca_activation_api/openapi/index.yaml#/definitions/EycaActivationDetail"
     
 securityDefinitions:
   Bearer:

--- a/api_cgn.yaml
+++ b/api_cgn.yaml
@@ -180,7 +180,7 @@ definitions:
   CgnActivationDetail:
     $ref: "https://raw.githubusercontent.com/pagopa/io-functions-cgn/master/openapi/index.yaml#/definitions/CgnActivationDetail"
   EycaActivationDetail:
-    $ref: "https://raw.githubusercontent.com/pagopa/io-functions-cgn/176924316_add_start_eyca_activation_api/openapi/index.yaml#/definitions/EycaActivationDetail"
+    $ref: "https://raw.githubusercontent.com/pagopa/io-functions-cgn/master/openapi/index.yaml#/definitions/EycaActivationDetail"
   EycaCard:
     $ref: "https://raw.githubusercontent.com/pagopa/io-functions-cgn/master/openapi/index.yaml#/definitions/EycaCard"
     

--- a/api_cgn.yaml
+++ b/api_cgn.yaml
@@ -136,6 +136,10 @@ paths:
           description: Wrong or missing function key.
         "404":
           description: No EYCA Card activation process found.
+        "500":
+          description: Service unavailable.
+          schema:
+            $ref: "#/definitions/ProblemJson"
 
   "/cgn/eyca/status":
     get:

--- a/api_cgn.yaml
+++ b/api_cgn.yaml
@@ -85,7 +85,42 @@ paths:
           description: Service unavailable.
           schema:
             $ref: "#/definitions/ProblemJson"
-
+  "/cgn/eyca/activation":
+    post:
+      operationId: startEycaActivation
+      summary: Start an EYCA activation procedure
+      description: | 
+        Start a new EYCA activation procedure
+        for the logged user calculating if the user is
+        eligible to enable EYCA on his CGN card.
+      responses:
+        "201":
+          description: Request created.
+          schema:
+            $ref: "#/definitions/InstanceId"
+          headers:
+            Location:
+              type: string
+              description: |-
+                Location (URL) of created request resource.
+                A GET request to this URL returns the request status and details.
+        "202":
+          description: Processing request.
+          schema:
+            $ref: "#/definitions/InstanceId"
+        "401":
+          description: Bearer token null or expired.
+        "403":
+          description: |
+            Cannot activate EYCA Card because the user is ineligible to enable EYCA.
+        "409":
+          description: |
+            Cannot activate EYCA Card because another EYCA Card activation request was found
+            for this user or it is already active.
+        "500":
+          description: Service unavailable.
+          schema:
+            $ref: "#/definitions/ProblemJson"
 definitions:
   Timestamp:
     $ref: "https://raw.githubusercontent.com/pagopa/io-functions-commons/v17.3.0/openapi/definitions.yaml#/Timestamp"

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "generate:proxy:bonus-models": "rimraf generated/bonus && gen-api-models --api-spec api_bonus.yaml --out-dir generated/bonus",
     "generate:proxy:cgn-models": "rimraf generated/cgn && gen-api-models --api-spec api_cgn.yaml --out-dir generated/cgn",
     "generate:api:io-bonus": "rimraf generated/io-bonus-api && gen-api-models --api-spec https://raw.githubusercontent.com/pagopa/io-functions-bonus/master/openapi/index.yaml --no-strict --out-dir generated/io-bonus-api --request-types --response-decoders --client",
-    "generate:api:io-cgn": "rimraf generated/io-cgn-api && gen-api-models --api-spec https://raw.githubusercontent.com/pagopa/io-functions-cgn/master/openapi/index.yaml --no-strict --out-dir generated/io-cgn-api --request-types --response-decoders --client",
+    "generate:api:io-cgn": "rimraf generated/io-cgn-api && gen-api-models --api-spec https://raw.githubusercontent.com/pagopa/io-functions-cgn/176924316_add_start_eyca_activation_api/openapi/index.yaml --no-strict --out-dir generated/io-cgn-api --request-types --response-decoders --client",
     "generate:api:pagopaproxy": "rimraf generated/pagopa-proxy && gen-api-models --api-spec https://raw.githubusercontent.com/pagopa/io-pagopa-proxy/v0.8.6/api_pagopa.yaml --no-strict --out-dir generated/pagopa-proxy --request-types --response-decoders --client",
     "generate:test-certs": "./scripts/generate-test-certs.sh certs",
     "postversion": "git push && git push --tags",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "generate:proxy:bonus-models": "rimraf generated/bonus && gen-api-models --api-spec api_bonus.yaml --out-dir generated/bonus",
     "generate:proxy:cgn-models": "rimraf generated/cgn && gen-api-models --api-spec api_cgn.yaml --out-dir generated/cgn",
     "generate:api:io-bonus": "rimraf generated/io-bonus-api && gen-api-models --api-spec https://raw.githubusercontent.com/pagopa/io-functions-bonus/master/openapi/index.yaml --no-strict --out-dir generated/io-bonus-api --request-types --response-decoders --client",
-    "generate:api:io-cgn": "rimraf generated/io-cgn-api && gen-api-models --api-spec https://raw.githubusercontent.com/pagopa/io-functions-cgn/176924316_add_start_eyca_activation_api/openapi/index.yaml --no-strict --out-dir generated/io-cgn-api --request-types --response-decoders --client",
+    "generate:api:io-cgn": "rimraf generated/io-cgn-api && gen-api-models --api-spec https://raw.githubusercontent.com/pagopa/io-functions-cgn/master/openapi/index.yaml --no-strict --out-dir generated/io-cgn-api --request-types --response-decoders --client",
     "generate:api:pagopaproxy": "rimraf generated/pagopa-proxy && gen-api-models --api-spec https://raw.githubusercontent.com/pagopa/io-pagopa-proxy/v0.8.6/api_pagopa.yaml --no-strict --out-dir generated/pagopa-proxy --request-types --response-decoders --client",
     "generate:test-certs": "./scripts/generate-test-certs.sh certs",
     "postversion": "git push && git push --tags",

--- a/src/app.ts
+++ b/src/app.ts
@@ -859,6 +859,12 @@ function registerCgnAPIRoutes(
     bearerSessionTokenAuth,
     toExpressHandler(cgnController.startEycaActivation, cgnController)
   );
+
+  app.get(
+    `${basePath}/cgn/eyca/activation`,
+    bearerSessionTokenAuth,
+    toExpressHandler(cgnController.getEycaActivation, cgnController)
+  );
 }
 
 function registerBonusAPIRoutes(

--- a/src/app.ts
+++ b/src/app.ts
@@ -847,6 +847,18 @@ function registerCgnAPIRoutes(
     bearerSessionTokenAuth,
     toExpressHandler(cgnController.startCgnActivation, cgnController)
   );
+
+  app.get(
+    `${basePath}/cgn/activation`,
+    bearerSessionTokenAuth,
+    toExpressHandler(cgnController.getCgnActivation, cgnController)
+  );
+
+  app.post(
+    `${basePath}/cgn/eyca/activation`,
+    bearerSessionTokenAuth,
+    toExpressHandler(cgnController.startEycaActivation, cgnController)
+  );
 }
 
 function registerBonusAPIRoutes(

--- a/src/controllers/__tests__/cgnController.test.ts
+++ b/src/controllers/__tests__/cgnController.test.ts
@@ -47,12 +47,14 @@ const mockedUser: User = {
 const mockGetCgnStatus = jest.fn();
 const mockStartCgnActivation = jest.fn();
 const mockGetCgnActivation = jest.fn();
+const mockStartEycaActivation = jest.fn();
 jest.mock("../../services/cgnService", () => {
   return {
     default: jest.fn().mockImplementation(() => ({
       getCgnActivation: mockGetCgnActivation,
       getCgnStatus: mockGetCgnStatus,
-      startCgnActivation: mockStartCgnActivation
+      startCgnActivation: mockStartCgnActivation,
+      startEycaActivation: mockStartEycaActivation
     }))
   };
 });
@@ -228,6 +230,61 @@ describe("CgnController#getCgnActivation", () => {
 
     // service method is not called
     expect(mockGetCgnActivation).not.toBeCalled();
+    // http output is correct
+    expect(res.json).toHaveBeenCalledWith(badRequestErrorResponse);
+  });
+});
+
+describe("CgnController#startEycaActivation", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should make the correct service method call", async () => {
+    const req = { ...mockReq(), user: mockedUser };
+
+    const client = CgnAPIClient(API_KEY, API_URL);
+    const cgnService = new CgnService(client);
+    const controller = new CgnController(cgnService);
+    await controller.startEycaActivation(req);
+
+    expect(mockStartEycaActivation).toHaveBeenCalledWith(mockedUser);
+  });
+
+  it("should call startEycaActivation method on the CgnService with valid values", async () => {
+    const req = { ...mockReq(), user: mockedUser };
+
+    mockStartEycaActivation.mockReturnValue(
+      Promise.resolve(ResponseSuccessAccepted())
+    );
+
+    const client = CgnAPIClient(API_KEY, API_URL);
+    const cgnService = new CgnService(client);
+    const controller = new CgnController(cgnService);
+    
+    const response = await controller.startEycaActivation(req);
+
+    expect(response).toEqual({
+      apply: expect.any(Function),
+      kind: "IResponseSuccessAccepted",
+      value: undefined
+    });
+  });
+
+  it("should not call startEycaActivation method on the CgnService with empty user", async () => {
+    const req = { ...mockReq(), user: undefined };
+    const res = mockRes();
+
+    const client = CgnAPIClient(API_KEY, API_URL);
+    const cgnService = new CgnService(client);
+    const controller = new CgnController(cgnService);
+    
+    const response = await controller.startEycaActivation(req);
+
+    response.apply(res);
+
+    // service method is not called
+    expect(mockStartEycaActivation).not.toBeCalled();
     // http output is correct
     expect(res.json).toHaveBeenCalledWith(badRequestErrorResponse);
   });

--- a/src/controllers/__tests__/cgnController.test.ts
+++ b/src/controllers/__tests__/cgnController.test.ts
@@ -13,6 +13,7 @@ import { CgnAPIClient } from "../../clients/cgn";
 import CgnService from "../../services/cgnService";
 import { CardPending, StatusEnum } from "../../../generated/io-cgn-api/CardPending";
 import { CgnActivationDetail, StatusEnum as ActivationStatusEnum } from "../../../generated/io-cgn-api/CgnActivationDetail";
+import { EycaActivationDetail } from "../../../generated/io-cgn-api/EycaActivationDetail";
 
 const API_KEY = "";
 const API_URL = "";
@@ -47,12 +48,14 @@ const mockedUser: User = {
 const mockGetCgnStatus = jest.fn();
 const mockStartCgnActivation = jest.fn();
 const mockGetCgnActivation = jest.fn();
+const mockGetEycaActivation = jest.fn();
 const mockStartEycaActivation = jest.fn();
 jest.mock("../../services/cgnService", () => {
   return {
     default: jest.fn().mockImplementation(() => ({
       getCgnActivation: mockGetCgnActivation,
       getCgnStatus: mockGetCgnStatus,
+      getEycaActivation: mockGetEycaActivation,
       startCgnActivation: mockStartCgnActivation,
       startEycaActivation: mockStartEycaActivation
     }))
@@ -67,6 +70,10 @@ const aCgnActivationDetail: CgnActivationDetail = {
   instance_id: {
     id: "instanceId" as NonEmptyString
   },
+  status: ActivationStatusEnum.COMPLETED
+}
+
+const anEycaActivationDetail: EycaActivationDetail = {
   status: ActivationStatusEnum.COMPLETED
 }
 
@@ -230,6 +237,61 @@ describe("CgnController#getCgnActivation", () => {
 
     // service method is not called
     expect(mockGetCgnActivation).not.toBeCalled();
+    // http output is correct
+    expect(res.json).toHaveBeenCalledWith(badRequestErrorResponse);
+  });
+});
+
+describe("CgnController#getEycaActivation", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should make the correct service method call", async () => {
+    const req = { ...mockReq(), user: mockedUser };
+
+    const client = CgnAPIClient(API_KEY, API_URL);
+    const cgnService = new CgnService(client);
+    const controller = new CgnController(cgnService);
+    await controller.getEycaActivation(req);
+
+    expect(mockGetEycaActivation).toHaveBeenCalledWith(mockedUser);
+  });
+
+  it("should call getEycaActivation method on the CgnService with valid values", async () => {
+    const req = { ...mockReq(), user: mockedUser };
+
+    mockGetEycaActivation.mockReturnValue(
+      Promise.resolve(ResponseSuccessJson(anEycaActivationDetail))
+    );
+
+    const client = CgnAPIClient(API_KEY, API_URL);
+    const cgnService = new CgnService(client);
+    const controller = new CgnController(cgnService);
+    
+    const response = await controller.getEycaActivation(req);
+
+    expect(response).toEqual({
+      apply: expect.any(Function),
+      kind: "IResponseSuccessJson",
+      value: anEycaActivationDetail
+    });
+  });
+
+  it("should not call getEycaActivation method on the CgnService with empty user", async () => {
+    const req = { ...mockReq(), user: undefined };
+    const res = mockRes();
+
+    const client = CgnAPIClient(API_KEY, API_URL);
+    const cgnService = new CgnService(client);
+    const controller = new CgnController(cgnService);
+    
+    const response = await controller.getEycaActivation(req);
+
+    response.apply(res);
+
+    // service method is not called
+    expect(mockGetEycaActivation).not.toBeCalled();
     // http output is correct
     expect(res.json).toHaveBeenCalledWith(badRequestErrorResponse);
   });

--- a/src/controllers/cgnController.ts
+++ b/src/controllers/cgnController.ts
@@ -63,4 +63,19 @@ export default class CgnController {
     | IResponseErrorNotFound
     | IResponseSuccessJson<CgnActivationDetail>
   > => withUserFromRequest(req, user => this.cgnService.getCgnActivation(user));
+
+  /**
+   * Start an EYCA activation for the current user.
+   */
+  public readonly startEycaActivation = (
+    req: express.Request
+  ): Promise<
+    | IResponseErrorInternal
+    | IResponseErrorValidation
+    | IResponseErrorForbiddenNotAuthorized
+    | IResponseErrorConflict
+    | IResponseSuccessRedirectToResource<InstanceId, InstanceId>
+    | IResponseSuccessAccepted
+  > =>
+    withUserFromRequest(req, user => this.cgnService.startEycaActivation(user));
 }

--- a/src/controllers/cgnController.ts
+++ b/src/controllers/cgnController.ts
@@ -15,6 +15,7 @@ import {
   IResponseSuccessRedirectToResource
 } from "italia-ts-commons/lib/responses";
 
+import { EycaActivationDetail } from "generated/io-cgn-api/EycaActivationDetail";
 import { Card } from "../../generated/cgn/Card";
 import CgnService from "../../src/services/cgnService";
 import { InstanceId } from "../../generated/cgn/InstanceId";
@@ -63,6 +64,19 @@ export default class CgnController {
     | IResponseErrorNotFound
     | IResponseSuccessJson<CgnActivationDetail>
   > => withUserFromRequest(req, user => this.cgnService.getCgnActivation(user));
+
+  /**
+   * Get EYCA card activation's process status for the current user.
+   */
+  public readonly getEycaActivation = (
+    req: express.Request
+  ): Promise<
+    | IResponseErrorInternal
+    | IResponseErrorValidation
+    | IResponseErrorNotFound
+    | IResponseSuccessJson<EycaActivationDetail>
+  > =>
+    withUserFromRequest(req, user => this.cgnService.getEycaActivation(user));
 
   /**
    * Start an EYCA activation for the current user.

--- a/src/services/__tests__/cgnService.test.ts
+++ b/src/services/__tests__/cgnService.test.ts
@@ -16,6 +16,8 @@ const mockGetCgnStatus = jest.fn();
 const mockStartCgnActivation = jest.fn();
 const mockGetCgnActivation = jest.fn();
 const mockStartEycaActivation = jest.fn();
+const mockGetEycaActivation = jest.fn();
+const mockGetEycaStatus = jest.fn();
 
 mockGetCgnStatus.mockImplementation(() =>
   t.success({status: 200, value:aPendingCgn})
@@ -33,6 +35,11 @@ mockGetCgnActivation.mockImplementation(() =>
   t.success({status: 200})
 );
 
+mockGetEycaActivation.mockImplementation(() =>
+  t.success({status: 200})
+);
+
+
 mockStartEycaActivation.mockImplementation(() => 
   t.success({status: 201, headers: {Location: "/api/v1/cgn/eyca/activation"}, value: {
     id: {
@@ -44,6 +51,8 @@ mockStartEycaActivation.mockImplementation(() =>
 const api = {
   getCgnActivation: mockGetCgnActivation,
   getCgnStatus: mockGetCgnStatus,
+  getEycaStatus: mockGetEycaStatus,
+  getEycaActivation: mockGetEycaActivation,
   startCgnActivation: mockStartCgnActivation,
   startEycaActivation: mockStartEycaActivation,
   upsertCgnStatus: jest.fn()
@@ -372,6 +381,102 @@ describe("CgnService#getCgnActivation", () => {
     const service = new CgnService(api);
 
     const res = await service.getCgnActivation(mockedUser);
+
+    expect(res).toMatchObject({
+      kind: "IResponseErrorInternal"
+    });
+  });
+});
+
+describe("CgnService#getEycaActivation", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should make the correct api call", async () => {
+    const service = new CgnService(api);
+
+    await service.getEycaActivation(mockedUser);
+
+    expect(mockGetEycaActivation).toHaveBeenCalledWith({
+      fiscalcode: mockedUser.fiscal_code
+    });
+  });
+
+  it("should handle a success response", async () => {
+
+    const service = new CgnService(api);
+
+    const res = await service.getEycaActivation(mockedUser);
+
+    expect(res).toMatchObject({
+      kind: "IResponseSuccessJson"
+    });
+  });
+
+  it("should handle an internal error when the client returns 401", async () => {
+    mockGetEycaActivation.mockImplementationOnce(() =>
+      t.success({ status: 401 })
+    );
+
+    const service = new CgnService(api);
+
+    const res = await service.getEycaActivation(mockedUser);
+
+    expect(res).toMatchObject({
+      kind: "IResponseErrorInternal"
+    });
+  });
+
+  it("should handle a Not Found Error when no CGN activation infos are found", async () => {
+    mockGetEycaActivation.mockImplementationOnce(() =>
+      t.success({ status: 404 })
+    );
+
+    const service = new CgnService(api);
+
+    const res = await service.getEycaActivation(mockedUser);
+
+    expect(res).toMatchObject({
+      kind: "IResponseErrorNotFound"
+    });
+  });
+
+  it("should handle an internal error response", async () => {
+    const aGenericProblem = {};
+    mockGetEycaActivation.mockImplementationOnce(() =>
+      t.success({ status: 500, value: aGenericProblem })
+    );
+
+    const service = new CgnService(api);
+
+    const res = await service.getEycaActivation(mockedUser);
+
+    expect(res).toMatchObject({
+      kind: "IResponseErrorInternal"
+    });
+  });
+
+  it("should return an error for unhandled response status code", async () => {
+    mockGetEycaActivation.mockImplementationOnce(() =>
+      t.success({ status: 123 })
+    );
+    const service = new CgnService(api);
+
+    const res = await service.getEycaActivation(mockedUser);
+
+    expect(res).toMatchObject({
+      kind: "IResponseErrorInternal"
+    });
+  });
+
+  it("should return an error if the api call thows", async () => {
+    mockGetEycaActivation.mockImplementationOnce(() => {
+      throw new Error();
+    });
+    const service = new CgnService(api);
+
+    const res = await service.getEycaActivation(mockedUser);
 
     expect(res).toMatchObject({
       kind: "IResponseErrorInternal"

--- a/src/services/__tests__/cgnService.test.ts
+++ b/src/services/__tests__/cgnService.test.ts
@@ -615,8 +615,8 @@ describe("CgnService#startEycaActivation", () => {
 
   it("should handle a success Accepted response", async () => {
     mockStartEycaActivation.mockImplementationOnce(() =>
-    t.success({status: 202})
-  );
+      t.success({status: 202})
+    );
 
   const service = new CgnService(api);
 

--- a/src/services/__tests__/cgnService.test.ts
+++ b/src/services/__tests__/cgnService.test.ts
@@ -15,6 +15,7 @@ const aValidSpidLevel = SpidLevelEnum["https://www.spid.gov.it/SpidL2"];
 const mockGetCgnStatus = jest.fn();
 const mockStartCgnActivation = jest.fn();
 const mockGetCgnActivation = jest.fn();
+const mockStartEycaActivation = jest.fn();
 
 mockGetCgnStatus.mockImplementation(() =>
   t.success({status: 200, value:aPendingCgn})
@@ -32,10 +33,19 @@ mockGetCgnActivation.mockImplementation(() =>
   t.success({status: 200})
 );
 
+mockStartEycaActivation.mockImplementation(() => 
+  t.success({status: 201, headers: {Location: "/api/v1/cgn/eyca/activation"}, value: {
+    id: {
+      id: "AnInstanceId"
+    }
+  }})
+)
+
 const api = {
   getCgnActivation: mockGetCgnActivation,
   getCgnStatus: mockGetCgnStatus,
   startCgnActivation: mockStartCgnActivation,
+  startEycaActivation: mockStartEycaActivation,
   upsertCgnStatus: jest.fn()
 } as ReturnType<CgnAPIClient>;
 
@@ -362,6 +372,129 @@ describe("CgnService#getCgnActivation", () => {
     const service = new CgnService(api);
 
     const res = await service.getCgnActivation(mockedUser);
+
+    expect(res).toMatchObject({
+      kind: "IResponseErrorInternal"
+    });
+  });
+});
+
+describe("CgnService#startEycaActivation", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should make the correct api call", async () => {
+    const service = new CgnService(api);
+
+    await service.startEycaActivation(mockedUser);
+
+    expect(mockStartEycaActivation).toHaveBeenCalledWith({
+      fiscalcode: mockedUser.fiscal_code
+    });
+  });
+
+  it("should handle a success redirect to resource response", async () => {
+
+    const service = new CgnService(api);
+
+    const res = await service.startEycaActivation(mockedUser);
+
+    expect(res).toMatchObject({
+      kind: "IResponseSuccessRedirectToResource"
+    });
+  });
+
+  it("should handle a success Accepted response", async () => {
+    mockStartEycaActivation.mockImplementationOnce(() =>
+    t.success({status: 202})
+  );
+
+  const service = new CgnService(api);
+
+  const res = await service.startEycaActivation(mockedUser);
+
+  expect(res).toMatchObject({
+    kind: "IResponseSuccessAccepted"
+  });
+});
+
+  it("should handle an internal error when the client returns 401", async () => {
+    mockStartEycaActivation.mockImplementationOnce(() =>
+    t.success({status: 401})
+  );
+    const service = new CgnService(api);
+
+    const res = await service.startEycaActivation(mockedUser);
+
+    expect(res).toMatchObject({
+      kind: "IResponseErrorInternal"
+    });
+  });
+
+  it("should handle a Forbidden error if the user is ineligible for an EYCA Card", async () => {
+    mockStartEycaActivation.mockImplementationOnce(() =>
+      t.success({ status: 403 })
+    );
+
+    const service = new CgnService(api);
+
+    const res = await service.startEycaActivation(mockedUser);
+
+    expect(res).toMatchObject({
+      kind: "IResponseErrorForbiddenNotAuthorized"
+    });
+  });
+
+  it("should handle a conflict error when the EYCA Card is already activated", async () => {
+    mockStartEycaActivation.mockImplementationOnce(() =>
+      t.success({ status: 409 })
+    );
+
+    const service = new CgnService(api);
+
+    const res = await service.startEycaActivation(mockedUser);
+
+    expect(res).toMatchObject({
+      kind: "IResponseErrorConflict"
+    });
+  });
+
+  it("should handle an internal error response", async () => {
+    const aGenericProblem = {};
+    mockStartEycaActivation.mockImplementationOnce(() =>
+      t.success({ status: 500, value: aGenericProblem })
+    );
+
+    const service = new CgnService(api);
+
+    const res = await service.startEycaActivation(mockedUser);
+
+    expect(res).toMatchObject({
+      kind: "IResponseErrorInternal"
+    });
+  });
+
+  it("should return an error for unhandled response status code", async () => {
+    mockStartEycaActivation.mockImplementationOnce(() =>
+      t.success({ status: 123 })
+    );
+    const service = new CgnService(api);
+
+    const res = await service.startEycaActivation(mockedUser);
+
+    expect(res).toMatchObject({
+      kind: "IResponseErrorInternal"
+    });
+  });
+
+  it("should return an error if the api call thows", async () => {
+    mockStartEycaActivation.mockImplementationOnce(() => {
+      throw new Error();
+    });
+    const service = new CgnService(api);
+
+    const res = await service.startEycaActivation(mockedUser);
 
     expect(res).toMatchObject({
       kind: "IResponseErrorInternal"

--- a/src/services/cgnService.ts
+++ b/src/services/cgnService.ts
@@ -232,7 +232,7 @@ export default class CgnService {
     });
 
   /**
-   * Get EYCA's activation status for the logged user.
+   * Get EYCA's activation status detail for the logged user.
    */
   public readonly getEycaActivation = (
     user: User


### PR DESCRIPTION
#### List of Changes
- Add `startEycaActivation` Api specs
- Add `getEycaActivation` Api specs
- Add tests

#### Motivation and Context
While a citizen requests for a CGN and he's between 18 up to 30 years old, he wants also activate an EYCA card ( CGN and EYCA are co-badged ), but in case of something goes wrong in EYCA activation, it must be possible to call directly EYCA activation from APP ( user retries ), see this [PR](https://github.com/pagopa/io-functions-cgn/pull/20) for function's side implementation.

#### How Has This Been Tested?
It has been tested by performing unit tests and integration test.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.