### PR TITLE
Bump app min version

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "@pagopa/io-backend",
   "version": "7.17.1",
   "min_app_version": {
-    "ios": "0.0.0",
-    "android": "0.0.0"
+    "ios": "1.27.0",
+    "android": "1.27.0"
   },
   "min_app_version_pagopa": {
     "ios": "0.0.0",


### PR DESCRIPTION
Set `1.27.0` as minimum app version. This information is consumed by APP IO to force users to update in case they have a lower version