### PR TITLE
[#IOCIT-285] Offuscate Tokens in Custom events payload

### DIFF
--- a/src/services/redisSessionStorage.ts
+++ b/src/services/redisSessionStorage.ts
@@ -42,6 +42,18 @@ const userSessionsSetKeyPrefix = "USERSESSIONS-";
 const sessionInfoKeyPrefix = "SESSIONINFO-";
 const noticeEmailPrefix = "NOTICEEMAIL-";
 const blockedUserSetKey = "BLOCKEDUSERS";
+export const keyPrefixes = [
+  sessionKeyPrefix,
+  walletKeyPrefix,
+  myPortalTokenPrefix,
+  fimsTokenPrefix,
+  bpdTokenPrefix,
+  zendeskTokenPrefix,
+  userSessionsSetKeyPrefix,
+  sessionInfoKeyPrefix,
+  noticeEmailPrefix,
+  blockedUserSetKey
+];
 export const sessionNotFoundError = new Error("Session not found");
 
 export default class RedisSessionStorage extends RedisStorageUtils

--- a/src/utils/__tests__/redis.test.ts
+++ b/src/utils/__tests__/redis.test.ts
@@ -1,0 +1,15 @@
+import TokenService from "../../services/tokenService";
+import { SESSION_TOKEN_LENGTH_BYTES } from "../../controllers/authenticationController";
+import { offuscateTokensInfo } from "../redis";
+
+const getAnErrorMessage = (token: string) =>
+  `{"code":"UNCERTAIN_STATE","command":"MGET","args":["${token}"],"origin":{"errno":-110,"code":"ETIMEDOUT","syscall":"read"}}`;
+describe("offuscateTokensInfo", () => {
+  it("should offuscate a token string", () => {
+    const token = new TokenService().getNewToken(SESSION_TOKEN_LENGTH_BYTES);
+    const errorMessage = getAnErrorMessage(`SESSION-${token}`);
+    expect(offuscateTokensInfo(errorMessage)).toEqual(
+      getAnErrorMessage(`SESSION-redacted`)
+    );
+  });
+});

--- a/src/utils/__tests__/redis.test.ts
+++ b/src/utils/__tests__/redis.test.ts
@@ -1,14 +1,14 @@
 import TokenService from "../../services/tokenService";
 import { SESSION_TOKEN_LENGTH_BYTES } from "../../controllers/authenticationController";
-import { offuscateTokensInfo } from "../redis";
+import { obfuscateTokensInfo } from "../redis";
 
 const getAnErrorMessage = (token: string) =>
   `{"code":"UNCERTAIN_STATE","command":"MGET","args":["${token}"],"origin":{"errno":-110,"code":"ETIMEDOUT","syscall":"read"}}`;
-describe("offuscateTokensInfo", () => {
+describe("obfuscateTokensInfo", () => {
   it("should offuscate a token string", () => {
     const token = new TokenService().getNewToken(SESSION_TOKEN_LENGTH_BYTES);
     const errorMessage = getAnErrorMessage(`SESSION-${token}`);
-    expect(offuscateTokensInfo(errorMessage)).toEqual(
+    expect(obfuscateTokensInfo(errorMessage)).toEqual(
       getAnErrorMessage(`SESSION-redacted`)
     );
   });

--- a/src/utils/redis.ts
+++ b/src/utils/redis.ts
@@ -1,6 +1,10 @@
 import * as redis from "redis";
 import RedisClustr = require("redis-clustr");
 import * as appInsights from "applicationinsights";
+import { pipe } from "fp-ts/lib/function";
+import * as RA from "fp-ts/lib/ReadonlyArray";
+import * as O from "fp-ts/lib/Option";
+import { keyPrefixes } from "../services/redisSessionStorage";
 import { log } from "./logger";
 
 export function createSimpleRedisClient(redisUrl?: string): redis.RedisClient {
@@ -8,6 +12,17 @@ export function createSimpleRedisClient(redisUrl?: string): redis.RedisClient {
   log.info("Creating SIMPLE redis client", { url: redisUrlOrDefault });
   return redis.createClient(redisUrlOrDefault);
 }
+
+export const offuscateTokensInfo = (message: string) =>
+  pipe(
+    keyPrefixes,
+    RA.findFirst(key => message.includes(key)),
+    O.map(key =>
+      // eslint-disable-next-line no-useless-escape
+      message.replace(new RegExp(`\\"${key}\\w+\\"`), `"${key}redacted"`)
+    ),
+    O.getOrElse(() => message)
+  );
 
 export const createClusterRedisClient = (
   appInsightsClient?: appInsights.TelemetryClient
@@ -41,7 +56,8 @@ export const createClusterRedisClient = (
       name: "io-backend.redis.error",
       properties: {
         error: String(err),
-        message: err instanceof Object ? JSON.stringify(err) : ""
+        message:
+          err instanceof Object ? offuscateTokensInfo(JSON.stringify(err)) : ""
       },
       tagOverrides: { samplingEnabled: "false" }
     });

--- a/src/utils/redis.ts
+++ b/src/utils/redis.ts
@@ -13,7 +13,7 @@ export function createSimpleRedisClient(redisUrl?: string): redis.RedisClient {
   return redis.createClient(redisUrlOrDefault);
 }
 
-export const offuscateTokensInfo = (message: string) =>
+export const obfuscateTokensInfo = (message: string) =>
   pipe(
     keyPrefixes,
     RA.findFirst(key => message.includes(key)),
@@ -57,7 +57,7 @@ export const createClusterRedisClient = (
       properties: {
         error: String(err),
         message:
-          err instanceof Object ? offuscateTokensInfo(JSON.stringify(err)) : ""
+          err instanceof Object ? obfuscateTokensInfo(JSON.stringify(err)) : ""
       },
       tagOverrides: { samplingEnabled: "false" }
     });


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->
Obfuscate tokens included in error messages sent to App Insights custom events.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Token can be sent to AI on custom events on errors. Before sending the message token info must be obfuscated or redacted.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
unit test

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

