### PR TITLE
Update pipelines templates to v15

### DIFF
--- a/.devops/code-review-pipelines.yml
+++ b/.devops/code-review-pipelines.yml
@@ -6,9 +6,6 @@
 # - DANGER_GITHUB_API_TOKEN
 # 
 
-variables:
-  NODE_VERSION: '10.14.2'
-  YARN_CACHE_FOLDER: $(Pipeline.Workspace)/.yarn
 
 # Automatically triggered on PR
 # https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema?view=azure-devops&tabs=schema%2Cparameter-schema#pr-trigger
@@ -24,7 +21,7 @@ resources:
     - repository: pagopaCommons
       type: github
       name: pagopa/azure-pipeline-templates
-      ref: refs/tags/v8
+      ref: refs/tags/v15
       endpoint: 'pagopa'
 
 stages:

--- a/.devops/deploy-pipelines.yml
+++ b/.devops/deploy-pipelines.yml
@@ -88,7 +88,7 @@ resources:
     - repository: pagopaCommons
       type: github
       name: pagopa/azure-pipeline-templates
-      ref: refs/tags/v11
+      ref: refs/tags/v15
       endpoint: 'pagopa'
 
 stages:


### PR DESCRIPTION
We need to use `azure-pipelines-template` with a version of 15 or higher, in order to use the fix adopted into https://github.com/pagopa/azure-pipeline-templates/pull/83 and make healtcheck steps to work again