### PR TITLE
[#177081289] Add Conflict and Forbidden responses on getEycaStatus

### DIFF
--- a/api_cgn.yaml
+++ b/api_cgn.yaml
@@ -154,8 +154,12 @@ paths:
             $ref: "#/definitions/EycaCard"
         "401":
           description: Bearer token null or expired.
+        "403":
+          description: Forbidden.
         "404":
           description: No Eyca Card found.
+        "409":
+          description: Conflict.
         "500":
           description: Service unavailable.
           schema:
@@ -194,7 +198,7 @@ definitions:
   EycaCardRevoked:
     $ref: "https://raw.githubusercontent.com/pagopa/io-functions-cgn/master/openapi/index.yaml#/definitions/EycaCardRevoked"
   CcdbNumber:
-    $ref: "https://raw.githubusercontent.com/pagopa/io-functions-cgn/master/openapi/index.yaml#/definitions/EycaCardRevoked"
+    $ref: "https://raw.githubusercontent.com/pagopa/io-functions-cgn/master/openapi/index.yaml#/definitions/CcdbNumber"
   
 securityDefinitions:
   Bearer:

--- a/src/controllers/cgnController.ts
+++ b/src/controllers/cgnController.ts
@@ -49,6 +49,7 @@ export default class CgnController {
     | IResponseErrorValidation
     | IResponseErrorNotFound
     | IResponseErrorForbiddenNotAuthorized
+    | IResponseErrorConflict
     | IResponseSuccessJson<EycaCard>
   > => withUserFromRequest(req, user => this.cgnService.getEycaStatus(user));
 

--- a/src/services/__tests__/cgnService.test.ts
+++ b/src/services/__tests__/cgnService.test.ts
@@ -215,6 +215,20 @@ describe("CgnService#getEycaStatus", () => {
         kind: "IResponseErrorInternal"
       });
     });
+
+    it("should handle a Forbidden error when the client returns 403", async () => {
+      mockGetEycaStatus.mockImplementationOnce(() =>
+      t.success({ status: 403 })
+    );
+
+    const service = new CgnService(api);
+
+    const res = await service.getEycaStatus(mockedUser);
+
+    expect(res).toMatchObject({
+      kind: "IResponseErrorForbiddenNotAuthorized"
+    });
+  });
   
     it("should handle a not found error when the Eyca Card is not found", async () => {
         mockGetEycaStatus.mockImplementationOnce(() =>
@@ -229,6 +243,20 @@ describe("CgnService#getEycaStatus", () => {
         kind: "IResponseErrorNotFound"
       });
     });
+
+    it("should handle a Conflict error when the client returns 409", async () => {
+      mockGetEycaStatus.mockImplementationOnce(() =>
+      t.success({ status: 409 })
+    );
+
+    const service = new CgnService(api);
+
+    const res = await service.getEycaStatus(mockedUser);
+
+    expect(res).toMatchObject({
+      kind: "IResponseErrorConflict"
+    });
+  });
   
     it("should handle an internal error response", async () => {
       const aGenericProblem = {};

--- a/src/services/cgnService.ts
+++ b/src/services/cgnService.ts
@@ -81,6 +81,7 @@ export default class CgnService {
     | IResponseErrorValidation
     | IResponseErrorNotFound
     | IResponseErrorForbiddenNotAuthorized
+    | IResponseErrorConflict
     | IResponseSuccessJson<EycaCard>
   > =>
     withCatchAsInternalError(async () => {
@@ -94,8 +95,14 @@ export default class CgnService {
             return ResponseSuccessJson(response.value);
           case 401:
             return ResponseErrorUnexpectedAuthProblem();
+          case 403:
+            return ResponseErrorForbiddenNotAuthorized;
           case 404:
             return ResponseErrorNotFound("Not Found", "Eyca Card not found");
+          case 409:
+            return ResponseErrorConflict(
+              "EYCA Card is missing while citizen is eligible to obtain it or a CGN is already activated"
+            );
           case 500:
             return ResponseErrorInternal(readableProblem(response.value));
           default:


### PR DESCRIPTION
This PR adds proper error responses on `getEycaStatus` used to manage particular case of errors. See [this](https://github.com/pagopa/io-functions-cgn/pull/29) for further informations.