### PR TITLE
[#175761529] Add CGN generate OTP API

### DIFF
--- a/api_cgn.yaml
+++ b/api_cgn.yaml
@@ -194,37 +194,37 @@ definitions:
   ProblemJson:
     $ref: "https://raw.githubusercontent.com/pagopa/io-functions-commons/v17.3.0/openapi/definitions.yaml#/ProblemJson"
   InstanceId:
-    $ref: "https://raw.githubusercontent.com/pagopa/io-functions-cgn/v0.1.4/openapi/index.yaml#/definitions/InstanceId"
+    $ref: "https://raw.githubusercontent.com/pagopa/io-functions-cgn/v0.2.0/openapi/index.yaml#/definitions/InstanceId"
   CommonCard:
-    $ref: "https://raw.githubusercontent.com/pagopa/io-functions-cgn/v0.1.4/openapi/index.yaml#/definitions/CommonCard"
+    $ref: "https://raw.githubusercontent.com/pagopa/io-functions-cgn/v0.2.0/openapi/index.yaml#/definitions/CommonCard"
   CardPending:
-    $ref: "https://raw.githubusercontent.com/pagopa/io-functions-cgn/v0.1.4/openapi/index.yaml#/definitions/CardPending"
+    $ref: "https://raw.githubusercontent.com/pagopa/io-functions-cgn/v0.2.0/openapi/index.yaml#/definitions/CardPending"
   CardActivated:
-    $ref: "https://raw.githubusercontent.com/pagopa/io-functions-cgn/v0.1.4/openapi/index.yaml#/definitions/CardActivated"
+    $ref: "https://raw.githubusercontent.com/pagopa/io-functions-cgn/v0.2.0/openapi/index.yaml#/definitions/CardActivated"
   CardRevoked:
-    $ref: "https://raw.githubusercontent.com/pagopa/io-functions-cgn/v0.1.4/openapi/index.yaml#/definitions/CardRevoked"
+    $ref: "https://raw.githubusercontent.com/pagopa/io-functions-cgn/v0.2.0/openapi/index.yaml#/definitions/CardRevoked"
   CardExpired:
-    $ref: "https://raw.githubusercontent.com/pagopa/io-functions-cgn/v0.1.4/openapi/index.yaml#/definitions/CardExpired"
+    $ref: "https://raw.githubusercontent.com/pagopa/io-functions-cgn/v0.2.0/openapi/index.yaml#/definitions/CardExpired"
   Card:
-    $ref: "https://raw.githubusercontent.com/pagopa/io-functions-cgn/v0.1.4/openapi/index.yaml#/definitions/Card"
+    $ref: "https://raw.githubusercontent.com/pagopa/io-functions-cgn/v0.2.0/openapi/index.yaml#/definitions/Card"
   CgnActivationDetail:
-    $ref: "https://raw.githubusercontent.com/pagopa/io-functions-cgn/v0.1.4/openapi/index.yaml#/definitions/CgnActivationDetail"
+    $ref: "https://raw.githubusercontent.com/pagopa/io-functions-cgn/v0.2.0/openapi/index.yaml#/definitions/CgnActivationDetail"
   EycaActivationDetail:
-    $ref: "https://raw.githubusercontent.com/pagopa/io-functions-cgn/v0.1.4/openapi/index.yaml#/definitions/EycaActivationDetail"
+    $ref: "https://raw.githubusercontent.com/pagopa/io-functions-cgn/v0.2.0/openapi/index.yaml#/definitions/EycaActivationDetail"
   EycaCard:
-    $ref: "https://raw.githubusercontent.com/pagopa/io-functions-cgn/v0.1.4/openapi/index.yaml#/definitions/EycaCard"
+    $ref: "https://raw.githubusercontent.com/pagopa/io-functions-cgn/v0.2.0/openapi/index.yaml#/definitions/EycaCard"
   EycaCardActivated:
-    $ref: "https://raw.githubusercontent.com/pagopa/io-functions-cgn/v0.1.4/openapi/index.yaml#/definitions/EycaCardActivated"
+    $ref: "https://raw.githubusercontent.com/pagopa/io-functions-cgn/v0.2.0/openapi/index.yaml#/definitions/EycaCardActivated"
   EycaCardExpired:
-    $ref: "https://raw.githubusercontent.com/pagopa/io-functions-cgn/v0.1.4/openapi/index.yaml#/definitions/EycaCardExpired"
+    $ref: "https://raw.githubusercontent.com/pagopa/io-functions-cgn/v0.2.0/openapi/index.yaml#/definitions/EycaCardExpired"
   EycaCardRevoked:
-    $ref: "https://raw.githubusercontent.com/pagopa/io-functions-cgn/v0.1.4/openapi/index.yaml#/definitions/EycaCardRevoked"
+    $ref: "https://raw.githubusercontent.com/pagopa/io-functions-cgn/v0.2.0/openapi/index.yaml#/definitions/EycaCardRevoked"
   CcdbNumber:
-    $ref: "https://raw.githubusercontent.com/pagopa/io-functions-cgn/v0.1.4/openapi/index.yaml#/definitions/CcdbNumber"
+    $ref: "https://raw.githubusercontent.com/pagopa/io-functions-cgn/v0.2.0/openapi/index.yaml#/definitions/CcdbNumber"
   Otp:
-    $ref: "https://raw.githubusercontent.com/pagopa/io-functions-cgn/175761529_expose_otp_generation_api/openapi/index.yaml#/definitions/Otp"
+    $ref: "https://raw.githubusercontent.com/pagopa/io-functions-cgn/v0.2.0/openapi/index.yaml#/definitions/Otp"
   OtpCode:
-    $ref: "https://raw.githubusercontent.com/pagopa/io-functions-cgn/175761529_expose_otp_generation_api/openapi/index.yaml#/definitions/OtpCode"
+    $ref: "https://raw.githubusercontent.com/pagopa/io-functions-cgn/v0.2.0/openapi/index.yaml#/definitions/OtpCode"
 
 securityDefinitions:
   Bearer:

--- a/api_cgn.yaml
+++ b/api_cgn.yaml
@@ -164,6 +164,28 @@ paths:
           description: Service unavailable.
           schema:
             $ref: "#/definitions/ProblemJson"
+  
+  "/cgn/otp":
+    post:
+      operationId: generateOtp
+      summary: |
+        Generate a new Otp related to a CGN
+      description: |
+        Generate a new Otp used to discount an online purchase
+        through a valid CGN
+      responses:
+        "200":
+            description: Otp generated.
+            schema:
+              $ref: "#/definitions/Otp"
+        "401":
+          description: Bearer token null or expired.
+        "403":
+          description: Forbidden.
+        "500":
+          description: Service unavailable.
+          schema:
+            $ref: "#/definitions/ProblemJson"
 definitions:
   Timestamp:
     $ref: "https://raw.githubusercontent.com/pagopa/io-functions-commons/v17.3.0/openapi/definitions.yaml#/Timestamp"
@@ -199,7 +221,11 @@ definitions:
     $ref: "https://raw.githubusercontent.com/pagopa/io-functions-cgn/v0.1.4/openapi/index.yaml#/definitions/EycaCardRevoked"
   CcdbNumber:
     $ref: "https://raw.githubusercontent.com/pagopa/io-functions-cgn/v0.1.4/openapi/index.yaml#/definitions/CcdbNumber"
-  
+  Otp:
+    $ref: "https://raw.githubusercontent.com/pagopa/io-functions-cgn/175761529_expose_otp_generation_api/openapi/index.yaml#/definitions/Otp"
+  OtpCode:
+    $ref: "https://raw.githubusercontent.com/pagopa/io-functions-cgn/175761529_expose_otp_generation_api/openapi/index.yaml#/definitions/OtpCode"
+
 securityDefinitions:
   Bearer:
     type: apiKey

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "generate:proxy:bonus-models": "rimraf generated/bonus && gen-api-models --api-spec api_bonus.yaml --out-dir generated/bonus",
     "generate:proxy:cgn-models": "rimraf generated/cgn && gen-api-models --api-spec api_cgn.yaml --out-dir generated/cgn",
     "generate:api:io-bonus": "rimraf generated/io-bonus-api && gen-api-models --api-spec https://raw.githubusercontent.com/pagopa/io-functions-bonus/master/openapi/index.yaml --no-strict --out-dir generated/io-bonus-api --request-types --response-decoders --client",
-    "generate:api:io-cgn": "rimraf generated/io-cgn-api && gen-api-models --api-spec https://raw.githubusercontent.com/pagopa/io-functions-cgn/175761529_expose_otp_generation_api/openapi/index.yaml --no-strict --out-dir generated/io-cgn-api --request-types --response-decoders --client",
+    "generate:api:io-cgn": "rimraf generated/io-cgn-api && gen-api-models --api-spec https://raw.githubusercontent.com/pagopa/io-functions-cgn/v0.2.0/openapi/index.yaml --no-strict --out-dir generated/io-cgn-api --request-types --response-decoders --client",
     "generate:api:pagopaproxy": "rimraf generated/pagopa-proxy && gen-api-models --api-spec https://raw.githubusercontent.com/pagopa/io-pagopa-proxy/v0.8.6/api_pagopa.yaml --no-strict --out-dir generated/pagopa-proxy --request-types --response-decoders --client",
     "generate:test-certs": "./scripts/generate-test-certs.sh certs",
     "postversion": "git push && git push --tags",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "generate:proxy:bonus-models": "rimraf generated/bonus && gen-api-models --api-spec api_bonus.yaml --out-dir generated/bonus",
     "generate:proxy:cgn-models": "rimraf generated/cgn && gen-api-models --api-spec api_cgn.yaml --out-dir generated/cgn",
     "generate:api:io-bonus": "rimraf generated/io-bonus-api && gen-api-models --api-spec https://raw.githubusercontent.com/pagopa/io-functions-bonus/master/openapi/index.yaml --no-strict --out-dir generated/io-bonus-api --request-types --response-decoders --client",
-    "generate:api:io-cgn": "rimraf generated/io-cgn-api && gen-api-models --api-spec https://raw.githubusercontent.com/pagopa/io-functions-cgn/v0.1.4/openapi/index.yaml --no-strict --out-dir generated/io-cgn-api --request-types --response-decoders --client",
+    "generate:api:io-cgn": "rimraf generated/io-cgn-api && gen-api-models --api-spec https://raw.githubusercontent.com/pagopa/io-functions-cgn/175761529_expose_otp_generation_api/openapi/index.yaml --no-strict --out-dir generated/io-cgn-api --request-types --response-decoders --client",
     "generate:api:pagopaproxy": "rimraf generated/pagopa-proxy && gen-api-models --api-spec https://raw.githubusercontent.com/pagopa/io-pagopa-proxy/v0.8.6/api_pagopa.yaml --no-strict --out-dir generated/pagopa-proxy --request-types --response-decoders --client",
     "generate:test-certs": "./scripts/generate-test-certs.sh certs",
     "postversion": "git push && git push --tags",

--- a/src/app.ts
+++ b/src/app.ts
@@ -871,6 +871,12 @@ function registerCgnAPIRoutes(
     bearerSessionTokenAuth,
     toExpressHandler(cgnController.getEycaActivation, cgnController)
   );
+
+  app.post(
+    `${basePath}/cgn/otp`,
+    bearerSessionTokenAuth,
+    toExpressHandler(cgnController.generateOtp, cgnController)
+  );
 }
 
 function registerBonusAPIRoutes(

--- a/src/controllers/cgnController.ts
+++ b/src/controllers/cgnController.ts
@@ -17,6 +17,7 @@ import {
 
 import { EycaActivationDetail } from "generated/io-cgn-api/EycaActivationDetail";
 import { EycaCard } from "generated/io-cgn-api/EycaCard";
+import { Otp } from "generated/cgn/Otp";
 import { Card } from "../../generated/cgn/Card";
 import CgnService from "../../src/services/cgnService";
 import { InstanceId } from "../../generated/cgn/InstanceId";
@@ -107,4 +108,16 @@ export default class CgnController {
     | IResponseSuccessAccepted
   > =>
     withUserFromRequest(req, user => this.cgnService.startEycaActivation(user));
+
+  /**
+   * Generate a CGN OTP for the current user.
+   */
+  public readonly generateOtp = (
+    req: express.Request
+  ): Promise<
+    | IResponseErrorInternal
+    | IResponseErrorValidation
+    | IResponseErrorForbiddenNotAuthorized
+    | IResponseSuccessJson<Otp>
+  > => withUserFromRequest(req, user => this.cgnService.generateOtp(user));
 }

--- a/src/services/__tests__/cgnService.test.ts
+++ b/src/services/__tests__/cgnService.test.ts
@@ -794,8 +794,8 @@ describe("CgnService#generateOtp", () => {
 
   it("should handle a Forbidden error when the client returns 403", async () => {
     mockGenerateOtp.mockImplementationOnce(() =>
-    t.success({ status: 403 })
-  );
+      t.success({ status: 403 })
+    );
 
   const service = new CgnService(api);
 

--- a/src/services/__tests__/cgnService.test.ts
+++ b/src/services/__tests__/cgnService.test.ts
@@ -835,7 +835,7 @@ describe("CgnService#generateOtp", () => {
   });
 
   it("should return an error if the api call thows", async () => {
-      mockGenerateOtp.mockImplementationOnce(() => {
+    mockGenerateOtp.mockImplementationOnce(() => {
       throw new Error();
     });
     const service = new CgnService(api);

--- a/src/services/__tests__/cgnService.test.ts
+++ b/src/services/__tests__/cgnService.test.ts
@@ -7,6 +7,8 @@ import { User } from "../../types/user";
 import CgnService from "../cgnService";
 import { SpidLevelEnum } from "../../../generated/backend/SpidLevel";
 import { CardPending, StatusEnum } from "../../../generated/io-cgn-api/CardPending";
+import { Otp } from "../../../generated/cgn/Otp";
+import { OtpCode } from "../../../generated/cgn/OtpCode";
 
 const aValidFiscalCode = "XUZTCT88A51Y311X" as FiscalCode;
 const aValidSPIDEmail = "from_spid@example.com" as EmailAddress;
@@ -18,6 +20,7 @@ const mockStartCgnActivation = jest.fn();
 const mockGetCgnActivation = jest.fn();
 const mockStartEycaActivation = jest.fn();
 const mockGetEycaActivation = jest.fn();
+const mockGenerateOtp = jest.fn();
 
 mockGetCgnStatus.mockImplementation(() =>
   t.success({status: 200, value:aPendingCgn})
@@ -50,9 +53,14 @@ mockStartEycaActivation.mockImplementation(() =>
       id: "AnInstanceId"
     }
   }})
-)
+);
+
+mockGenerateOtp.mockImplementation(() =>
+t.success({status: 200, value:aGeneratedOtp})
+);
 
 const api = {
+  generateOtp: mockGenerateOtp,
   getCgnActivation: mockGetCgnActivation,
   getCgnStatus: mockGetCgnStatus,
   getEycaStatus: mockGetEycaStatus,
@@ -79,6 +87,12 @@ const aPendingCgn: CardPending = {
 }
 const aPendingEycaCard: CardPending = {
     status: StatusEnum.PENDING
+}
+
+const aGeneratedOtp: Otp = {
+  code: "AAAAAA12312" as OtpCode,
+  expires_at: new Date(),
+  ttl: 10
 }
 describe("CgnService#getCgnStatus", () => {
     beforeEach(() => {
@@ -731,6 +745,102 @@ describe("CgnService#startEycaActivation", () => {
     const service = new CgnService(api);
 
     const res = await service.startEycaActivation(mockedUser);
+
+    expect(res).toMatchObject({
+      kind: "IResponseErrorInternal"
+    });
+  });
+});
+
+describe("CgnService#generateOtp", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should make the correct api call", async () => {
+    const service = new CgnService(api);
+
+    await service.generateOtp(mockedUser);
+
+    expect(mockGenerateOtp).toHaveBeenCalledWith({
+      fiscalcode: mockedUser.fiscal_code
+    });
+  });
+
+  it("should handle a success response", async () => {
+
+    const service = new CgnService(api);
+
+    const res = await service.generateOtp(mockedUser);
+
+    expect(res).toMatchObject({
+      kind: "IResponseSuccessJson"
+    });
+  });
+
+  it("should handle an internal error when the client returns 401", async () => {
+    mockGenerateOtp.mockImplementationOnce(() =>
+      t.success({ status: 401 })
+    );
+
+    const service = new CgnService(api);
+
+    const res = await service.generateOtp(mockedUser);
+
+    expect(res).toMatchObject({
+      kind: "IResponseErrorInternal"
+    });
+  });
+
+  it("should handle a Forbidden error when the client returns 403", async () => {
+    mockGenerateOtp.mockImplementationOnce(() =>
+    t.success({ status: 403 })
+  );
+
+  const service = new CgnService(api);
+
+  const res = await service.generateOtp(mockedUser);
+
+  expect(res).toMatchObject({
+    kind: "IResponseErrorForbiddenNotAuthorized"
+  });
+});
+
+  it("should handle an internal error response", async () => {
+    const aGenericProblem = {};
+    mockGenerateOtp.mockImplementationOnce(() =>
+      t.success({ status: 500, value: aGenericProblem })
+    );
+
+    const service = new CgnService(api);
+
+    const res = await service.generateOtp(mockedUser);
+
+    expect(res).toMatchObject({
+      kind: "IResponseErrorInternal"
+    });
+  });
+
+  it("should return an error for unhandled response status code", async () => {
+      mockGenerateOtp.mockImplementationOnce(() =>
+      t.success({ status: 123 })
+    );
+    const service = new CgnService(api);
+
+    const res = await service.generateOtp(mockedUser);
+
+    expect(res).toMatchObject({
+      kind: "IResponseErrorInternal"
+    });
+  });
+
+  it("should return an error if the api call thows", async () => {
+      mockGenerateOtp.mockImplementationOnce(() => {
+      throw new Error();
+    });
+    const service = new CgnService(api);
+
+    const res = await service.generateOtp(mockedUser);
 
     expect(res).toMatchObject({
       kind: "IResponseErrorInternal"

--- a/src/services/__tests__/cgnService.test.ts
+++ b/src/services/__tests__/cgnService.test.ts
@@ -55,9 +55,9 @@ mockStartEycaActivation.mockImplementation(() =>
   }})
 );
 
-mockGenerateOtp.mockImplementation(() =>
-t.success({status: 200, value:aGeneratedOtp})
-);
+  mockGenerateOtp.mockImplementation(() =>
+    t.success({status: 200, value:aGeneratedOtp})
+  );
 
 const api = {
   generateOtp: mockGenerateOtp,

--- a/src/services/cgnService.ts
+++ b/src/services/cgnService.ts
@@ -21,13 +21,13 @@ import {
 } from "italia-ts-commons/lib/responses";
 
 import { fromNullable } from "fp-ts/lib/Option";
-import { EycaActivationDetail } from "generated/cgn/EycaActivationDetail";
-import { EycaCard } from "generated/cgn/EycaCard";
-import { InstanceId } from "../../generated/cgn/InstanceId";
-import { CgnActivationDetail } from "../../generated/cgn/CgnActivationDetail";
+import { EycaActivationDetail } from "../../generated/io-cgn-api/EycaActivationDetail";
+import { EycaCard } from "../../generated/io-cgn-api/EycaCard";
+import { InstanceId } from "../../generated/io-cgn-api/InstanceId";
+import { CgnActivationDetail } from "../../generated/io-cgn-api/CgnActivationDetail";
 import { CgnAPIClient } from "../../src/clients/cgn";
-import { Card } from "../../generated/cgn/Card";
-import { Otp } from "../../generated/cgn/Otp";
+import { Card } from "../../generated/io-cgn-api/Card";
+import { Otp } from "../../generated/io-cgn-api/Otp";
 import { User } from "../types/user";
 import {
   ResponseErrorStatusNotDefinedInSpec,


### PR DESCRIPTION
#### List of Changes
- Add `generateOtp` API Specs
- Add tests

#### Motivation and Context
Since a CGN could be used to obtain discounts over online's purchase, we must provide an API that could generate an OTP, to be used in the checkout phase through third-parties e-commerce portal. See this [story](https://www.pivotaltracker.com/story/show/175761529) for further informations.

#### How Has This Been Tested?
Unit tests

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.