### PR TITLE
[#IC-182] Remove errorMessage from CIE redirect error url params

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -49,6 +49,8 @@ JWT_SUPPORT_TOKEN_PRIVATE_RSA_KEY="-----BEGIN RSA PRIVATE KEY-----\n
 JWT_SUPPORT_TOKEN_ISSUER=io-backend
 SPID_LEVEL_WHITELIST=SpidL2,SpidL3
 
+FF_USER_AGE_LIMIT_ENABLED=1
+
 # ------------------------------------
 # CGN Env Variables
 # ------------------------------------
@@ -80,7 +82,7 @@ JWT_MIT_VOUCHER_TOKEN_EXPIRATION=1200
 JWT_MIT_VOUCHER_TOKEN_AUDIENCE=69b3d5a9c935fac3d60c
 
 # ------------------------------------
-# Zendesk support env Variables
+# Zendesk support env Variables
 # ------------------------------------
 ZENDESK_BASE_PATH="/api/backend/zendesk/v1"
 ALLOW_ZENDESK_IP_SOURCE_RANGE="::ffff:ac13:1/112"

--- a/src/controllers/__tests__/authenticationController.test.ts
+++ b/src/controllers/__tests__/authenticationController.test.ts
@@ -45,8 +45,7 @@ import UsersLoginLogService from "../../services/usersLoginLogService";
 import { exactUserIdentityDecode, SpidUser } from "../../types/user";
 import AuthenticationController, {
   AGE_LIMIT,
-  AGE_LIMIT_ERROR_CODE,
-  AGE_LIMIT_ERROR_MESSAGE
+  AGE_LIMIT_ERROR_CODE
 } from "../authenticationController";
 import { addDays, addMonths, format, subYears } from "date-fns";
 import { getClientErrorRedirectionUrl } from "../../config";
@@ -452,7 +451,7 @@ describe("AuthenticationController#acs", () => {
     expect(mockSet).not.toBeCalled();
     expect(res.redirect).toHaveBeenCalledWith(
       301,
-      `/error.html?errorMessage=${AGE_LIMIT_ERROR_MESSAGE}&errorCode=${AGE_LIMIT_ERROR_CODE}`
+      `/error.html?errorCode=${AGE_LIMIT_ERROR_CODE}`
     );
   });
 
@@ -483,7 +482,7 @@ describe("AuthenticationController#acs", () => {
     expect(mockSet).not.toBeCalled();
     expect(res.redirect).toHaveBeenCalledWith(
       301,
-      `/error.html?errorMessage=${AGE_LIMIT_ERROR_MESSAGE}&errorCode=${AGE_LIMIT_ERROR_CODE}`
+      `/error.html?errorCode=${AGE_LIMIT_ERROR_CODE}`
     );
   });
 

--- a/src/controllers/authenticationController.ts
+++ b/src/controllers/authenticationController.ts
@@ -127,6 +127,8 @@ export default class AuthenticationController {
     ) {
       // The IO App show the proper error screen if only the `errorCode`
       // query param is provided and `errorMessage` is missing.
+      // this constraint could be ignored when this PR https://github.com/pagopa/io-app/pull/3642 is merged,
+      // released in a certain app version and that version become the minimum version supported.
       const redirectionUrl = this.getClientErrorRedirectionUrl({
         errorCode: AGE_LIMIT_ERROR_CODE
       });

--- a/src/controllers/authenticationController.ts
+++ b/src/controllers/authenticationController.ts
@@ -38,7 +38,10 @@ import { isOlderThan } from "../utils/date";
 import { SuccessResponse } from "../../generated/auth/SuccessResponse";
 import { UserIdentity } from "../../generated/auth/UserIdentity";
 import { AccessToken } from "../../generated/public/AccessToken";
-import { clientProfileRedirectionUrl } from "../config";
+import {
+  ClientErrorRedirectionUrlParams,
+  clientProfileRedirectionUrl
+} from "../config";
 import { ISessionStorage } from "../services/ISessionStorage";
 import NotificationService from "../services/notificationService";
 import ProfileService from "../services/profileService";
@@ -80,8 +83,7 @@ export default class AuthenticationController {
       token: string
     ) => UrlFromString,
     private readonly getClientErrorRedirectionUrl: (
-      errorMessage: string,
-      errorCode?: number
+      params: ClientErrorRedirectionUrlParams
     ) => UrlFromString,
     private readonly profileService: ProfileService,
     private readonly notificationService: NotificationService,
@@ -123,10 +125,11 @@ export default class AuthenticationController {
       this.hasUserAgeLimitEnabled &&
       !isOlderThan(AGE_LIMIT)(parse(spidUser.dateOfBirth), new Date())
     ) {
-      const redirectionUrl = this.getClientErrorRedirectionUrl(
-        AGE_LIMIT_ERROR_MESSAGE,
-        AGE_LIMIT_ERROR_CODE
-      );
+      // The IO App show the proper error screen if only the `errorCode`
+      // query param is provided and `errorMessage` is missing.
+      const redirectionUrl = this.getClientErrorRedirectionUrl({
+        errorCode: AGE_LIMIT_ERROR_CODE
+      });
       log.error(
         `acs: the age of the user is less than ${AGE_LIMIT} yo [%s]`,
         spidUser.dateOfBirth


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->
The `ClientErrorRedirectionUrl` for minors of 14 yo returns only the query param `errorCode`. `errorMessage` was removed. The newer app versions will handle all the query params sent with the redirect url pagopa/io-app#3642

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The actual version of the IO App cannot handle properly the error when `errorMessage` prop is defined with `errorCode`.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Unit test

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
