### PR TITLE
177119268 switch to cgn client sdk

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ npm-debug.log
 *.js
 !.eslintrc.js
 !.release-it.js
+!jest.config.js
 *.js.map
 
 # Excluded auto-generated API client.

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  preset: "ts-jest",
+  testEnvironment: "node",
+  testPathIgnorePatterns: ["dist", "/node_modules"]
+};

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "watch": "tsc -w",
     "prebuild": "yarn generate:proxy-models",
     "build": "tsc",
+    "clean": "tsc --build --clean",
     "build-noemit": "tsc --noEmit",
     "hot-reload": "nodemon --legacy-watch --watch ./src --inspect=0.0.0.0:5859 --nolazy src/server.js",
     "lint": "eslint . -c .eslintrc.js --ext .ts,.tsx --cache",
@@ -40,7 +41,6 @@
     "generate:proxy:bonus-models": "rimraf generated/bonus && gen-api-models --api-spec api_bonus.yaml --out-dir generated/bonus",
     "generate:proxy:cgn-models": "rimraf generated/cgn && gen-api-models --api-spec api_cgn.yaml --out-dir generated/cgn",
     "generate:api:io-bonus": "rimraf generated/io-bonus-api && gen-api-models --api-spec https://raw.githubusercontent.com/pagopa/io-functions-bonus/master/openapi/index.yaml --no-strict --out-dir generated/io-bonus-api --request-types --response-decoders --client",
-    "generate:api:io-cgn": "rimraf generated/io-cgn-api && gen-api-models --api-spec https://raw.githubusercontent.com/pagopa/io-functions-cgn/master/openapi/index.yaml --no-strict --out-dir generated/io-cgn-api --request-types --response-decoders --client",
     "generate:api:pagopaproxy": "rimraf generated/pagopa-proxy && gen-api-models --api-spec https://raw.githubusercontent.com/pagopa/io-pagopa-proxy/v0.8.6/api_pagopa.yaml --no-strict --out-dir generated/pagopa-proxy --request-types --response-decoders --client",
     "generate:test-certs": "./scripts/generate-test-certs.sh certs",
     "postversion": "git push && git push --tags",
@@ -62,6 +62,7 @@
   "homepage": "https://github.com/pagopa/io-backend#readme",
   "dependencies": {
     "@azure/storage-queue": "^12.0.0",
+    "@pagopa/io-functions-cgn-sdk": "^0.1.3",
     "@pagopa/io-spid-commons": "^6.1.0",
     "apicache": "^1.4.0",
     "applicationinsights": "^1.7.4",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
   "homepage": "https://github.com/pagopa/io-backend#readme",
   "dependencies": {
     "@azure/storage-queue": "^12.0.0",
-    "@pagopa/io-functions-cgn-sdk": "^0.1.3",
+    "@pagopa/io-functions-cgn-sdk": "^0.1.4",
     "@pagopa/io-spid-commons": "^6.1.0",
     "apicache": "^1.4.0",
     "applicationinsights": "^1.7.4",

--- a/src/clients/cgn.ts
+++ b/src/clients/cgn.ts
@@ -1,5 +1,5 @@
 import nodeFetch from "node-fetch";
-import { Client, createClient } from "../../generated/io-cgn-api/client";
+import { Client, createClient } from "@pagopa/io-functions-cgn-sdk/client";
 
 export function CgnAPIClient(
   token: string,

--- a/src/controllers/__tests__/cgnController.test.ts
+++ b/src/controllers/__tests__/cgnController.test.ts
@@ -11,9 +11,9 @@ import { User } from "../../types/user";
 import CgnController from "../cgnController";
 import { CgnAPIClient } from "../../clients/cgn";
 import CgnService from "../../services/cgnService";
-import { CardPending, StatusEnum } from "../../../generated/io-cgn-api/CardPending";
-import { CgnActivationDetail, StatusEnum as ActivationStatusEnum } from "../../../generated/io-cgn-api/CgnActivationDetail";
-import { EycaActivationDetail } from "../../../generated/io-cgn-api/EycaActivationDetail";
+import { CardPending, StatusEnum } from "@pagopa/io-functions-cgn-sdk/CardPending";
+import { CgnActivationDetail, StatusEnum as ActivationStatusEnum } from "@pagopa/io-functions-cgn-sdk/CgnActivationDetail";
+import { EycaActivationDetail } from "@pagopa/io-functions-cgn-sdk/EycaActivationDetail";
 
 const API_KEY = "";
 const API_URL = "";

--- a/src/controllers/__tests__/cgnController.test.ts
+++ b/src/controllers/__tests__/cgnController.test.ts
@@ -14,6 +14,8 @@ import CgnService from "../../services/cgnService";
 import { CardPending, StatusEnum } from "@pagopa/io-functions-cgn-sdk/CardPending";
 import { CgnActivationDetail, StatusEnum as ActivationStatusEnum } from "@pagopa/io-functions-cgn-sdk/CgnActivationDetail";
 import { EycaActivationDetail } from "@pagopa/io-functions-cgn-sdk/EycaActivationDetail";
+import { OtpCode } from "@pagopa/io-functions-cgn-sdk/OtpCode";
+import { Otp } from "@pagopa/io-functions-cgn-sdk/Otp";
 
 const API_KEY = "";
 const API_URL = "";

--- a/src/controllers/cgnController.ts
+++ b/src/controllers/cgnController.ts
@@ -18,6 +18,7 @@ import {
 import { EycaCard } from "@pagopa/io-functions-cgn-sdk/EycaCard";
 import { EycaActivationDetail } from "@pagopa/io-functions-cgn-sdk/EycaActivationDetail";
 import { CgnActivationDetail } from "@pagopa/io-functions-cgn-sdk/CgnActivationDetail";
+import { Otp } from "@pagopa/io-functions-cgn-sdk/Otp";
 import { Card } from "../../generated/cgn/Card";
 import CgnService from "../../src/services/cgnService";
 import { InstanceId } from "../../generated/cgn/InstanceId";

--- a/src/controllers/cgnController.ts
+++ b/src/controllers/cgnController.ts
@@ -15,13 +15,13 @@ import {
   IResponseSuccessRedirectToResource
 } from "italia-ts-commons/lib/responses";
 
-import { EycaActivationDetail } from "generated/io-cgn-api/EycaActivationDetail";
-import { EycaCard } from "generated/io-cgn-api/EycaCard";
+import { EycaCard } from "@pagopa/io-functions-cgn-sdk/EycaCard";
+import { EycaActivationDetail } from "@pagopa/io-functions-cgn-sdk/EycaActivationDetail";
+import { CgnActivationDetail } from "@pagopa/io-functions-cgn-sdk/CgnActivationDetail";
 import { Card } from "../../generated/cgn/Card";
 import CgnService from "../../src/services/cgnService";
 import { InstanceId } from "../../generated/cgn/InstanceId";
 import { withUserFromRequest } from "../types/user";
-import { CgnActivationDetail } from "../../generated/io-cgn-api/CgnActivationDetail";
 
 export default class CgnController {
   constructor(private readonly cgnService: CgnService) {}

--- a/src/services/__tests__/cgnService.test.ts
+++ b/src/services/__tests__/cgnService.test.ts
@@ -6,7 +6,7 @@ import { SessionToken, WalletToken } from "../../types/token";
 import { User } from "../../types/user";
 import CgnService from "../cgnService";
 import { SpidLevelEnum } from "../../../generated/backend/SpidLevel";
-import { CardPending, StatusEnum } from "../../../generated/io-cgn-api/CardPending";
+import { CardPending, StatusEnum } from "@pagopa/io-functions-cgn-sdk/CardPending";
 
 const aValidFiscalCode = "XUZTCT88A51Y311X" as FiscalCode;
 const aValidSPIDEmail = "from_spid@example.com" as EmailAddress;

--- a/src/services/__tests__/cgnService.test.ts
+++ b/src/services/__tests__/cgnService.test.ts
@@ -6,13 +6,9 @@ import { SessionToken, WalletToken } from "../../types/token";
 import { User } from "../../types/user";
 import CgnService from "../cgnService";
 import { SpidLevelEnum } from "../../../generated/backend/SpidLevel";
-<<<<<<< HEAD
 import { CardPending, StatusEnum } from "@pagopa/io-functions-cgn-sdk/CardPending";
-=======
-import { CardPending, StatusEnum } from "../../../generated/io-cgn-api/CardPending";
-import { Otp } from "../../../generated/cgn/Otp";
-import { OtpCode } from "../../../generated/cgn/OtpCode";
->>>>>>> origin/master
+import { Otp } from "@pagopa/io-functions-cgn-sdk/Otp";
+import { OtpCode } from "@pagopa/io-functions-cgn-sdk/OtpCode";
 
 const aValidFiscalCode = "XUZTCT88A51Y311X" as FiscalCode;
 const aValidSPIDEmail = "from_spid@example.com" as EmailAddress;

--- a/src/services/cgnService.ts
+++ b/src/services/cgnService.ts
@@ -26,6 +26,7 @@ import { EycaActivationDetail } from "@pagopa/io-functions-cgn-sdk/EycaActivatio
 import { InstanceId } from "@pagopa/io-functions-cgn-sdk/InstanceId";
 import { CgnActivationDetail } from "@pagopa/io-functions-cgn-sdk/CgnActivationDetail";
 import { Card } from "@pagopa/io-functions-cgn-sdk/Card";
+import { Otp } from "@pagopa/io-functions-cgn-sdk/Otp";
 import { CgnAPIClient } from "../../src/clients/cgn";
 import { User } from "../types/user";
 import {

--- a/src/services/cgnService.ts
+++ b/src/services/cgnService.ts
@@ -21,12 +21,12 @@ import {
 } from "italia-ts-commons/lib/responses";
 
 import { fromNullable } from "fp-ts/lib/Option";
-import { EycaActivationDetail } from "generated/io-cgn-api/EycaActivationDetail";
-import { EycaCard } from "generated/io-cgn-api/EycaCard";
-import { InstanceId } from "../../generated/io-cgn-api/InstanceId";
-import { CgnActivationDetail } from "../../generated/io-cgn-api/CgnActivationDetail";
+import { EycaCard } from "@pagopa/io-functions-cgn-sdk/EycaCard";
+import { EycaActivationDetail } from "@pagopa/io-functions-cgn-sdk/EycaActivationDetail";
+import { InstanceId } from "@pagopa/io-functions-cgn-sdk/InstanceId";
+import { CgnActivationDetail } from "@pagopa/io-functions-cgn-sdk/CgnActivationDetail";
+import { Card } from "@pagopa/io-functions-cgn-sdk/Card";
 import { CgnAPIClient } from "../../src/clients/cgn";
-import { Card } from "../../generated/io-cgn-api/Card";
 import { User } from "../types/user";
 import {
   ResponseErrorStatusNotDefinedInSpec,

--- a/yarn.lock
+++ b/yarn.lock
@@ -301,6 +301,15 @@
     eslint-plugin-sonarjs "^0.5.0"
     prettier "^2.1.2"
 
+"@pagopa/io-functions-cgn-sdk@^0.1.3":
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/@pagopa/io-functions-cgn-sdk/-/io-functions-cgn-sdk-0.1.3.tgz#c6234be7d25b5b651ad807e4d7165cf6a1af45db"
+  integrity sha512-rw9gvL4A3LCulhfv13dK/eh4cY5UhT04gR5IsI6+G+DjvQZRxIw55sNvUVobKpGuW+PcGSbA89sWxsteuC1ekw==
+  dependencies:
+    fp-ts "1.17.4"
+    io-ts "1.8.5"
+    italia-ts-commons "^5.1.13"
+
 "@pagopa/io-spid-commons@^6.1.0":
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/@pagopa/io-spid-commons/-/io-spid-commons-6.1.0.tgz#faebd392062a9cbbe6194c4cadebe122dd893dee"
@@ -4157,7 +4166,7 @@ istanbul-reports@^1.5.1:
   dependencies:
     handlebars "^4.0.3"
 
-italia-ts-commons@^5.1.4:
+italia-ts-commons@^5.1.13, italia-ts-commons@^5.1.4:
   version "5.1.13"
   resolved "https://registry.yarnpkg.com/italia-ts-commons/-/italia-ts-commons-5.1.13.tgz#7ae919374f9c03c04e38603b7f7e9681ebee79b7"
   integrity sha512-mXtrNG/HR6lRCOTtBrEzsxGmkHccoDXKqoc9i+J2+yGhhxcznASu+0KMC05ZR1yJP4bWliC9rXJ3hnCw0rMSnQ==
@@ -4640,9 +4649,9 @@ json-schema@0.2.3:
   integrity sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=
 
 json-set-map@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/json-set-map/-/json-set-map-1.0.2.tgz#608aacb5464d9759158d06523a6e30be5650adc4"
-  integrity sha1-YIqstUZNl1kVjQZSOm4wvlZQrcQ=
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/json-set-map/-/json-set-map-1.1.2.tgz#536cbc6549d06e8af11f76cb4fbd441ed2389e6e"
+  integrity sha512-x0TGwgcOG21jOa8wV1PWXDpSXUAKa1WuhMSHPBQhXU5Pb+4DdMrxOw5HMAWztVLP8KhSG5Kl5BoAOVF0aW63wA==
 
 json-stable-stringify-without-jsonify@^1.0.1:
   version "1.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -301,10 +301,10 @@
     eslint-plugin-sonarjs "^0.5.0"
     prettier "^2.1.2"
 
-"@pagopa/io-functions-cgn-sdk@^0.1.3":
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/@pagopa/io-functions-cgn-sdk/-/io-functions-cgn-sdk-0.1.3.tgz#c6234be7d25b5b651ad807e4d7165cf6a1af45db"
-  integrity sha512-rw9gvL4A3LCulhfv13dK/eh4cY5UhT04gR5IsI6+G+DjvQZRxIw55sNvUVobKpGuW+PcGSbA89sWxsteuC1ekw==
+"@pagopa/io-functions-cgn-sdk@^0.1.4":
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/@pagopa/io-functions-cgn-sdk/-/io-functions-cgn-sdk-0.1.4.tgz#da10af9fb65da4fc31a1568c61cd0b17d74bfa5d"
+  integrity sha512-QMWGMGe00V0x5tXZ3/VuAeGAq2zkQXNz9q5J1tccdu4uMhkAi6WEDx6/B3K14Uqpk0bkdNktHHA90jGekLhEtg==
   dependencies:
     fp-ts "1.17.4"
     io-ts "1.8.5"


### PR DESCRIPTION
A little refactor that uses models, interfaces and http client from package @pagopa/io-functions-cgn-sdk in order to connect with CGN API service.

This replaces the need to reference CGN API specification from CGN's own repository, and to generate code on pre-build.