### PR TITLE
[#177137914] Add Allowed Test Fiscal Codes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -52,3 +52,5 @@ SPID_LEVEL_WHITELIST=SpidL2,SpidL3
 CGN_API_KEY=put_your_api_key_here
 CGN_API_URL=http://host.docker.internal:7073/api/v1
 CGN_API_BASE_PATH="/api/v1/cgn"
+
+TEST_CGN_FISCAL_CODES=

--- a/api_cgn.yaml
+++ b/api_cgn.yaml
@@ -23,6 +23,8 @@ paths:
             $ref: "#/definitions/Card"
         "401":
           description: Bearer token null or expired.
+        "403":
+          description: Forbidden.
         "404":
           description: No CGN found.
         "500":
@@ -79,6 +81,8 @@ paths:
               $ref: "#/definitions/CgnActivationDetail"
         "401":
           description: Bearer token null or expired.
+        "403":
+          description: Forbidden.
         "404":
           description: No CGN activation process found.
         "500":
@@ -134,6 +138,8 @@ paths:
               $ref: "#/definitions/EycaActivationDetail"
         "401":
           description: Wrong or missing function key.
+        "403":
+          description: Forbidden.
         "404":
           description: No EYCA Card activation process found.
         "500":

--- a/src/app.ts
+++ b/src/app.ts
@@ -52,7 +52,8 @@ import {
   tokenDurationSecs,
   URL_TOKEN_STRATEGY,
   USERS_LOGIN_QUEUE_NAME,
-  USERS_LOGIN_STORAGE_CONNECTION_STRING
+  USERS_LOGIN_STORAGE_CONNECTION_STRING,
+  TEST_CGN_FISCAL_CODES
 } from "./config";
 import AuthenticationController from "./controllers/authenticationController";
 import MessagesController from "./controllers/messagesController";
@@ -834,7 +835,10 @@ function registerCgnAPIRoutes(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   bearerSessionTokenAuth: any
 ): void {
-  const cgnController: CgnController = new CgnController(cgnService);
+  const cgnController: CgnController = new CgnController(
+    cgnService,
+    TEST_CGN_FISCAL_CODES
+  );
 
   app.get(
     `${basePath}/cgn/status`,

--- a/src/config.ts
+++ b/src/config.ts
@@ -41,7 +41,7 @@ import { getRequiredENVVar, readFile } from "./utils/container";
 import PagoPAClientFactory from "./services/pagoPAClientFactory";
 import ApiClientFactory from "./services/apiClientFactory";
 import { BonusAPIClient } from "./clients/bonus";
-import { STRINGS_RECORD } from "./types/commons";
+import { CommaSeparatedListOf, STRINGS_RECORD } from "./types/commons";
 import { SpidLevelArray } from "./types/spidLevel";
 import { decodeCIDRs } from "./utils/cidrs";
 
@@ -455,9 +455,10 @@ log.info(
   JWT_SUPPORT_TOKEN_EXPIRATION
 );
 
-export const TEST_CGN_FISCAL_CODES = NonEmptyString.decode(
-  process.env.TEST_CGN_FISCAL_CODES
-)
-  .map(_ => _.split(","))
-  .map(_ => rights(_.map(FiscalCode.decode)))
-  .getOrElse([]);
+export const TEST_CGN_FISCAL_CODES = CommaSeparatedListOf(FiscalCode)
+  .decode(process.env.TEST_CGN_FISCAL_CODES || "")
+  .getOrElseL(err => {
+    throw new Error(
+      `Invalid TEST_CGN_FISCAL_CODES value: ${readableReport(err)}`
+    );
+  });

--- a/src/config.ts
+++ b/src/config.ts
@@ -454,3 +454,10 @@ log.info(
   "JWT support token expiration set to %s seconds",
   JWT_SUPPORT_TOKEN_EXPIRATION
 );
+
+export const TEST_CGN_FISCAL_CODES = NonEmptyString.decode(
+  process.env.TEST_CGN_FISCAL_CODES
+)
+  .map(_ => _.split(","))
+  .map(_ => rights(_.map(FiscalCode.decode)))
+  .getOrElse([]);

--- a/src/controllers/__tests__/cgnController.test.ts
+++ b/src/controllers/__tests__/cgnController.test.ts
@@ -51,6 +51,7 @@ const mockStartCgnActivation = jest.fn();
 const mockGetCgnActivation = jest.fn();
 const mockGetEycaActivation = jest.fn();
 const mockStartEycaActivation = jest.fn();
+
 jest.mock("../../services/cgnService", () => {
   return {
     default: jest.fn().mockImplementation(() => ({
@@ -83,6 +84,8 @@ const anEycaActivationDetail: EycaActivationDetail = {
   status: ActivationStatusEnum.COMPLETED
 }
 
+const allowedTestFiscalCodesMock = jest.fn().mockImplementation(() => [])
+
 describe("CgnController#getCgnStatus", () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -90,10 +93,9 @@ describe("CgnController#getCgnStatus", () => {
 
   it("should make the correct service method call", async () => {
     const req = { ...mockReq(), user: mockedUser };
-
     const client = CgnAPIClient(API_KEY, API_URL);
     const cgnService = new CgnService(client);
-    const controller = new CgnController(cgnService);
+    const controller = new CgnController(cgnService, allowedTestFiscalCodesMock());
     await controller.getCgnStatus(req);
 
     expect(mockGetCgnStatus).toHaveBeenCalledWith(mockedUser);
@@ -105,10 +107,9 @@ describe("CgnController#getCgnStatus", () => {
     mockGetCgnStatus.mockReturnValue(
       Promise.resolve(ResponseSuccessJson(aPendingCgn))
     );
-
     const client = CgnAPIClient(API_KEY, API_URL);
     const cgnService = new CgnService(client);
-    const controller = new CgnController(cgnService);
+    const controller = new CgnController(cgnService, allowedTestFiscalCodesMock());
     
     const response = await controller.getCgnStatus(req);
 
@@ -125,7 +126,7 @@ describe("CgnController#getCgnStatus", () => {
 
     const client = CgnAPIClient(API_KEY, API_URL);
     const cgnService = new CgnService(client);
-    const controller = new CgnController(cgnService);
+    const controller = new CgnController(cgnService, allowedTestFiscalCodesMock());
     
     const response = await controller.getCgnStatus(req);
 
@@ -135,6 +136,23 @@ describe("CgnController#getCgnStatus", () => {
     expect(mockGetCgnStatus).not.toBeCalled();
     // http output is correct
     expect(res.json).toHaveBeenCalledWith(badRequestErrorResponse);
+  });
+
+  it("should not call getCgnStatus method on the CgnService with Not allowed user", async () => {
+    const req = { ...mockReq(), user: mockedUser };
+
+    allowedTestFiscalCodesMock.mockImplementationOnce(() => ["GRBGPP87L04L741Z" as FiscalCode])
+    const client = CgnAPIClient(API_KEY, API_URL);
+    const cgnService = new CgnService(client);
+    const controller = new CgnController(cgnService, allowedTestFiscalCodesMock());
+
+    const response = await controller.getCgnStatus(req);
+
+    // service method is not called
+    expect(mockGetCgnStatus).not.toBeCalled();
+    expect(response).toMatchObject({
+      kind: "IResponseErrorForbiddenNotAuthorized"
+    });
   });
 });
 
@@ -148,7 +166,7 @@ describe("CgnController#getEycaStatus", () => {
 
     const client = CgnAPIClient(API_KEY, API_URL);
     const cgnService = new CgnService(client);
-    const controller = new CgnController(cgnService);
+    const controller = new CgnController(cgnService, allowedTestFiscalCodesMock());
     await controller.getEycaStatus(req);
 
     expect(mockGetEycaStatus).toHaveBeenCalledWith(mockedUser);
@@ -163,7 +181,7 @@ describe("CgnController#getEycaStatus", () => {
 
     const client = CgnAPIClient(API_KEY, API_URL);
     const cgnService = new CgnService(client);
-    const controller = new CgnController(cgnService);
+    const controller = new CgnController(cgnService, allowedTestFiscalCodesMock());
     
     const response = await controller.getEycaStatus(req);
 
@@ -180,7 +198,7 @@ describe("CgnController#getEycaStatus", () => {
 
     const client = CgnAPIClient(API_KEY, API_URL);
     const cgnService = new CgnService(client);
-    const controller = new CgnController(cgnService);
+    const controller = new CgnController(cgnService, allowedTestFiscalCodesMock());
     
     const response = await controller.getEycaStatus(req);
 
@@ -191,6 +209,23 @@ describe("CgnController#getEycaStatus", () => {
 
     // http output is correct
     expect(res.json).toHaveBeenCalledWith(badRequestErrorResponse);
+  });
+
+  it("should not call getEycaStatus method on the CgnService with Not allowed user", async () => {
+    const req = { ...mockReq(), user: mockedUser };
+
+    allowedTestFiscalCodesMock.mockImplementationOnce(() => ["GRBGPP87L04L741Z" as FiscalCode])
+    const client = CgnAPIClient(API_KEY, API_URL);
+    const cgnService = new CgnService(client);
+    const controller = new CgnController(cgnService, allowedTestFiscalCodesMock());
+
+    const response = await controller.getEycaStatus(req);
+
+    // service method is not called
+    expect(mockGetEycaStatus).not.toBeCalled();
+    expect(response).toMatchObject({
+      kind: "IResponseErrorForbiddenNotAuthorized"
+    });
   });
 });
 
@@ -204,7 +239,7 @@ describe("CgnController#startCgnActivation", () => {
 
     const client = CgnAPIClient(API_KEY, API_URL);
     const cgnService = new CgnService(client);
-    const controller = new CgnController(cgnService);
+    const controller = new CgnController(cgnService, allowedTestFiscalCodesMock());
     await controller.startCgnActivation(req);
 
     expect(mockStartCgnActivation).toHaveBeenCalledWith(mockedUser);
@@ -219,7 +254,7 @@ describe("CgnController#startCgnActivation", () => {
 
     const client = CgnAPIClient(API_KEY, API_URL);
     const cgnService = new CgnService(client);
-    const controller = new CgnController(cgnService);
+    const controller = new CgnController(cgnService, allowedTestFiscalCodesMock());
     
     const response = await controller.startCgnActivation(req);
 
@@ -236,7 +271,7 @@ describe("CgnController#startCgnActivation", () => {
 
     const client = CgnAPIClient(API_KEY, API_URL);
     const cgnService = new CgnService(client);
-    const controller = new CgnController(cgnService);
+    const controller = new CgnController(cgnService, allowedTestFiscalCodesMock());
     
     const response = await controller.startCgnActivation(req);
 
@@ -246,6 +281,23 @@ describe("CgnController#startCgnActivation", () => {
     expect(mockStartCgnActivation).not.toBeCalled();
     // http output is correct
     expect(res.json).toHaveBeenCalledWith(badRequestErrorResponse);
+  });
+
+  it("should not call startCgnActivation method on the CgnService with Not allowed user", async () => {
+    const req = { ...mockReq(), user: mockedUser };
+
+    allowedTestFiscalCodesMock.mockImplementationOnce(() => ["GRBGPP87L04L741Z" as FiscalCode])
+    const client = CgnAPIClient(API_KEY, API_URL);
+    const cgnService = new CgnService(client);
+    const controller = new CgnController(cgnService, allowedTestFiscalCodesMock());
+
+    const response = await controller.startCgnActivation(req);
+
+    // service method is not called
+    expect(mockStartCgnActivation).not.toBeCalled();
+    expect(response).toMatchObject({
+      kind: "IResponseErrorForbiddenNotAuthorized"
+    });
   });
 });
 
@@ -259,7 +311,7 @@ describe("CgnController#getCgnActivation", () => {
 
     const client = CgnAPIClient(API_KEY, API_URL);
     const cgnService = new CgnService(client);
-    const controller = new CgnController(cgnService);
+    const controller = new CgnController(cgnService, allowedTestFiscalCodesMock());
     await controller.getCgnActivation(req);
 
     expect(mockGetCgnActivation).toHaveBeenCalledWith(mockedUser);
@@ -274,7 +326,7 @@ describe("CgnController#getCgnActivation", () => {
 
     const client = CgnAPIClient(API_KEY, API_URL);
     const cgnService = new CgnService(client);
-    const controller = new CgnController(cgnService);
+    const controller = new CgnController(cgnService, allowedTestFiscalCodesMock());
     
     const response = await controller.getCgnActivation(req);
 
@@ -285,13 +337,13 @@ describe("CgnController#getCgnActivation", () => {
     });
   });
 
-  it("should not call startCgnActivation method on the CgnService with empty user", async () => {
+  it("should not call getCgnActivation method on the CgnService with empty user", async () => {
     const req = { ...mockReq(), user: undefined };
     const res = mockRes();
 
     const client = CgnAPIClient(API_KEY, API_URL);
     const cgnService = new CgnService(client);
-    const controller = new CgnController(cgnService);
+    const controller = new CgnController(cgnService, allowedTestFiscalCodesMock());
     
     const response = await controller.getCgnActivation(req);
 
@@ -301,6 +353,22 @@ describe("CgnController#getCgnActivation", () => {
     expect(mockGetCgnActivation).not.toBeCalled();
     // http output is correct
     expect(res.json).toHaveBeenCalledWith(badRequestErrorResponse);
+  });
+  it("should not call getCgnActivation method on the CgnService with Not allowed user", async () => {
+    const req = { ...mockReq(), user: mockedUser };
+
+    allowedTestFiscalCodesMock.mockImplementationOnce(() => ["GRBGPP87L04L741Z" as FiscalCode])
+    const client = CgnAPIClient(API_KEY, API_URL);
+    const cgnService = new CgnService(client);
+    const controller = new CgnController(cgnService, allowedTestFiscalCodesMock());
+
+    const response = await controller.getCgnActivation(req);
+
+    // service method is not called
+    expect(mockGetCgnActivation).not.toBeCalled();
+    expect(response).toMatchObject({
+      kind: "IResponseErrorForbiddenNotAuthorized"
+    });
   });
 });
 
@@ -314,7 +382,7 @@ describe("CgnController#getEycaActivation", () => {
 
     const client = CgnAPIClient(API_KEY, API_URL);
     const cgnService = new CgnService(client);
-    const controller = new CgnController(cgnService);
+    const controller = new CgnController(cgnService, allowedTestFiscalCodesMock());
     await controller.getEycaActivation(req);
 
     expect(mockGetEycaActivation).toHaveBeenCalledWith(mockedUser);
@@ -329,7 +397,7 @@ describe("CgnController#getEycaActivation", () => {
 
     const client = CgnAPIClient(API_KEY, API_URL);
     const cgnService = new CgnService(client);
-    const controller = new CgnController(cgnService);
+    const controller = new CgnController(cgnService, allowedTestFiscalCodesMock());
     
     const response = await controller.getEycaActivation(req);
 
@@ -346,7 +414,7 @@ describe("CgnController#getEycaActivation", () => {
 
     const client = CgnAPIClient(API_KEY, API_URL);
     const cgnService = new CgnService(client);
-    const controller = new CgnController(cgnService);
+    const controller = new CgnController(cgnService, allowedTestFiscalCodesMock());
     
     const response = await controller.getEycaActivation(req);
 
@@ -356,6 +424,23 @@ describe("CgnController#getEycaActivation", () => {
     expect(mockGetEycaActivation).not.toBeCalled();
     // http output is correct
     expect(res.json).toHaveBeenCalledWith(badRequestErrorResponse);
+  });
+
+  it("should not call getEycaActivation method on the CgnService with Not allowed user", async () => {
+    const req = { ...mockReq(), user: mockedUser };
+
+    allowedTestFiscalCodesMock.mockImplementationOnce(() => ["GRBGPP87L04L741Z" as FiscalCode])
+    const client = CgnAPIClient(API_KEY, API_URL);
+    const cgnService = new CgnService(client);
+    const controller = new CgnController(cgnService, allowedTestFiscalCodesMock());
+
+    const response = await controller.getEycaActivation(req);
+
+    // service method is not called
+    expect(mockGetEycaActivation).not.toBeCalled();
+    expect(response).toMatchObject({
+      kind: "IResponseErrorForbiddenNotAuthorized"
+    });
   });
 });
 
@@ -369,7 +454,7 @@ describe("CgnController#startEycaActivation", () => {
 
     const client = CgnAPIClient(API_KEY, API_URL);
     const cgnService = new CgnService(client);
-    const controller = new CgnController(cgnService);
+    const controller = new CgnController(cgnService, allowedTestFiscalCodesMock());
     await controller.startEycaActivation(req);
 
     expect(mockStartEycaActivation).toHaveBeenCalledWith(mockedUser);
@@ -384,7 +469,7 @@ describe("CgnController#startEycaActivation", () => {
 
     const client = CgnAPIClient(API_KEY, API_URL);
     const cgnService = new CgnService(client);
-    const controller = new CgnController(cgnService);
+    const controller = new CgnController(cgnService, allowedTestFiscalCodesMock());
     
     const response = await controller.startEycaActivation(req);
 
@@ -401,7 +486,7 @@ describe("CgnController#startEycaActivation", () => {
 
     const client = CgnAPIClient(API_KEY, API_URL);
     const cgnService = new CgnService(client);
-    const controller = new CgnController(cgnService);
+    const controller = new CgnController(cgnService, allowedTestFiscalCodesMock());
     
     const response = await controller.startEycaActivation(req);
 
@@ -411,5 +496,21 @@ describe("CgnController#startEycaActivation", () => {
     expect(mockStartEycaActivation).not.toBeCalled();
     // http output is correct
     expect(res.json).toHaveBeenCalledWith(badRequestErrorResponse);
+  });
+  it("should not call startEycaActivation method on the CgnService with Not allowed user", async () => {
+    const req = { ...mockReq(), user: mockedUser };
+
+    allowedTestFiscalCodesMock.mockImplementationOnce(() => ["GRBGPP87L04L741Z" as FiscalCode])
+    const client = CgnAPIClient(API_KEY, API_URL);
+    const cgnService = new CgnService(client);
+    const controller = new CgnController(cgnService, allowedTestFiscalCodesMock());
+
+    const response = await controller.startEycaActivation(req);
+
+    // service method is not called
+    expect(mockStartEycaActivation).not.toBeCalled();
+    expect(response).toMatchObject({
+      kind: "IResponseErrorForbiddenNotAuthorized"
+    });
   });
 });

--- a/src/controllers/cgnController.ts
+++ b/src/controllers/cgnController.ts
@@ -30,8 +30,8 @@ export const withAllowedUser = async <T>(
   allowedFiscalCodes: ReadonlyArray<FiscalCode>,
   f: (user: User) => Promise<T>
 ) =>
-  allowedFiscalCodes.includes(user.fiscal_code) ||
-  allowedFiscalCodes.length === 0
+  allowedFiscalCodes.length === 0 ||
+  allowedFiscalCodes.includes(user.fiscal_code)
     ? f(user)
     : ResponseErrorForbiddenNotAuthorized;
 

--- a/src/types/commons.ts
+++ b/src/types/commons.ts
@@ -16,3 +16,28 @@ export type STRINGS_RECORD = t.TypeOf<typeof STRINGS_RECORD>;
 export function assertUnreachable(_: never): never {
   throw new Error("Unexpected type error");
 }
+
+/**
+ * Create a decoder that parses a list of comma-separated elements into an array of typed items, using the provided decoder
+ *
+ * @param decoder a io-ts decoder
+ * @returns either a decode error or the array of decoded items
+ */
+export const CommaSeparatedListOf = (decoder: t.Mixed) =>
+  new t.Type<ReadonlyArray<t.TypeOf<typeof decoder>>, string, unknown>(
+    `CommaSeparatedListOf<${decoder.name}>`,
+    (value: unknown): value is ReadonlyArray<t.TypeOf<typeof decoder>> =>
+      Array.isArray(value) && value.every(e => decoder.is(e)),
+    input =>
+      t.readonlyArray(decoder).decode(
+        typeof input === "string"
+          ? input
+              .split(",")
+              .map(e => e.trim())
+              .filter(Boolean)
+          : !input
+          ? [] // fallback to empty array in case of empty input
+          : input // it should not happen, but in case we let the decoder fail
+      ),
+    String
+  );


### PR DESCRIPTION
#### List of Changes
- Add Allowed CGN Fiscal Codes env variable
- Add CgnController internal middleware `withAllowedUser`
- Add tests

#### Motivation and Context
In order to provide an internal MVP of CGN functionalities, we must allow only a subset of fiscal codes that can perform api calls. See this [story](https://www.pivotaltracker.com/story/show/177137914) for further informations.

#### How Has This Been Tested?
Unit tests

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.