### PR TITLE
Use SDK to connect with fns-cgn

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "generate:proxy:bonus-models": "rimraf generated/bonus && gen-api-models --api-spec api_bonus.yaml --out-dir generated/bonus",
     "generate:proxy:cgn-models": "rimraf generated/cgn && gen-api-models --api-spec api_cgn.yaml --out-dir generated/cgn",
     "generate:api:io-bonus": "rimraf generated/io-bonus-api && gen-api-models --api-spec https://raw.githubusercontent.com/pagopa/io-functions-bonus/master/openapi/index.yaml --no-strict --out-dir generated/io-bonus-api --request-types --response-decoders --client",
-    "generate:api:io-cgn": "rimraf generated/io-cgn-api && gen-api-models --api-spec https://raw.githubusercontent.com/pagopa/io-functions-cgn/v0.2.0/openapi/index.yaml --no-strict --out-dir generated/io-cgn-api --request-types --response-decoders --client",
     "generate:api:pagopaproxy": "rimraf generated/pagopa-proxy && gen-api-models --api-spec https://raw.githubusercontent.com/pagopa/io-pagopa-proxy/v0.8.6/api_pagopa.yaml --no-strict --out-dir generated/pagopa-proxy --request-types --response-decoders --client",
     "generate:test-certs": "./scripts/generate-test-certs.sh certs",
     "postversion": "git push && git push --tags",
@@ -62,6 +61,7 @@
   "homepage": "https://github.com/pagopa/io-backend#readme",
   "dependencies": {
     "@azure/storage-queue": "^12.0.0",
+    "@pagopa/io-functions-cgn-sdk": "*",
     "@pagopa/io-spid-commons": "^6.1.0",
     "apicache": "^1.4.0",
     "applicationinsights": "^1.7.4",

--- a/src/clients/cgn.ts
+++ b/src/clients/cgn.ts
@@ -1,5 +1,5 @@
 import nodeFetch from "node-fetch";
-import { Client, createClient } from "../../generated/io-cgn-api/client";
+import { Client, createClient } from "@pagopa/io-functions-cgn-sdk/client";
 
 export function CgnAPIClient(
   token: string,

--- a/src/controllers/__tests__/cgnController.test.ts
+++ b/src/controllers/__tests__/cgnController.test.ts
@@ -1,4 +1,7 @@
-import { ResponseSuccessAccepted, ResponseSuccessJson } from "italia-ts-commons/lib/responses";
+import {
+  ResponseSuccessAccepted,
+  ResponseSuccessJson
+} from "italia-ts-commons/lib/responses";
 import { NonEmptyString } from "italia-ts-commons/lib/strings";
 
 import { EmailAddress } from "../../../generated/backend/EmailAddress";
@@ -11,9 +14,15 @@ import { User } from "../../types/user";
 import CgnController from "../cgnController";
 import { CgnAPIClient } from "../../clients/cgn";
 import CgnService from "../../services/cgnService";
-import { CardPending, StatusEnum } from "../../../generated/io-cgn-api/CardPending";
-import { CgnActivationDetail, StatusEnum as ActivationStatusEnum } from "../../../generated/io-cgn-api/CgnActivationDetail";
-import { EycaActivationDetail } from "../../../generated/io-cgn-api/EycaActivationDetail";
+import {
+  CardPending,
+  StatusEnum
+} from "../@pagopa/io-functions-cgn-sdk/CardPending";
+import {
+  CgnActivationDetail,
+  StatusEnum as ActivationStatusEnum
+} from "../@pagopa/io-functions-cgn-sdk/CgnActivationDetail";
+import { EycaActivationDetail } from "../@pagopa/io-functions-cgn-sdk/EycaActivationDetail";
 import { Otp } from "../../../generated/cgn/Otp";
 import { OtpCode } from "../../../generated/cgn/OtpCode";
 
@@ -70,28 +79,28 @@ jest.mock("../../services/cgnService", () => {
 
 const aPendingCgn: CardPending = {
   status: StatusEnum.PENDING
-}
+};
 
 const aPendingEycaCard: CardPending = {
   status: StatusEnum.PENDING
-}
+};
 
 const aCgnActivationDetail: CgnActivationDetail = {
   instance_id: {
     id: "instanceId" as NonEmptyString
   },
   status: ActivationStatusEnum.COMPLETED
-}
+};
 
 const anEycaActivationDetail: EycaActivationDetail = {
   status: ActivationStatusEnum.COMPLETED
-}
+};
 
 const aGeneratedOtp: Otp = {
   code: "AAAAAA12312" as OtpCode,
   expires_at: new Date(),
   ttl: 10
-}
+};
 
 describe("CgnController#getCgnStatus", () => {
   beforeEach(() => {
@@ -119,7 +128,7 @@ describe("CgnController#getCgnStatus", () => {
     const client = CgnAPIClient(API_KEY, API_URL);
     const cgnService = new CgnService(client);
     const controller = new CgnController(cgnService);
-    
+
     const response = await controller.getCgnStatus(req);
 
     expect(response).toEqual({
@@ -136,7 +145,7 @@ describe("CgnController#getCgnStatus", () => {
     const client = CgnAPIClient(API_KEY, API_URL);
     const cgnService = new CgnService(client);
     const controller = new CgnController(cgnService);
-    
+
     const response = await controller.getCgnStatus(req);
 
     response.apply(res);
@@ -174,7 +183,7 @@ describe("CgnController#getEycaStatus", () => {
     const client = CgnAPIClient(API_KEY, API_URL);
     const cgnService = new CgnService(client);
     const controller = new CgnController(cgnService);
-    
+
     const response = await controller.getEycaStatus(req);
 
     expect(response).toEqual({
@@ -191,7 +200,7 @@ describe("CgnController#getEycaStatus", () => {
     const client = CgnAPIClient(API_KEY, API_URL);
     const cgnService = new CgnService(client);
     const controller = new CgnController(cgnService);
-    
+
     const response = await controller.getEycaStatus(req);
 
     response.apply(res);
@@ -230,7 +239,7 @@ describe("CgnController#startCgnActivation", () => {
     const client = CgnAPIClient(API_KEY, API_URL);
     const cgnService = new CgnService(client);
     const controller = new CgnController(cgnService);
-    
+
     const response = await controller.startCgnActivation(req);
 
     expect(response).toEqual({
@@ -247,7 +256,7 @@ describe("CgnController#startCgnActivation", () => {
     const client = CgnAPIClient(API_KEY, API_URL);
     const cgnService = new CgnService(client);
     const controller = new CgnController(cgnService);
-    
+
     const response = await controller.startCgnActivation(req);
 
     response.apply(res);
@@ -285,7 +294,7 @@ describe("CgnController#getCgnActivation", () => {
     const client = CgnAPIClient(API_KEY, API_URL);
     const cgnService = new CgnService(client);
     const controller = new CgnController(cgnService);
-    
+
     const response = await controller.getCgnActivation(req);
 
     expect(response).toEqual({
@@ -302,7 +311,7 @@ describe("CgnController#getCgnActivation", () => {
     const client = CgnAPIClient(API_KEY, API_URL);
     const cgnService = new CgnService(client);
     const controller = new CgnController(cgnService);
-    
+
     const response = await controller.getCgnActivation(req);
 
     response.apply(res);
@@ -340,7 +349,7 @@ describe("CgnController#getEycaActivation", () => {
     const client = CgnAPIClient(API_KEY, API_URL);
     const cgnService = new CgnService(client);
     const controller = new CgnController(cgnService);
-    
+
     const response = await controller.getEycaActivation(req);
 
     expect(response).toEqual({
@@ -357,7 +366,7 @@ describe("CgnController#getEycaActivation", () => {
     const client = CgnAPIClient(API_KEY, API_URL);
     const cgnService = new CgnService(client);
     const controller = new CgnController(cgnService);
-    
+
     const response = await controller.getEycaActivation(req);
 
     response.apply(res);
@@ -395,7 +404,7 @@ describe("CgnController#startEycaActivation", () => {
     const client = CgnAPIClient(API_KEY, API_URL);
     const cgnService = new CgnService(client);
     const controller = new CgnController(cgnService);
-    
+
     const response = await controller.startEycaActivation(req);
 
     expect(response).toEqual({
@@ -412,7 +421,7 @@ describe("CgnController#startEycaActivation", () => {
     const client = CgnAPIClient(API_KEY, API_URL);
     const cgnService = new CgnService(client);
     const controller = new CgnController(cgnService);
-    
+
     const response = await controller.startEycaActivation(req);
 
     response.apply(res);
@@ -450,7 +459,7 @@ describe("CgnController#generateOtp", () => {
     const client = CgnAPIClient(API_KEY, API_URL);
     const cgnService = new CgnService(client);
     const controller = new CgnController(cgnService);
-    
+
     const response = await controller.generateOtp(req);
 
     expect(response).toEqual({
@@ -467,7 +476,7 @@ describe("CgnController#generateOtp", () => {
     const client = CgnAPIClient(API_KEY, API_URL);
     const cgnService = new CgnService(client);
     const controller = new CgnController(cgnService);
-    
+
     const response = await controller.generateOtp(req);
 
     response.apply(res);

--- a/src/controllers/cgnController.ts
+++ b/src/controllers/cgnController.ts
@@ -15,14 +15,14 @@ import {
   IResponseSuccessRedirectToResource
 } from "italia-ts-commons/lib/responses";
 
-import { EycaActivationDetail } from "generated/io-cgn-api/EycaActivationDetail";
-import { EycaCard } from "generated/io-cgn-api/EycaCard";
+import { EycaActivationDetail } from "@pagopa/io-functions-cgn-sdk/EycaActivationDetail";
+import { EycaCard } from "@pagopa/io-functions-cgn-sdk/EycaCard";
 import { Otp } from "generated/cgn/Otp";
+import { CgnActivationDetail } from "@pagopa/io-functions-cgn-sdk/CgnActivationDetail";
 import { Card } from "../../generated/cgn/Card";
 import CgnService from "../../src/services/cgnService";
 import { InstanceId } from "../../generated/cgn/InstanceId";
 import { withUserFromRequest } from "../types/user";
-import { CgnActivationDetail } from "../../generated/io-cgn-api/CgnActivationDetail";
 
 export default class CgnController {
   constructor(private readonly cgnService: CgnService) {}

--- a/src/services/cgnService.ts
+++ b/src/services/cgnService.ts
@@ -21,13 +21,13 @@ import {
 } from "italia-ts-commons/lib/responses";
 
 import { fromNullable } from "fp-ts/lib/Option";
-import { EycaActivationDetail } from "../../generated/io-cgn-api/EycaActivationDetail";
-import { EycaCard } from "../../generated/io-cgn-api/EycaCard";
-import { InstanceId } from "../../generated/io-cgn-api/InstanceId";
-import { CgnActivationDetail } from "../../generated/io-cgn-api/CgnActivationDetail";
+import { EycaActivationDetail } from "@pagopa/io-functions-cgn-sdk/EycaActivationDetail";
+import { EycaCard } from "@pagopa/io-functions-cgn-sdk/EycaCard";
+import { InstanceId } from "@pagopa/io-functions-cgn-sdk/InstanceId";
+import { CgnActivationDetail } from "@pagopa/io-functions-cgn-sdk/CgnActivationDetail";
+import { Card } from "@pagopa/io-functions-cgn-sdk/Card";
+import { Otp } from "@pagopa/io-functions-cgn-sdk/Otp";
 import { CgnAPIClient } from "../../src/clients/cgn";
-import { Card } from "../../generated/io-cgn-api/Card";
-import { Otp } from "../../generated/io-cgn-api/Otp";
 import { User } from "../types/user";
 import {
   ResponseErrorStatusNotDefinedInSpec,

--- a/yarn.lock
+++ b/yarn.lock
@@ -301,6 +301,15 @@
     eslint-plugin-sonarjs "^0.5.0"
     prettier "^2.1.2"
 
+"@pagopa/io-functions-cgn-sdk@*":
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/@pagopa/io-functions-cgn-sdk/-/io-functions-cgn-sdk-0.1.4.tgz#da10af9fb65da4fc31a1568c61cd0b17d74bfa5d"
+  integrity sha512-QMWGMGe00V0x5tXZ3/VuAeGAq2zkQXNz9q5J1tccdu4uMhkAi6WEDx6/B3K14Uqpk0bkdNktHHA90jGekLhEtg==
+  dependencies:
+    fp-ts "1.17.4"
+    io-ts "1.8.5"
+    italia-ts-commons "^5.1.13"
+
 "@pagopa/io-spid-commons@^6.1.0":
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/@pagopa/io-spid-commons/-/io-spid-commons-6.1.0.tgz#faebd392062a9cbbe6194c4cadebe122dd893dee"
@@ -4157,7 +4166,7 @@ istanbul-reports@^1.5.1:
   dependencies:
     handlebars "^4.0.3"
 
-italia-ts-commons@^5.1.4:
+italia-ts-commons@^5.1.13, italia-ts-commons@^5.1.4:
   version "5.1.13"
   resolved "https://registry.yarnpkg.com/italia-ts-commons/-/italia-ts-commons-5.1.13.tgz#7ae919374f9c03c04e38603b7f7e9681ebee79b7"
   integrity sha512-mXtrNG/HR6lRCOTtBrEzsxGmkHccoDXKqoc9i+J2+yGhhxcznASu+0KMC05ZR1yJP4bWliC9rXJ3hnCw0rMSnQ==


### PR DESCRIPTION
A little refactor that uses models, interfaces and http client from package `@pagopa/io-functions-cgn-sdk` in order to connect with CGN API service.

This replaces the need to reference CGN API specification from CGN's own repository, and to generate code on pre-build.