### PR TITLE
[IC-395] add 403 response to upsert message status

### DIFF
--- a/api_backend.yaml
+++ b/api_backend.yaml
@@ -298,6 +298,8 @@ paths:
             $ref: "#/definitions/ProblemJson"
         "401":
           description: Bearer token null or expired.
+        "403":
+          description: Operation forbidden.
         "404":
           description: No message found for the provided ID.
           schema:

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "generate:proxy:bpd-models": "rimraf generated/bpd && gen-api-models --api-spec api_bpd.yaml --out-dir generated/bpd",
     "generate:proxy:public-models": "rimraf generated/public  && gen-api-models --api-spec api_public.yaml --out-dir generated/public",
     "generate:api:io": "rimraf generated/io-api && gen-api-models --api-spec https://raw.githubusercontent.com/pagopa/io-functions-app/v4.0.1/openapi/index.yaml --no-strict --out-dir generated/io-api --request-types --response-decoders --client",
-    "generate:api:io-messages": "rimraf generated/io-messages-api && gen-api-models --api-spec https://raw.githubusercontent.com/pagopa/io-functions-app-messages/v3.14.0/openapi/index.yaml --no-strict --out-dir generated/io-messages-api --request-types --response-decoders --client",
+    "generate:api:io-messages": "rimraf generated/io-messages-api && gen-api-models --api-spec https://raw.githubusercontent.com/pagopa/io-functions-app-messages/IC-395--add-403-as-return-status-in-upsert/openapi/index.yaml --no-strict --out-dir generated/io-messages-api --request-types --response-decoders --client",
     "generate:proxy:bonus-models": "rimraf generated/bonus && gen-api-models --api-spec api_bonus.yaml --out-dir generated/bonus",
     "generate:proxy:cgn-models": "rimraf generated/cgn && gen-api-models --api-spec api_cgn.yaml --out-dir generated/cgn",
     "generate:proxy:cgn-operator-search-models": "rimraf generated/cgn-operator-search && gen-api-models --api-spec api_cgn_operator_search.yaml --out-dir generated/cgn-operator-search",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "generate:proxy:bpd-models": "rimraf generated/bpd && gen-api-models --api-spec api_bpd.yaml --out-dir generated/bpd",
     "generate:proxy:public-models": "rimraf generated/public  && gen-api-models --api-spec api_public.yaml --out-dir generated/public",
     "generate:api:io": "rimraf generated/io-api && gen-api-models --api-spec https://raw.githubusercontent.com/pagopa/io-functions-app/v4.0.1/openapi/index.yaml --no-strict --out-dir generated/io-api --request-types --response-decoders --client",
-    "generate:api:io-messages": "rimraf generated/io-messages-api && gen-api-models --api-spec https://raw.githubusercontent.com/pagopa/io-functions-app-messages/IC-395--add-403-as-return-status-in-upsert/openapi/index.yaml --no-strict --out-dir generated/io-messages-api --request-types --response-decoders --client",
+    "generate:api:io-messages": "rimraf generated/io-messages-api && gen-api-models --api-spec https://raw.githubusercontent.com/pagopa/io-functions-app-messages/v3.15.0/openapi/index.yaml --no-strict --out-dir generated/io-messages-api --request-types --response-decoders --client",
     "generate:proxy:bonus-models": "rimraf generated/bonus && gen-api-models --api-spec api_bonus.yaml --out-dir generated/bonus",
     "generate:proxy:cgn-models": "rimraf generated/cgn && gen-api-models --api-spec api_cgn.yaml --out-dir generated/cgn",
     "generate:proxy:cgn-operator-search-models": "rimraf generated/cgn-operator-search && gen-api-models --api-spec api_cgn_operator_search.yaml --out-dir generated/cgn-operator-search",

--- a/src/controllers/messagesController.ts
+++ b/src/controllers/messagesController.ts
@@ -15,7 +15,10 @@ import {
 import { CreatedMessageWithContentAndAttachments } from "generated/backend/CreatedMessageWithContentAndAttachments";
 import { tryCatch } from "fp-ts/lib/TaskEither";
 import { toError } from "fp-ts/lib/Either";
-import { ResponseErrorInternal } from "@pagopa/ts-commons/lib/responses";
+import {
+  IResponseErrorForbiddenNotAuthorized,
+  ResponseErrorInternal
+} from "@pagopa/ts-commons/lib/responses";
 import { identity } from "fp-ts/lib/function";
 import { NonEmptyString } from "italia-ts-commons/lib/strings";
 import { withUserFromRequest } from "../types/user";
@@ -156,6 +159,7 @@ export default class MessagesController {
     | IResponseErrorInternal
     | IResponseErrorValidation
     | IResponseErrorNotFound
+    | IResponseErrorForbiddenNotAuthorized
     | IResponseErrorTooManyRequests
     | IResponseSuccessJson<MessageStatusAttributes>
   > =>

--- a/src/services/__tests__/newMessagesService.test.ts
+++ b/src/services/__tests__/newMessagesService.test.ts
@@ -1,0 +1,336 @@
+/* tslint:disable:no-identical-functions */
+
+import * as e from "express";
+import * as t from "io-ts";
+
+import { mockedUser } from "../../__mocks__/user_mock";
+import NewMessageService from "../newMessagesService";
+import mockRes from "../../__mocks__/response";
+import { GetMessagesParameters } from "../../../generated/backend/GetMessagesParameters";
+import { MessageStatusChange } from "../../../generated/io-api/MessageStatusChange";
+import { Change_typeEnum as Reading_Change_typeEnum } from "../../../generated/io-api/MessageStatusReadingChange";
+import { MessageStatusValueEnum } from "../../../generated/io-api/MessageStatusValue";
+import { NonEmptyString } from "@pagopa/ts-commons/lib/strings";
+import { MessageStatusAttributes } from "../../../generated/io-api/MessageStatusAttributes";
+import { MessageStatusWithAttributes } from "../../../generated/io-api/MessageStatusWithAttributes";
+import { AppMessagesAPIClient } from "../../clients/app-messages.client";
+
+const aValidMessageId = "01C3GDA0GB7GAFX6CCZ3FK3Z5Q";
+const aValidSubject = "Lorem ipsum";
+const aValidMarkdown =
+  "# This is a markdown header\n\nto show how easily markdown can be converted to **HTML**\n\nRemember: this has to be a long text.";
+const validApiMessagesResponse = {
+  status: 200,
+  value: {
+    items: [
+      {
+        created_at: "2018-05-21T07:36:41.209Z",
+        fiscal_code: "LSSLCU79B24L219P",
+        id: "01CE0T1Z18T3NT9ECK5NJ09YR3",
+        sender_service_id: "5a563817fcc896087002ea46c49a"
+      },
+      {
+        created_at: "2018-05-21T07:41:01.361Z",
+        fiscal_code: "LSSLCU79B24L219P",
+        id: "01CE0T9X1HT595GEF8FH9NRSW7",
+        sender_service_id: "5a563817fcc896087002ea46c49a"
+      }
+    ],
+    page_size: 2
+  }
+};
+const validApiMessageResponse = {
+  status: 200,
+  value: {
+    message: {
+      content: {
+        markdown: aValidMarkdown,
+        subject: aValidSubject
+      },
+      created_at: "2018-06-12T09:45:06.771Z",
+      fiscal_code: "LSSLCU79B24L219P",
+      id: "01CFSP4XYK3Y0VZTKHW9FKS1XM",
+      sender_service_id: "5a563817fcc896087002ea46c49a"
+    },
+    notification: {
+      email: "SENT",
+      webhook: "SENT"
+    },
+    status: "PROCESSED"
+  }
+};
+
+const emptyApiMessagesResponse = {
+  status: 404
+};
+const tooManyReqApiMessagesResponse = {
+  status: 429
+};
+const invalidApiMessagesResponse = {
+  status: 500
+};
+const invalidApiMessageResponse = {
+  status: 500
+};
+
+const problemJson = {
+  status: 500
+};
+
+const proxyMessagesResponse = {
+  items: validApiMessagesResponse.value.items,
+  page_size: validApiMessagesResponse.value.page_size
+};
+const proxyMessageResponse = validApiMessageResponse.value.message;
+
+const mockParameters: GetMessagesParameters = {
+  pageSize: undefined,
+  enrichResultData: undefined,
+  maximumId: undefined,
+  minimumId: undefined
+};
+
+const mockGetMessages = jest.fn();
+const mockGetMessage = jest.fn();
+const mockUpsertMessageStatus = jest.fn();
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+const api: ReturnType<typeof AppMessagesAPIClient> = {
+  getMessage: mockGetMessage,
+  getMessagesByUser: mockGetMessages,
+  upsertMessageStatusAttributes: mockUpsertMessageStatus
+};
+
+describe("MessageService#getMessagesByUser", () => {
+  it("returns a list of messages from the API", async () => {
+    mockGetMessages.mockImplementation(() => {
+      return t.success(validApiMessagesResponse);
+    });
+
+    const service = new NewMessageService(api);
+
+    const res = await service.getMessagesByUser(mockedUser, mockParameters);
+
+    expect(mockGetMessages).toHaveBeenCalledWith({
+      fiscal_code: mockedUser.fiscal_code
+    });
+    expect(res).toMatchObject({
+      kind: "IResponseSuccessJson",
+      value: proxyMessagesResponse
+    });
+  });
+
+  it("returns an empty list if the of messages from the API is empty", async () => {
+    mockGetMessages.mockImplementation(() =>
+      t.success(emptyApiMessagesResponse)
+    );
+
+    const service = new NewMessageService(api);
+
+    const res = await service.getMessagesByUser(mockedUser, mockParameters);
+
+    expect(mockGetMessages).toHaveBeenCalledWith({
+      fiscal_code: mockedUser.fiscal_code
+    });
+    expect(res.kind).toEqual("IResponseErrorNotFound");
+  });
+
+  it("returns an 429 HTTP error from getMessagesByUser upstream API", async () => {
+    mockGetMessages.mockImplementation(() =>
+      t.success(tooManyReqApiMessagesResponse)
+    );
+
+    const service = new NewMessageService(api);
+
+    const res = await service.getMessagesByUser(mockedUser, mockParameters);
+
+    expect(res.kind).toEqual("IResponseErrorTooManyRequests");
+  });
+
+  it("returns an error if the getMessagesByUser API returns an error", async () => {
+    mockGetMessages.mockImplementation(() => t.success(problemJson));
+
+    const service = new NewMessageService(api);
+
+    const res = await service.getMessagesByUser(mockedUser, mockParameters);
+    expect(mockGetMessages).toHaveBeenCalledWith({
+      fiscal_code: mockedUser.fiscal_code
+    });
+    expect(res.kind).toEqual("IResponseErrorInternal");
+  });
+
+  it("returns a 500 response if the response from the getMessagesByUser API returns something wrong", async () => {
+    mockGetMessages.mockImplementation(() =>
+      t.success(invalidApiMessagesResponse)
+    );
+
+    const service = new NewMessageService(api);
+
+    const res = await service.getMessagesByUser(mockedUser, mockParameters);
+    expect(mockGetMessages).toHaveBeenCalledWith({
+      fiscal_code: mockedUser.fiscal_code
+    });
+    expect(res.kind).toEqual("IResponseErrorInternal");
+  });
+});
+
+describe("MessageService#getMessage", () => {
+  it("returns a message from the API", async () => {
+    mockGetMessage.mockImplementation(() => t.success(validApiMessageResponse));
+
+    const service = new NewMessageService(api);
+
+    const res = await service.getMessage(mockedUser, aValidMessageId);
+
+    expect(mockGetMessage).toHaveBeenCalledWith({
+      fiscal_code: mockedUser.fiscal_code,
+      id: aValidMessageId
+    });
+    expect(res).toMatchObject({
+      kind: "IResponseSuccessJson",
+      value: proxyMessageResponse
+    });
+  });
+
+  it("returns an error if the getMessage API returns an error", async () => {
+    mockGetMessage.mockImplementation(() => t.success(problemJson));
+
+    const service = new NewMessageService(api);
+
+    const res = await service.getMessage(mockedUser, aValidMessageId);
+    expect(mockGetMessage).toHaveBeenCalledWith({
+      fiscal_code: mockedUser.fiscal_code,
+      id: aValidMessageId
+    });
+    expect(res.kind).toEqual("IResponseErrorInternal");
+  });
+
+  it("returns unknown response if the response from the getMessage API returns something wrong", async () => {
+    mockGetMessage.mockImplementation(() =>
+      t.success(invalidApiMessageResponse)
+    );
+
+    const service = new NewMessageService(api);
+
+    const res = await service.getMessage(mockedUser, aValidMessageId);
+    expect(mockGetMessage).toHaveBeenCalledWith({
+      fiscal_code: mockedUser.fiscal_code,
+      id: aValidMessageId
+    });
+    expect(res.kind).toEqual("IResponseErrorInternal");
+  });
+
+  it("returns an 429 HTTP error from getMessage upstream API", async () => {
+    mockGetMessage.mockImplementation(() =>
+      t.success(tooManyReqApiMessagesResponse)
+    );
+
+    const service = new NewMessageService(api);
+
+    const res = await service.getMessage(mockedUser, aValidMessageId);
+
+    expect(res.kind).toEqual("IResponseErrorTooManyRequests");
+  });
+});
+
+describe("MessageService#upsertMessageStatus", () => {
+  const aMessageStatusChange: MessageStatusChange = {
+    change_type: Reading_Change_typeEnum.reading,
+    is_read: true
+  };
+
+  const aMessageStatusAttributes: MessageStatusAttributes = {
+    is_read: true,
+    is_archived: false
+  };
+
+  const aMessageStatusWithAttributes: MessageStatusWithAttributes = {
+    is_read: true,
+    is_archived: false,
+    status: MessageStatusValueEnum.PROCESSED,
+    version: 1,
+    updated_at: new Date()
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should make the correct api call", async () => {
+    mockUpsertMessageStatus.mockImplementation(() => {
+      return t.success({
+        status: 200,
+        value: aMessageStatusWithAttributes
+      });
+    });
+
+    const service = new NewMessageService(api);
+    const res = await service.upsertMessageStatus(
+      mockedUser.fiscal_code,
+      aValidMessageId as NonEmptyString,
+      aMessageStatusChange
+    );
+
+    expect(res).toMatchObject({
+      kind: "IResponseSuccessJson",
+      value: aMessageStatusAttributes
+    });
+
+    if (res.kind === "IResponseSuccessJson") {
+      expect(res.value).not.toHaveProperty("version");
+      expect(res.value).not.toHaveProperty("status");
+      expect(res.value).not.toHaveProperty("updated_at");
+    }
+
+    expect(mockUpsertMessageStatus).toHaveBeenCalledWith({
+      fiscal_code: mockedUser.fiscal_code,
+      id: aValidMessageId,
+      body: aMessageStatusChange
+    });
+  });
+
+  it.each`
+    title                                                             | statusCode | value   | expectedStatusCode | expectedKind                              | expectedDetail
+    ${"return IResponseErrorInternal if status is 401"}               | ${401}     | ${null} | ${500}             | ${"IResponseErrorInternal"}               | ${"Internal server error: Underlying API fails with an unexpected 401"}
+    ${"return IResponseErrorForbiddenNotAuthorized if status is 403"} | ${403}     | ${null} | ${403}             | ${"IResponseErrorForbiddenNotAuthorized"} | ${"You are not allowed here: You do not have enough permission to complete the operation you requested"}
+    ${"return IResponseErrorNotFound if status is 404"}               | ${404}     | ${null} | ${404}             | ${"IResponseErrorNotFound"}               | ${"Not Found: Message status not found"}
+    ${"return IResponseErrorTooManyRequests if status is 429"}        | ${429}     | ${null} | ${429}             | ${"IResponseErrorTooManyRequests"}        | ${"Too many requests: "}
+    ${"return IResponseErrorInternal if status code is not in spec"}  | ${418}     | ${null} | ${500}             | ${"IResponseErrorInternal"}               | ${"Internal server error: unhandled API response status [418]"}
+  `(
+    "should $title",
+    async ({
+      statusCode,
+      value,
+      expectedStatusCode,
+      expectedKind,
+      expectedDetail
+    }) => {
+      mockUpsertMessageStatus.mockImplementation(() => {
+        return t.success({
+          status: statusCode,
+          value
+        });
+      });
+
+      const service = new NewMessageService(api);
+      const res = await service.upsertMessageStatus(
+        mockedUser.fiscal_code,
+        aValidMessageId as NonEmptyString,
+        aMessageStatusChange
+      );
+
+      // Check status code
+      const responseMock: e.Response = mockRes();
+      res.apply(responseMock);
+      expect(responseMock.status).toHaveBeenCalledWith(expectedStatusCode);
+
+      expect(res).toMatchObject({
+        kind: expectedKind,
+        detail: expectedDetail
+      });
+    }
+  );
+});

--- a/src/services/newMessagesService.ts
+++ b/src/services/newMessagesService.ts
@@ -3,6 +3,7 @@
  */
 
 import {
+  IResponseErrorForbiddenNotAuthorized,
   IResponseErrorInternal,
   IResponseErrorNotFound,
   IResponseErrorTooManyRequests,
@@ -10,7 +11,8 @@ import {
   IResponseSuccessJson,
   ResponseErrorNotFound,
   ResponseErrorTooManyRequests,
-  ResponseSuccessJson
+  ResponseSuccessJson,
+  ResponseErrorForbiddenNotAuthorized
 } from "@pagopa/ts-commons/lib/responses";
 
 import { fromNullable } from "fp-ts/lib/Option";
@@ -133,6 +135,7 @@ export default class NewMessagesService {
     | IResponseErrorInternal
     | IResponseErrorNotFound
     | IResponseErrorValidation
+    | IResponseErrorForbiddenNotAuthorized
     | IResponseErrorTooManyRequests
     | IResponseSuccessJson<MessageStatusAttributes>
   > =>
@@ -153,6 +156,8 @@ export default class NewMessagesService {
             });
           case 401:
             return ResponseErrorUnexpectedAuthProblem();
+          case 403:
+            return ResponseErrorForbiddenNotAuthorized;
           case 404:
             return ResponseErrorNotFound(
               "Not Found",


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

This PR depends on https://github.com/pagopa/io-functions-app-messages/pull/17

#### List of Changes
<!--- Describe your changes in detail -->

- Handle 403 response type in upsertMessageStatus from fn-app-messages
- Add 403 response to api_backend.yaml

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
