### PR TITLE
[#ICC-144] Fix getThirdPartyAttachment routing

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -970,7 +970,7 @@ function registerAPIRoutes(
   );
 
   app.get(
-    `${basePath}/third-party-messages/:id/attachments/:attachment_url`,
+    `${basePath}/third-party-messages/:id/attachments/:attachment_url(*)`,
     bearerSessionTokenAuth,
     toExpressHandler(
       messagesController.getThirdPartyMessageAttachment,


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Problem:
Calling the getThirdPartyAttachment endpoint with the path relative to a file on PN, it returns 404.
This is due to express routing: the path `${basePath}/third-party-messages/:id/attachments/:attachment_url` does not support `attachment_url` parameters containing `/`, so it tries to redirect the request to a non-existent endpoint.

#### List of Changes
<!--- Describe your changes in detail -->

Fix routing path to allow `/` in `attachment_url` parameter

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Manually running io-mock

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
