### PR TITLE
[#IOCIT-35] Get Activation for PN courtesy service

### DIFF
--- a/api_pn.yaml
+++ b/api_pn.yaml
@@ -10,6 +10,27 @@ security:
   - Bearer: []
 paths:
   "/activation":
+    get:
+      operationId: getPNActivation
+      summary: Get Piattaforma Notifiche Activation
+      description: |
+        Get the Piattaforma Notifiche activation for Special Service "Avvisi di Cortesia"
+      parameters:
+        - in: query
+          name: isTest
+          required: false
+          type: boolean
+      responses:
+        "200":
+          description: Request created.
+          schema:
+            $ref: "#/definitions/PNActivation"
+        "401":
+          description: Bearer token null or expired.
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: "#/definitions/ProblemJson"
     post:
       operationId: upsertPNActivation
       summary: Upsert Piattaforma Notifiche Activation

--- a/src/app.ts
+++ b/src/app.ts
@@ -146,7 +146,7 @@ import PecServerClientFactory from "./services/pecServerClientFactory";
 import NewMessagesService from "./services/newMessagesService";
 import bearerFIMSTokenStrategy from "./strategies/bearerFIMSTokenStrategy";
 import { getThirdPartyServiceClientFactory } from "./clients/third-party-service-client";
-import { PnService } from "./services/pnService";
+import { PNService } from "./services/pnService";
 
 const defaultModule = {
   // eslint-disable-next-line @typescript-eslint/no-use-before-define
@@ -565,7 +565,7 @@ export function newApp({
           PNAddressBookConfig.FF_PN_ACTIVATION_ENABLED === "1" &&
           O.isSome(PN_ADDRESS_BOOK_CLIENT_SELECTOR)
         ) {
-          const pnService = PnService(PN_ADDRESS_BOOK_CLIENT_SELECTOR.value);
+          const pnService = PNService(PN_ADDRESS_BOOK_CLIENT_SELECTOR.value);
           // eslint-disable-next-line @typescript-eslint/no-use-before-define
           registerPNRoutes(
             app,
@@ -1344,7 +1344,7 @@ function registerAuthenticationRoutes(
 function registerPNRoutes(
   app: Express,
   pnBasePath: string,
-  pnService: ReturnType<typeof PnService>,
+  pnService: ReturnType<typeof PNService>,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   bearerSessionTokenAuth: any
 ) {

--- a/src/app.ts
+++ b/src/app.ts
@@ -146,10 +146,7 @@ import PecServerClientFactory from "./services/pecServerClientFactory";
 import NewMessagesService from "./services/newMessagesService";
 import bearerFIMSTokenStrategy from "./strategies/bearerFIMSTokenStrategy";
 import { getThirdPartyServiceClientFactory } from "./clients/third-party-service-client";
-import {
-  getPnActivationService,
-  upsertPnActivationService
-} from "./services/pnService";
+import { PnService } from "./services/pnService";
 
 const defaultModule = {
   // eslint-disable-next-line @typescript-eslint/no-use-before-define
@@ -568,19 +565,12 @@ export function newApp({
           PNAddressBookConfig.FF_PN_ACTIVATION_ENABLED === "1" &&
           O.isSome(PN_ADDRESS_BOOK_CLIENT_SELECTOR)
         ) {
-          const upsertPnActivation = upsertPnActivationService(
-            PN_ADDRESS_BOOK_CLIENT_SELECTOR.value
-          );
-
-          const getPnActivation = getPnActivationService(
-            PN_ADDRESS_BOOK_CLIENT_SELECTOR.value
-          );
+          const pnService = PnService(PN_ADDRESS_BOOK_CLIENT_SELECTOR.value);
           // eslint-disable-next-line @typescript-eslint/no-use-before-define
           registerPNRoutes(
             app,
             PNAddressBookConfig.PN_ACTIVATION_BASE_PATH,
-            upsertPnActivation,
-            getPnActivation,
+            pnService,
             authMiddlewares.bearerSession
           );
         }
@@ -1354,21 +1344,20 @@ function registerAuthenticationRoutes(
 function registerPNRoutes(
   app: Express,
   pnBasePath: string,
-  upsertPnActivation: ReturnType<typeof upsertPnActivationService>,
-  getPnActivation: ReturnType<typeof getPnActivationService>,
+  pnService: ReturnType<typeof PnService>,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   bearerSessionTokenAuth: any
 ) {
   app.get(
     `${pnBasePath}/activation`,
     bearerSessionTokenAuth,
-    toExpressHandler(getPNActivationController(getPnActivation))
+    toExpressHandler(getPNActivationController(pnService.getPnActivation))
   );
 
   app.post(
     `${pnBasePath}/activation`,
     bearerSessionTokenAuth,
-    toExpressHandler(upsertPNActivationController(upsertPnActivation))
+    toExpressHandler(upsertPNActivationController(pnService.upsertPnActivation))
   );
 }
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -88,7 +88,10 @@ import checkIP from "./utils/middleware/checkIP";
 import BonusController from "./controllers/bonusController";
 import CgnController from "./controllers/cgnController";
 import SessionLockController from "./controllers/sessionLockController";
-import { upsertPNActivationController } from "./controllers/pnController";
+import {
+  getPNActivationController,
+  upsertPNActivationController
+} from "./controllers/pnController";
 import {
   getUserForBPD,
   getUserForFIMS,
@@ -143,7 +146,10 @@ import PecServerClientFactory from "./services/pecServerClientFactory";
 import NewMessagesService from "./services/newMessagesService";
 import bearerFIMSTokenStrategy from "./strategies/bearerFIMSTokenStrategy";
 import { getThirdPartyServiceClientFactory } from "./clients/third-party-service-client";
-import { upsertPnActivationService } from "./services/pnService";
+import {
+  getPnActivationService,
+  upsertPnActivationService
+} from "./services/pnService";
 
 const defaultModule = {
   // eslint-disable-next-line @typescript-eslint/no-use-before-define
@@ -565,11 +571,16 @@ export function newApp({
           const upsertPnActivation = upsertPnActivationService(
             PN_ADDRESS_BOOK_CLIENT_SELECTOR.value
           );
+
+          const getPnActivation = getPnActivationService(
+            PN_ADDRESS_BOOK_CLIENT_SELECTOR.value
+          );
           // eslint-disable-next-line @typescript-eslint/no-use-before-define
           registerPNRoutes(
             app,
             PNAddressBookConfig.PN_ACTIVATION_BASE_PATH,
             upsertPnActivation,
+            getPnActivation,
             authMiddlewares.bearerSession
           );
         }
@@ -1344,9 +1355,16 @@ function registerPNRoutes(
   app: Express,
   pnBasePath: string,
   upsertPnActivation: ReturnType<typeof upsertPnActivationService>,
+  getPnActivation: ReturnType<typeof getPnActivationService>,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   bearerSessionTokenAuth: any
 ) {
+  app.get(
+    `${pnBasePath}/activation`,
+    bearerSessionTokenAuth,
+    toExpressHandler(getPNActivationController(getPnActivation))
+  );
+
   app.post(
     `${pnBasePath}/activation`,
     bearerSessionTokenAuth,

--- a/src/controllers/pnController.ts
+++ b/src/controllers/pnController.ts
@@ -18,14 +18,14 @@ import {
   withValidatedOrValidationError
 } from "../utils/responses";
 import { PNActivation } from "../../generated/api_piattaforma-notifiche-courtesy/PNActivation";
-import { PnService } from "../services/pnService";
+import { PNService } from "../services/pnService";
 
 /**
  * Upsert the Activation for `Avvisi di Cortesia` Piattaforma Notifiche
  * Special Service
  */
 export const upsertPNActivationController = (
-  upsertPnActivation: ReturnType<typeof PnService>["upsertPnActivation"]
+  upsertPnActivation: ReturnType<typeof PNService>["upsertPnActivation"]
 ) => (
   req: express.Request
 ): Promise<
@@ -75,7 +75,7 @@ export const upsertPNActivationController = (
   );
 
 export const getPNActivationController = (
-  getPnActivation: ReturnType<typeof PnService>["getPnActivation"]
+  getPnActivation: ReturnType<typeof PNService>["getPnActivation"]
 ) => (
   req: express.Request
 ): Promise<

--- a/src/controllers/pnController.ts
+++ b/src/controllers/pnController.ts
@@ -18,17 +18,14 @@ import {
   withValidatedOrValidationError
 } from "../utils/responses";
 import { PNActivation } from "../../generated/api_piattaforma-notifiche-courtesy/PNActivation";
-import {
-  upsertPnActivationService,
-  getPnActivationService
-} from "../services/pnService";
+import { PnService } from "../services/pnService";
 
 /**
  * Upsert the Activation for `Avvisi di Cortesia` Piattaforma Notifiche
  * Special Service
  */
 export const upsertPNActivationController = (
-  upsertPnActivation: ReturnType<typeof upsertPnActivationService>
+  upsertPnActivation: ReturnType<typeof PnService>["upsertPnActivation"]
 ) => (
   req: express.Request
 ): Promise<
@@ -78,7 +75,7 @@ export const upsertPNActivationController = (
   );
 
 export const getPNActivationController = (
-  getPnActivation: ReturnType<typeof getPnActivationService>
+  getPnActivation: ReturnType<typeof PnService>["getPnActivation"]
 ) => (
   req: express.Request
 ): Promise<

--- a/src/controllers/pnController.ts
+++ b/src/controllers/pnController.ts
@@ -103,11 +103,11 @@ export const getPNActivationController = (
           )
         )
       ),
-      TE.map(_ => {
-        switch (_.status) {
+      TE.map(pnActivationResponse => {
+        switch (pnActivationResponse.status) {
           case 200:
             return ResponseSuccessJson({
-              activation_status: _.value.activationStatus
+              activation_status: pnActivationResponse.value.activationStatus
             });
           case 404:
             // When the activation is missing on PN

--- a/src/services/__tests__/pnService.test.ts
+++ b/src/services/__tests__/pnService.test.ts
@@ -1,4 +1,4 @@
-import { PnService } from "../pnService";
+import { PNService } from "../pnService";
 import * as PNClients from "../../clients/pn-clients";
 import { PNClientFactory } from "../../clients/pn-clients";
 import { ValidUrl } from "@pagopa/ts-commons/lib/url";
@@ -22,7 +22,7 @@ const anActivationStatusPayload: IoCourtesyDigitalAddressActivation = {
 };
 
 describe("pnService#upsertPnServiceActivation", () => {
-  const service = PnService(
+  const service = PNService(
     PNClientFactory(
       mockProdUrl,
       mockProdKey,
@@ -165,7 +165,7 @@ describe("pnService#upsertPnServiceActivation", () => {
 });
 
 describe("pnService#getPnServiceActivation", () => {
-  const service = PnService(
+  const service = PNService(
     PNClientFactory(
       mockProdUrl,
       mockProdKey,

--- a/src/services/__tests__/pnService.test.ts
+++ b/src/services/__tests__/pnService.test.ts
@@ -1,7 +1,4 @@
-import {
-  upsertPnActivationService,
-  getPnActivationService
-} from "../pnService";
+import { PnService } from "../pnService";
 import * as PNClients from "../../clients/pn-clients";
 import { PNClientFactory } from "../../clients/pn-clients";
 import { ValidUrl } from "@pagopa/ts-commons/lib/url";
@@ -25,7 +22,7 @@ const anActivationStatusPayload: IoCourtesyDigitalAddressActivation = {
 };
 
 describe("pnService#upsertPnServiceActivation", () => {
-  const service = upsertPnActivationService(
+  const service = PnService(
     PNClientFactory(
       mockProdUrl,
       mockProdKey,
@@ -48,7 +45,7 @@ describe("pnService#upsertPnServiceActivation", () => {
     );
   });
   it("should call setCourtesyAddressIo with right PROD params", async () => {
-    const response = await service(
+    const response = await service.upsertPnActivation(
       PNClients.PNEnvironment.PRODUCTION,
       aFiscalCode,
       anActivationStatusPayload
@@ -78,7 +75,7 @@ describe("pnService#upsertPnServiceActivation", () => {
   });
 
   it("should call setCourtesyAddressIo with right UAT params", async () => {
-    const response = await service(
+    const response = await service.upsertPnActivation(
       PNClients.PNEnvironment.UAT,
       aFiscalCode,
       anActivationStatusPayload
@@ -113,7 +110,7 @@ describe("pnService#upsertPnServiceActivation", () => {
       async (_input: RequestInfo | URL, _init?: RequestInit) =>
         Promise.reject(expectedError)
     );
-    const responsePromise = service(
+    const responsePromise = service.upsertPnActivation(
       PNClients.PNEnvironment.UAT,
       aFiscalCode,
       anActivationStatusPayload
@@ -145,7 +142,7 @@ describe("pnService#upsertPnServiceActivation", () => {
           }
         } as Response)
     );
-    const response = await service(
+    const response = await service.upsertPnActivation(
       PNClients.PNEnvironment.PRODUCTION,
       aFiscalCode,
       anActivationStatusPayload
@@ -168,7 +165,7 @@ describe("pnService#upsertPnServiceActivation", () => {
 });
 
 describe("pnService#getPnServiceActivation", () => {
-  const service = getPnActivationService(
+  const service = PnService(
     PNClientFactory(
       mockProdUrl,
       mockProdKey,
@@ -191,7 +188,7 @@ describe("pnService#getPnServiceActivation", () => {
     );
   });
   it("should call getPnServiceActivation with right PROD params", async () => {
-    const response = await service(
+    const response = await service.getPnActivation(
       PNClients.PNEnvironment.PRODUCTION,
       aFiscalCode
     );
@@ -219,7 +216,10 @@ describe("pnService#getPnServiceActivation", () => {
   });
 
   it("should call getPnServiceActivation with right UAT params", async () => {
-    const response = await service(PNClients.PNEnvironment.UAT, aFiscalCode);
+    const response = await service.getPnActivation(
+      PNClients.PNEnvironment.UAT,
+      aFiscalCode
+    );
     expect(mockPnAddressBookIOClient).toBeCalledWith(
       mockUATUrl.href,
       mockUATKey,
@@ -249,7 +249,10 @@ describe("pnService#getPnServiceActivation", () => {
       async (_input: RequestInfo | URL, _init?: RequestInit) =>
         Promise.reject(expectedError)
     );
-    const responsePromise = service(PNClients.PNEnvironment.UAT, aFiscalCode);
+    const responsePromise = service.getPnActivation(
+      PNClients.PNEnvironment.UAT,
+      aFiscalCode
+    );
     await expect(responsePromise).rejects.toThrowError(expectedError);
     expect(mockPnAddressBookIOClient).toBeCalledWith(
       mockUATUrl.href,
@@ -276,7 +279,7 @@ describe("pnService#getPnServiceActivation", () => {
           }
         } as Response)
     );
-    const response = await service(
+    const response = await service.getPnActivation(
       PNClients.PNEnvironment.PRODUCTION,
       aFiscalCode
     );

--- a/src/services/__tests__/pnService.test.ts
+++ b/src/services/__tests__/pnService.test.ts
@@ -34,18 +34,18 @@ describe("pnService#upsertPnServiceActivation", () => {
       mockNodeFetch
     )
   );
-  mockNodeFetch.mockImplementation(
-    async (_input: RequestInfo | URL, _init?: RequestInit) =>
-      ({
-        ok: true,
-        status: 204,
-        json: async () => {
-          return;
-        }
-      } as Response)
-  );
   beforeEach(() => {
     jest.clearAllMocks();
+    mockNodeFetch.mockImplementation(
+      async (_input: RequestInfo | URL, _init?: RequestInit) =>
+        ({
+          ok: true,
+          status: 204,
+          json: async () => {
+            return;
+          }
+        } as Response)
+    );
   });
   it("should call setCourtesyAddressIo with right PROD params", async () => {
     const response = await service(
@@ -177,18 +177,18 @@ describe("pnService#getPnServiceActivation", () => {
       mockNodeFetch
     )
   );
-  mockNodeFetch.mockImplementation(
-    async (_input: RequestInfo | URL, _init?: RequestInit) =>
-      ({
-        ok: true,
-        status: 200,
-        json: async () => {
-          return anActivationStatusPayload;
-        }
-      } as Response)
-  );
   beforeEach(() => {
     jest.clearAllMocks();
+    mockNodeFetch.mockImplementation(
+      async (_input: RequestInfo | URL, _init?: RequestInit) =>
+        ({
+          ok: true,
+          status: 200,
+          json: async () => {
+            return anActivationStatusPayload;
+          }
+        } as Response)
+    );
   });
   it("should call getPnServiceActivation with right PROD params", async () => {
     const response = await service(

--- a/src/services/pnService.ts
+++ b/src/services/pnService.ts
@@ -2,7 +2,7 @@ import { IoCourtesyDigitalAddressActivation } from "../../generated/piattaforma-
 import { PNClientFactory, PNEnvironment } from "../clients/pn-clients";
 import { FiscalCode } from "../../generated/backend/FiscalCode";
 
-export const upsertPnActivationService = (
+const upsertPnActivationService = (
   PnAddressBookIOClientSelector: ReturnType<typeof PNClientFactory>
 ) => (
   pnEnvironment: PNEnvironment,
@@ -14,9 +14,16 @@ export const upsertPnActivationService = (
     "x-pagopa-cx-taxid": fiscalCode
   });
 
-export const getPnActivationService = (
+const getPnActivationService = (
   PnAddressBookIOClientSelector: ReturnType<typeof PNClientFactory>
 ) => (pnEnvironment: PNEnvironment, fiscalCode: FiscalCode) =>
   PnAddressBookIOClientSelector(pnEnvironment).getCourtesyAddressIo({
     "x-pagopa-cx-taxid": fiscalCode
   });
+
+export const PnService = (
+  PnAddressBookIOClientSelector: ReturnType<typeof PNClientFactory>
+) => ({
+  getPnActivation: getPnActivationService(PnAddressBookIOClientSelector),
+  upsertPnActivation: upsertPnActivationService(PnAddressBookIOClientSelector)
+});

--- a/src/services/pnService.ts
+++ b/src/services/pnService.ts
@@ -21,7 +21,7 @@ const getPnActivationService = (
     "x-pagopa-cx-taxid": fiscalCode
   });
 
-export const PnService = (
+export const PNService = (
   PnAddressBookIOClientSelector: ReturnType<typeof PNClientFactory>
 ) => ({
   getPnActivation: getPnActivationService(PnAddressBookIOClientSelector),

--- a/src/services/pnService.ts
+++ b/src/services/pnService.ts
@@ -13,3 +13,10 @@ export const upsertPnActivationService = (
     body: activationStatusPayload,
     "x-pagopa-cx-taxid": fiscalCode
   });
+
+export const getPnActivationService = (
+  PnAddressBookIOClientSelector: ReturnType<typeof PNClientFactory>
+) => (pnEnvironment: PNEnvironment, fiscalCode: FiscalCode) =>
+  PnAddressBookIOClientSelector(pnEnvironment).getCourtesyAddressIo({
+    "x-pagopa-cx-taxid": fiscalCode
+  });


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->
New Endpoint to read the Activation status for Piattaforma Notifiche special service.
New PN service and controller
Refactor PnService structure for more compact initialization.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The _Piattaforma Notifiche Avvisi di cortesia_ special service need two endpoint to read the current activation status and update the value. This PR introduce the new endpoint for reading the current activation status on PN servers, returning this information to the IO App.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Unit Test

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Before merge wait that #913 will be merged
