### PR TITLE
[IA-755] Upgrade `min_app_version` to 1.38.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "@pagopa/io-backend",
   "version": "7.37.0",
   "min_app_version": {
-    "ios": "1.32.0",
-    "android": "1.32.0"
+    "ios": "1.38.0",
+    "android": "1.38.0"
   },
   "min_app_version_pagopa": {
     "ios": "0.0.0",


### PR DESCRIPTION
This PR upgrades `min_app_version` to 1.38.0
[more info](https://pagopa.atlassian.net/wiki/spaces/IOAPP/pages/462258341/Versione+minima+app+OS#Update-24-Marzo-2022-1.38.0.12)