### PR TITLE
[#177017837] added getEycaStatus api

### DIFF
--- a/api_cgn.yaml
+++ b/api_cgn.yaml
@@ -86,6 +86,26 @@ paths:
           schema:
             $ref: "#/definitions/ProblemJson"
 
+  "/cgn/eyca/status":
+    get:
+      operationId: getEycaStatus
+      summary: Get the Eyca Card status details
+      description: |
+        Get the Eyca Card status details
+      responses:
+        "200":
+          description: Eyca Card status details.
+          schema:
+            $ref: "#/definitions/EycaCard"
+        "401":
+          description: Bearer token null or expired.
+        "404":
+          description: No Eyca Card found.
+        "500":
+          description: Service unavailable.
+          schema:
+            $ref: "#/definitions/ProblemJson"
+
 definitions:
   Timestamp:
     $ref: "https://raw.githubusercontent.com/pagopa/io-functions-commons/v17.3.0/openapi/definitions.yaml#/Timestamp"
@@ -109,6 +129,8 @@ definitions:
     $ref: "https://raw.githubusercontent.com/pagopa/io-functions-cgn/master/openapi/index.yaml#/definitions/Card"
   CgnActivationDetail:
     $ref: "https://raw.githubusercontent.com/pagopa/io-functions-cgn/master/openapi/index.yaml#/definitions/CgnActivationDetail"
+  EycaCard:
+    $ref: "https://raw.githubusercontent.com/pagopa/io-functions-cgn/master/openapi/index.yaml#/definitions/EycaCard"
     
 securityDefinitions:
   Bearer:

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "generate:proxy:bonus-models": "rimraf generated/bonus && gen-api-models --api-spec api_bonus.yaml --out-dir generated/bonus",
     "generate:proxy:cgn-models": "rimraf generated/cgn && gen-api-models --api-spec api_cgn.yaml --out-dir generated/cgn",
     "generate:api:io-bonus": "rimraf generated/io-bonus-api && gen-api-models --api-spec https://raw.githubusercontent.com/pagopa/io-functions-bonus/master/openapi/index.yaml --no-strict --out-dir generated/io-bonus-api --request-types --response-decoders --client",
-    "generate:api:io-cgn": "rimraf generated/io-cgn-api && gen-api-models --api-spec https://raw.githubusercontent.com/pagopa/io-functions-cgn/master/openapi/index.yaml --no-strict --out-dir generated/io-cgn-api --request-types --response-decoders --client",
+    "generate:api:io-cgn": "rimraf generated/io-cgn-api && gen-api-models --api-spec https://raw.githubusercontent.com/pagopa/io-functions-cgn/177017837_addEYCA_get_status_api/openapi/index.yaml --no-strict --out-dir generated/io-cgn-api --request-types --response-decoders --client",
     "generate:api:pagopaproxy": "rimraf generated/pagopa-proxy && gen-api-models --api-spec https://raw.githubusercontent.com/pagopa/io-pagopa-proxy/v0.8.6/api_pagopa.yaml --no-strict --out-dir generated/pagopa-proxy --request-types --response-decoders --client",
     "generate:test-certs": "./scripts/generate-test-certs.sh certs",
     "postversion": "git push && git push --tags",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "generate:proxy:bonus-models": "rimraf generated/bonus && gen-api-models --api-spec api_bonus.yaml --out-dir generated/bonus",
     "generate:proxy:cgn-models": "rimraf generated/cgn && gen-api-models --api-spec api_cgn.yaml --out-dir generated/cgn",
     "generate:api:io-bonus": "rimraf generated/io-bonus-api && gen-api-models --api-spec https://raw.githubusercontent.com/pagopa/io-functions-bonus/master/openapi/index.yaml --no-strict --out-dir generated/io-bonus-api --request-types --response-decoders --client",
-    "generate:api:io-cgn": "rimraf generated/io-cgn-api && gen-api-models --api-spec https://raw.githubusercontent.com/pagopa/io-functions-cgn/177017837_addEYCA_get_status_api/openapi/index.yaml --no-strict --out-dir generated/io-cgn-api --request-types --response-decoders --client",
+    "generate:api:io-cgn": "rimraf generated/io-cgn-api && gen-api-models --api-spec https://raw.githubusercontent.com/pagopa/io-functions-cgn/master/openapi/index.yaml --no-strict --out-dir generated/io-cgn-api --request-types --response-decoders --client",
     "generate:api:pagopaproxy": "rimraf generated/pagopa-proxy && gen-api-models --api-spec https://raw.githubusercontent.com/pagopa/io-pagopa-proxy/v0.8.6/api_pagopa.yaml --no-strict --out-dir generated/pagopa-proxy --request-types --response-decoders --client",
     "generate:test-certs": "./scripts/generate-test-certs.sh certs",
     "postversion": "git push && git push --tags",

--- a/src/app.ts
+++ b/src/app.ts
@@ -842,6 +842,12 @@ function registerCgnAPIRoutes(
     toExpressHandler(cgnController.getCgnStatus, cgnController)
   );
 
+  app.get(
+    `${basePath}/cgn/eyca/status`,
+    bearerSessionTokenAuth,
+    toExpressHandler(cgnController.getEycaStatus, cgnController)
+  );
+
   app.post(
     `${basePath}/cgn/activation`,
     bearerSessionTokenAuth,

--- a/src/controllers/cgnController.ts
+++ b/src/controllers/cgnController.ts
@@ -15,6 +15,7 @@ import {
   IResponseSuccessRedirectToResource
 } from "italia-ts-commons/lib/responses";
 
+import { EycaCard } from "generated/io-cgn-api/EycaCard";
 import { Card } from "../../generated/cgn/Card";
 import CgnService from "../../src/services/cgnService";
 import { InstanceId } from "../../generated/cgn/InstanceId";
@@ -36,6 +37,19 @@ export default class CgnController {
     | IResponseErrorForbiddenNotAuthorized
     | IResponseSuccessJson<Card>
   > => withUserFromRequest(req, user => this.cgnService.getCgnStatus(user));
+
+  /**
+   * Get the Eyca Card status for the current user.
+   */
+  public readonly getEycaStatus = (
+    req: express.Request
+  ): Promise<
+    | IResponseErrorInternal
+    | IResponseErrorValidation
+    | IResponseErrorNotFound
+    | IResponseErrorForbiddenNotAuthorized
+    | IResponseSuccessJson<EycaCard>
+  > => withUserFromRequest(req, user => this.cgnService.getEycaStatus(user));
 
   /**
    * Start a Cgn activation for the current user.

--- a/src/services/__tests__/cgnService.test.ts
+++ b/src/services/__tests__/cgnService.test.ts
@@ -13,11 +13,16 @@ const aValidSPIDEmail = "from_spid@example.com" as EmailAddress;
 const aValidSpidLevel = SpidLevelEnum["https://www.spid.gov.it/SpidL2"];
 
 const mockGetCgnStatus = jest.fn();
+const mockGetEycaStatus = jest.fn();
 const mockStartCgnActivation = jest.fn();
 const mockGetCgnActivation = jest.fn();
 
 mockGetCgnStatus.mockImplementation(() =>
   t.success({status: 200, value:aPendingCgn})
+);
+
+mockGetEycaStatus.mockImplementation(() =>
+  t.success({status: 200, value:aPendingEycaCard})
 );
 
 mockStartCgnActivation.mockImplementation(() =>
@@ -35,6 +40,7 @@ mockGetCgnActivation.mockImplementation(() =>
 const api = {
   getCgnActivation: mockGetCgnActivation,
   getCgnStatus: mockGetCgnStatus,
+  getEycaStatus: mockGetEycaStatus,
   startCgnActivation: mockStartCgnActivation,
   upsertCgnStatus: jest.fn()
 } as ReturnType<CgnAPIClient>;
@@ -52,6 +58,9 @@ const mockedUser: User = {
   };
 
 const aPendingCgn: CardPending = {
+    status: StatusEnum.PENDING
+}
+const aPendingEycaCard: CardPending = {
     status: StatusEnum.PENDING
 }
 describe("CgnService#getCgnStatus", () => {
@@ -143,6 +152,102 @@ describe("CgnService#getCgnStatus", () => {
       const service = new CgnService(api);
   
       const res = await service.getCgnStatus(mockedUser);
+  
+      expect(res).toMatchObject({
+        kind: "IResponseErrorInternal"
+      });
+    });
+  });
+
+describe("CgnService#getEycaStatus", () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+  
+    it("should make the correct api call", async () => {
+      const service = new CgnService(api);
+  
+      await service.getEycaStatus(mockedUser);
+  
+      expect(mockGetEycaStatus).toHaveBeenCalledWith({
+        fiscalcode: mockedUser.fiscal_code
+      });
+    });
+  
+    it("should handle a success response", async () => {
+  
+      const service = new CgnService(api);
+  
+      const res = await service.getEycaStatus(mockedUser);
+  
+      expect(res).toMatchObject({
+        kind: "IResponseSuccessJson"
+      });
+    });
+
+    it("should handle an internal error when the client returns 401", async () => {
+        mockGetEycaStatus.mockImplementationOnce(() =>
+        t.success({ status: 401 })
+      );
+  
+      const service = new CgnService(api);
+  
+      const res = await service.getEycaStatus(mockedUser);
+  
+      expect(res).toMatchObject({
+        kind: "IResponseErrorInternal"
+      });
+    });
+  
+    it("should handle a not found error when the Eyca Card is not found", async () => {
+        mockGetEycaStatus.mockImplementationOnce(() =>
+        t.success({ status: 404 })
+      );
+  
+      const service = new CgnService(api);
+  
+      const res = await service.getEycaStatus(mockedUser);
+  
+      expect(res).toMatchObject({
+        kind: "IResponseErrorNotFound"
+      });
+    });
+  
+    it("should handle an internal error response", async () => {
+      const aGenericProblem = {};
+      mockGetEycaStatus.mockImplementationOnce(() =>
+        t.success({ status: 500, value: aGenericProblem })
+      );
+  
+      const service = new CgnService(api);
+  
+      const res = await service.getEycaStatus(mockedUser);
+  
+      expect(res).toMatchObject({
+        kind: "IResponseErrorInternal"
+      });
+    });
+  
+    it("should return an error for unhandled response status code", async () => {
+        mockGetEycaStatus.mockImplementationOnce(() =>
+        t.success({ status: 123 })
+      );
+      const service = new CgnService(api);
+  
+      const res = await service.getEycaStatus(mockedUser);
+  
+      expect(res).toMatchObject({
+        kind: "IResponseErrorInternal"
+      });
+    });
+  
+    it("should return an error if the api call thows", async () => {
+      mockGetEycaStatus.mockImplementationOnce(() => {
+        throw new Error();
+      });
+      const service = new CgnService(api);
+  
+      const res = await service.getEycaStatus(mockedUser);
   
       expect(res).toMatchObject({
         kind: "IResponseErrorInternal"

--- a/src/services/cgnService.ts
+++ b/src/services/cgnService.ts
@@ -21,6 +21,7 @@ import {
 } from "italia-ts-commons/lib/responses";
 
 import { fromNullable } from "fp-ts/lib/Option";
+import { EycaCard } from "generated/io-cgn-api/EycaCard";
 import { InstanceId } from "../../generated/io-cgn-api/InstanceId";
 import { CgnActivationDetail } from "../../generated/io-cgn-api/CgnActivationDetail";
 import { CgnAPIClient } from "../../src/clients/cgn";
@@ -61,6 +62,39 @@ export default class CgnService {
             return ResponseErrorUnexpectedAuthProblem();
           case 404:
             return ResponseErrorNotFound("Not Found", "CGN not found");
+          case 500:
+            return ResponseErrorInternal(readableProblem(response.value));
+          default:
+            return ResponseErrorStatusNotDefinedInSpec(response);
+        }
+      });
+    });
+
+  /**
+   * Get the current Eyca Card Status related to the user.
+   */
+  public readonly getEycaStatus = (
+    user: User
+  ): Promise<
+    | IResponseErrorInternal
+    | IResponseErrorValidation
+    | IResponseErrorNotFound
+    | IResponseErrorForbiddenNotAuthorized
+    | IResponseSuccessJson<EycaCard>
+  > =>
+    withCatchAsInternalError(async () => {
+      const validated = await this.cgnApiClient.getEycaStatus({
+        fiscalcode: user.fiscal_code
+      });
+
+      return withValidatedOrInternalError(validated, response => {
+        switch (response.status) {
+          case 200:
+            return ResponseSuccessJson(response.value);
+          case 401:
+            return ResponseErrorUnexpectedAuthProblem();
+          case 404:
+            return ResponseErrorNotFound("Not Found", "Eyca Card not found");
           case 500:
             return ResponseErrorInternal(readableProblem(response.value));
           default:


### PR DESCRIPTION
#### List of Changes
- Add `getEycaStatus` API
- Add tests

#### Motivation and Context
While a citizen requests for a CGN and he's between 18 up to 30 years old, he wants also activate an EYCA card ( CGN and EYCA are co-badged ). We need to provide an API that could return detailed information about an EYCA Card.

#### How Has This Been Tested?
It has been tested by performing unit tests .

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.