### PR TITLE
[#ICC-296]  Add LolliPoP header definitions

### DIFF
--- a/.devops/code-review-pipelines.yml
+++ b/.devops/code-review-pipelines.yml
@@ -54,7 +54,7 @@ stages:
               valid=1
               for apispec in $(ls openapi/generated/*.yaml); do
                 echo "validating $apispec"
-                npx oval validate -p $apispec
+                npx swagger-cli validate  $apispec
                 result=$?
                 if [ ! $result = 0 ]; then
                   valid=0

--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,6 @@ local.*
 
 # Exclude ESLint cache file
 .eslintcache
+
+# Exclude swagger codegen (needed to generate PN specs)
+swagger-codegen-cli-*.jar

--- a/openapi/generated/lollipop_definitions.yaml
+++ b/openapi/generated/lollipop_definitions.yaml
@@ -100,9 +100,7 @@ components:
 
     LollipopSignatureInput:
       type: string
-      description: 
       pattern: "^(((sig[0-9]{1,})=.*?)(, ){0,1}){1,}$"
     LollipopSignature:
       type: string
-      description: 
       pattern: "^((sig[0-9]{1,})=:[A-Za-z0-9+/=]*:(, ){0,1}){1,}$"

--- a/openapi/generated/lollipop_definitions.yaml
+++ b/openapi/generated/lollipop_definitions.yaml
@@ -85,7 +85,7 @@ components:
         - DELETE
     LollipopOriginalURL:
       type: string
-      pattern: "^(\\b(https?)://)?((?!\\.\\.).)*$"
+      pattern: "^https?:\/\/app-backend\\.io\\.italia\\.it\\/\\w+\\/{0,1}\\?{0,1}(?:\\w+={0,1}\\w&{0,1})+$"
 
     LollipopContentType:
       type: string

--- a/openapi/generated/lollipop_definitions.yaml
+++ b/openapi/generated/lollipop_definitions.yaml
@@ -85,7 +85,7 @@ components:
         - DELETE
     LollipopOriginalURL:
       type: string
-      pattern: "^https?:\/\/app-backend\\.io\\.italia\\.it\\/\\w+\\/{0,1}\\?{0,1}(?:\\w+={0,1}\\w&{0,1})+$"
+      pattern: "^https:\/\/"
 
     LollipopContentType:
       type: string

--- a/openapi/generated/lollipop_definitions.yaml
+++ b/openapi/generated/lollipop_definitions.yaml
@@ -85,7 +85,7 @@ components:
         - DELETE
     LollipopOriginalURL:
       type: string
-      pattern: "^(\\b(https?)://)?((?!\\.\\.)[a-9a-zA-Z\/&\\?])*$"
+      pattern: "^(\\b(https?)://)?((?!\\.\\.).)*$"
 
     LollipopContentType:
       type: string

--- a/openapi/generated/lollipop_definitions.yaml
+++ b/openapi/generated/lollipop_definitions.yaml
@@ -13,56 +13,96 @@ paths:
           description: "ok"
 
 components:
-  
   parameters:
+
+    # --------------------------------------------
+    # Custom LolliPoP headers
+    # --------------------------------------------
     LollipopMethodHeader:
-      name: x-pagopa-lollipop-method
+      name: x-pagopa-lollipop-original-method
       in: header
       description: 
       required: true
       schema:
-        $ref: "#/components/schemas/LolliopMethod"
-    LollipopAuthorityHeader:
-      name: x-pagopa-lollipop-authority
-      in: header
-      description: 
-      required: true
-      schema:
-        $ref: "#/components/schemas/LolliopAuthority"
+        $ref: "#/components/schemas/LollipopMethod"
     LollipopOriginalURLHeader:
       name: x-pagopa-lollipop-original-url
       in: header
       description: 
       required: true
       schema:
-        $ref: "#/components/schemas/LolliopOriginalURL"
-    LollipopSignatureInputHeader:
-      name: x-pagopa-lollipop-original-url
+        $ref: "#/components/schemas/LollipopOriginalURL"
+
+    # --------------------------------------------
+    # Standard HTTP Message Signatures headers
+    # --------------------------------------------
+    LollipopContentTypeHeader:
+      name: content-type
       in: header
-      description: 
+      description: The content type, if any.
+      required: false
+      schema:
+        $ref: "#/components/schemas/LollipopContentType"
+    LollipopContentLengthHeader:
+      name: content-length
+      in: header
+      description: The body length, if any.
+      required: false
+      schema:
+        $ref: "#/components/schemas/LollipopContentLength"
+    LollipopContentDigestHeader:
+      name: content-digest
+      in: header
+      description: The body digest, if any, as defined in https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-digest-headers-10
+      required: false
+      schema:
+        $ref: "#/components/schemas/LollipopContentDigest"
+
+
+    LollipopSignatureInputHeader:
+      name: signature-input
+      in: header
+      description: The signature input, needed to verify the `signature` header
       required: true
       schema:
-        $ref: "#/components/schemas/LolliopSignatureInput"
+        $ref: "#/components/schemas/LollipopSignatureInput"
+    LollipopSignatureHeader:
+      name: signature
+      in: header
+      description: The signature of the HTTP request, signed by the client with its private key.
+      required: true
+      schema:
+        $ref: "#/components/schemas/LollipopSignature"
   
   schemas:
     LollipopMethod:
       type: string
-      description: 
       x-extensible-enum:
         - GET
         - POST
         - PUT
         - PATCH
         - DELETE
-    LollipopAuthority:
-      type: string
-      description: 
-      pattern: "^[0-9a-zA-Z.]*$"
     LollipopOriginalURL:
       type: string
-      description: 
-      pattern: "^[0-9a-zA-Z\/]*$"
-    LolliopSignatureInput:
+      pattern: "^(\\b(https?)://)?((?!\\.\\.)[a-9a-zA-Z\/&\\?])*$"
+
+    LollipopContentType:
+      type: string
+      x-extensible-enum:
+        - application/json
+        - application/octet-stream
+    LollipopContentLength:
+      type: number
+    LollipopContentDigest:
+      type: string
+      pattern: "^(sha-256|sha-512)=:[0-9a-zA-Z( \\n\\)+\/=]*:$"
+
+    LollipopSignatureInput:
       type: string
       description: 
-      pattern: "^[0-9a-zA-Z\/]*$"
+      pattern: "^(((sig[0-9]*)=.*?)(, ){0,1}){1,}$"
+    LollipopSignature:
+      type: string
+      description: 
+      pattern: "^((sig[0-9]*)=:[0-9a-zA-Z( \\n\\)+\/=]*:(, ){0,1}){1,}$"

--- a/openapi/generated/lollipop_definitions.yaml
+++ b/openapi/generated/lollipop_definitions.yaml
@@ -1,0 +1,68 @@
+openapi: 3.0.1
+info:
+  title: Test API
+  description: Test API.
+  version: 1.0.0
+
+# Dummy unused endpoint
+paths:
+  /dummy:
+    get:
+      responses:
+        "200":
+          description: "ok"
+
+components:
+  
+  parameters:
+    LollipopMethodHeader:
+      name: x-pagopa-lollipop-method
+      in: header
+      description: 
+      required: true
+      schema:
+        $ref: "#/components/schemas/LolliopMethod"
+    LollipopAuthorityHeader:
+      name: x-pagopa-lollipop-authority
+      in: header
+      description: 
+      required: true
+      schema:
+        $ref: "#/components/schemas/LolliopAuthority"
+    LollipopOriginalURLHeader:
+      name: x-pagopa-lollipop-original-url
+      in: header
+      description: 
+      required: true
+      schema:
+        $ref: "#/components/schemas/LolliopOriginalURL"
+    LollipopSignatureInputHeader:
+      name: x-pagopa-lollipop-original-url
+      in: header
+      description: 
+      required: true
+      schema:
+        $ref: "#/components/schemas/LolliopSignatureInput"
+  
+  schemas:
+    LollipopMethod:
+      type: string
+      description: 
+      x-extensible-enum:
+        - GET
+        - POST
+        - PUT
+        - PATCH
+        - DELETE
+    LollipopAuthority:
+      type: string
+      description: 
+      pattern: "^[0-9a-zA-Z.]*$"
+    LollipopOriginalURL:
+      type: string
+      description: 
+      pattern: "^[0-9a-zA-Z\/]*$"
+    LolliopSignatureInput:
+      type: string
+      description: 
+      pattern: "^[0-9a-zA-Z\/]*$"

--- a/openapi/generated/lollipop_definitions.yaml
+++ b/openapi/generated/lollipop_definitions.yaml
@@ -21,14 +21,14 @@ components:
     LollipopMethodHeader:
       name: x-pagopa-lollipop-original-method
       in: header
-      description: 
+      description: The method of the endpoint called by IO app
       required: true
       schema:
         $ref: "#/components/schemas/LollipopMethod"
     LollipopOriginalURLHeader:
       name: x-pagopa-lollipop-original-url
       in: header
-      description: 
+      description: The url of the endpoint called by IO app
       required: true
       schema:
         $ref: "#/components/schemas/LollipopOriginalURL"
@@ -96,13 +96,13 @@ components:
       type: number
     LollipopContentDigest:
       type: string
-      pattern: "^(sha-256|sha-512)=:[0-9a-zA-Z( \\n\\)+\/=]*:$"
+      pattern: "^(sha-256=:[A-Za-z0-9+/=]{44}:|sha-512=:[A-Za-z0-9+/=]{88}:)$"
 
     LollipopSignatureInput:
       type: string
       description: 
-      pattern: "^(((sig[0-9]*)=.*?)(, ){0,1}){1,}$"
+      pattern: "^(((sig[0-9]{1,})=.*?)(, ){0,1}){1,}$"
     LollipopSignature:
       type: string
       description: 
-      pattern: "^((sig[0-9]*)=:[0-9a-zA-Z( \\n\\)+\/=]*:(, ){0,1}){1,}$"
+      pattern: "^((sig[0-9]{1,})=:[A-Za-z0-9+/=]*:(, ){0,1}){1,}$"

--- a/openapi/generated/lollipop_definitions.yaml
+++ b/openapi/generated/lollipop_definitions.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.1
 info:
-  title: Test API
-  description: Test API.
+  title: LolliPoP Definitions
+  description: The definitions of the headers needed by the LolliPoP protocol.
   version: 1.0.0
 
 # Dummy unused endpoint

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "test:coverage": "jest -i --coverage",
     "start": "node dist/src/server.js",
     "openapi:bundle": "./openapi/bundle.sh $npm_package_version",
-    "generate:proxy-models": "npm-run-all generate:proxy:* generate:api:* generate:messages:*",
+    "generate:proxy-models": "npm-run-all generate:proxy:* generate:api:* generate:messages:* generate:lollipop-definitions",
     "generate:proxy:api-models": "rimraf generated/backend && gen-api-models --api-spec api_backend.yaml --out-dir generated/backend",
     "generate:proxy:api-parameters": "gen-api-models --api-spec api_parameters.yaml --out-dir generated/parameters",
     "generate:proxy:auth-models": "rimraf generated/auth && gen-api-models --api-spec api_auth.yaml --out-dir generated/auth",

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "generate:proxy:piattaforma-notifiche-courtesy": "rimraf generated/piattaforma-notifiche-courtesy && gen-api-models --api-spec https://raw.githubusercontent.com/pagopa/pn-user-attributes/13b91a353f6a219c60d5cdadc023cc18c4157554/docs/openapi/pn-address-book-b2b-external-io-v1.yaml --out-dir generated/piattaforma-notifiche-courtesy --request-types --response-decoders --client",
     "generate:test-certs": "./scripts/generate-test-certs.sh certs",
     "generate:proxy:api-session": "rimraf generated/session && gen-api-models --api-spec api_session.yaml --out-dir generated/session",
+    "generate:lollipop-definitions": "rimraf generated/lollipop && gen-api-models --api-spec openapi/generated/lollipop_definitions.yaml --out-dir generated/lollipop",
     "postversion": "git push && git push --tags",
     "dist:modules": "modclean -r -n default:safe && yarn install --production",
     "predeploy": "npm-run-all build dist:modules",

--- a/src/__tests__/lollipop.test.ts
+++ b/src/__tests__/lollipop.test.ts
@@ -33,8 +33,7 @@ describe("LollipopOriginalURL", () => {
   });
 
   it("should fail with an invalid URL", async () => {
-    const value =
-      "https://app-backend.io.italia.it/foo/../foo2?param=value&pet=dog";
+    const value = "http://app-backend.io.italia.it/foo2?param=value&pet=dog";
 
     const res = LollipopOriginalURL.decode(value);
     expect(res).toMatchObject(E.left(expect.any(Array)));

--- a/src/__tests__/lollipop.test.ts
+++ b/src/__tests__/lollipop.test.ts
@@ -1,0 +1,127 @@
+import * as E from "fp-ts/Either";
+
+import { LollipopMethod } from "../../generated/lollipop/LollipopMethod";
+import { LollipopOriginalURL } from "../../generated/lollipop/LollipopOriginalURL";
+import { LollipopContentType } from "../../generated/lollipop/LollipopContentType";
+import { LollipopContentDigest } from "../../generated/lollipop/LollipopContentDigest";
+import { LollipopSignatureInput } from "../../generated/lollipop/LollipopSignatureInput";
+import { LollipopSignature } from "../../generated/lollipop/LollipopSignature";
+
+describe("LollipopMethodHeader", () => {
+  it("should decode a valid method", async () => {
+    const value = "GET";
+
+    const res = LollipopMethod.decode(value);
+    expect(res).toMatchObject(E.right(value));
+  });
+
+  it("should fail with an invalid method", async () => {
+    const value = "GETT";
+
+    const res = LollipopMethod.decode(value);
+    expect(res).toMatchObject(E.left(expect.any(Array)));
+  });
+});
+
+describe("LollipopOriginalURL", () => {
+  it("should decode a valid url", async () => {
+    const value = "http://example.com/foo?param=value&pet=dog";
+
+    const res = LollipopOriginalURL.decode(value);
+
+    expect(res).toMatchObject(E.right(value));
+  });
+
+  it("should fail with an invalid URL", async () => {
+    const value = "http://example.com/foo/../foo2?param=value&pet=dog";
+
+    const res = LollipopOriginalURL.decode(value);
+    expect(res).toMatchObject(E.left(expect.any(Array)));
+  });
+});
+
+describe("LollipopContentType", () => {
+  it("should decode a valid content type", async () => {
+    const value = "application/json";
+
+    const res = LollipopContentType.decode(value);
+
+    expect(res).toMatchObject(E.right(value));
+  });
+
+  it("should fail with an invalid content type", async () => {
+    const value = "application/other";
+
+    const res = LollipopContentType.decode(value);
+    expect(res).toMatchObject(E.left(expect.any(Array)));
+  });
+});
+
+describe("LollipopContentDigest", () => {
+  it("should decode a valid digest", async () => {
+    const value =
+      "sha-512=:WZDPaVn/7XgHaAy8pmojAkGWoRx2UFChF41A2svX+T\
+  aPm+AbwAgBWnrIiYllu7BNNyealdVLvRwEmTHWXvJwew==:";
+
+    const res = LollipopContentDigest.decode(value);
+
+    expect(res).toMatchObject(E.right(value));
+  });
+
+  it("should fail with an invalid digest", async () => {
+    const value =
+      ":WZDPaVn/7XgHaAy8pmojAkGWoRx2UFChF41A2svX+T\
+  aPm+AbwAgBWnrIiYllu7BNNyealdVLvRwEmTHWXvJwew==:";
+
+    const res = LollipopContentDigest.decode(value);
+    expect(res).toMatchObject(E.left(expect.any(Array)));
+  });
+});
+
+describe("LollipopSignatureInput", () => {
+  it("should decode a valid signature input", async () => {
+    const value = `sig1=("x-io-sign-qtspclauses");created=1675258547;nonce="aNonce";alg="ecdsa-p384-sha384";keyid="aKeyId"`;
+
+    const res = LollipopSignatureInput.decode(value);
+    expect(res).toMatchObject(E.right(value));
+  });
+
+  it("should decode a valid multi-signature input", async () => {
+    const value = `sig1=("x-io-sign-qtspclauses");created=1675258547;nonce="aNonce";alg="ecdsa-p384-sha384";keyid="aKeyId, sig2=("x-pagopa-lollipop-original-method" "x-pagopa-lollipop-original-url");created=1675258547;nonce="aNonce";alg="ecdsa-p384-sha384";keyid="aKeyId"`;
+
+    const res = LollipopSignatureInput.decode(value);
+    expect(res).toMatchObject(E.right(value));
+  });
+
+  it("should fail with an invalid signature input", async () => {
+    const value = `("x-io-sign-qtspclauses");created=1675258547;nonce="aNonce";alg="ecdsa-p384-sha384";keyid="aKeyId", sig2=("x-pagopa-lollipop-original-method" "x-pagopa-lollipop-original-url");created=1675258547;nonce="aNonce";alg="ecdsa-p384-sha384";keyid="aKeyId`;
+
+    const res = LollipopSignatureInput.decode(value);
+    expect(res).toMatchObject(E.left(expect.any(Array)));
+  });
+});
+
+describe("LollipopSignature", () => {
+  it("should decode a valid signature", async () => {
+    const value = `sig1=:wdsNx2jtTeDayCaf6wn1IKxdxuvUV2EZnbPhAVS9v1ZWAfyN0gbVRC1hi+0T7ysuHF6dHdxHB81ELTbe7tz3lzQbRMYn7FW+kjeT8CL+gb1hUHeWESvxlPgbd7xZxp0i:`;
+
+    const res = LollipopSignature.decode(value);
+
+    expect(res).toMatchObject(E.right(value));
+  });
+
+  it("should decode a valid multi-signature", async () => {
+    const value = `sig1=:wdsNx2jtTeDayCaf6wn1IKxdxuvUV2EZnbPhAVS9v1ZWAfyN0gbVRC1hi+0T7ysuHF6dHdxHB81ELTbe7tz3lzQbRMYn7FW+kjeT8CL+gb1hUHeWESvxlPgbd7xZxp0i:, sig2=:Y3p2rx43PYOwsvR/7xRK3ysbOwxVJQdhE3OSVhGDtrMWqsdfo6iDGL8HhyHVhdcE/GiLUsLKhYClJuNtWN46nHnKAz2OarVuhplQCxG/dxgA/b8jDddFjZuiJKi2n5d+:`;
+
+    const res = LollipopSignature.decode(value);
+
+    expect(res).toMatchObject(E.right(value));
+  });
+
+  it("should fail with an invalid signature", async () => {
+    const value = `:wdsNx2jtTeDayCaf6wn1IKxdxuvUV2EZnbPhAVS9v1ZWAfyN0gbVRC1hi+0T7ysuHF6dHdxHB81ELTbe7tz3lzQbRMYn7FW+kjeT8CL+gb1hUHeWESvxlPgbd7xZxp0i:, sig2=:Y3p2rx43PYOwsvR/7xRK3ysbOwxVJQdhE3OSVhGDtrMWqsdfo6iDGL8HhyHVhdcE/GiLUsLKhYClJuNtWN46nHnKAz2OarVuhplQCxG/dxgA/b8jDddFjZuiJKi2n5d+:`;
+
+    const res = LollipopSignature.decode(value);
+    expect(res).toMatchObject(E.left(expect.any(Array)));
+  });
+});

--- a/src/__tests__/lollipop.test.ts
+++ b/src/__tests__/lollipop.test.ts
@@ -25,7 +25,7 @@ describe("LollipopMethodHeader", () => {
 
 describe("LollipopOriginalURL", () => {
   it("should decode a valid url", async () => {
-    const value = "http://example.com/foo?param=value&pet=dog";
+    const value = "https://app-backend.io.italia.it/foo?param=value&pet=dog";
 
     const res = LollipopOriginalURL.decode(value);
 
@@ -33,7 +33,8 @@ describe("LollipopOriginalURL", () => {
   });
 
   it("should fail with an invalid URL", async () => {
-    const value = "http://example.com/foo/../foo2?param=value&pet=dog";
+    const value =
+      "https://app-backend.io.italia.it/foo/../foo2?param=value&pet=dog";
 
     const res = LollipopOriginalURL.decode(value);
     expect(res).toMatchObject(E.left(expect.any(Array)));

--- a/src/__tests__/lollipop.test.ts
+++ b/src/__tests__/lollipop.test.ts
@@ -60,8 +60,7 @@ describe("LollipopContentType", () => {
 describe("LollipopContentDigest", () => {
   it("should decode a valid digest", async () => {
     const value =
-      "sha-512=:WZDPaVn/7XgHaAy8pmojAkGWoRx2UFChF41A2svX+T\
-  aPm+AbwAgBWnrIiYllu7BNNyealdVLvRwEmTHWXvJwew==:";
+      "sha-512=:WZDPaVn/7XgHaAy8pmojAkGWoRx2UFChF41A2svX+TaPm+AbwAgBWnrIiYllu7BNNyealdVLvRwEmTHWXvJwew==:";
 
     const res = LollipopContentDigest.decode(value);
 
@@ -70,8 +69,7 @@ describe("LollipopContentDigest", () => {
 
   it("should fail with an invalid digest", async () => {
     const value =
-      ":WZDPaVn/7XgHaAy8pmojAkGWoRx2UFChF41A2svX+T\
-  aPm+AbwAgBWnrIiYllu7BNNyealdVLvRwEmTHWXvJwew==:";
+      ":WZDPaVn/7XgHaAy8pmojAkGWoRx2UFChF41A2svX+TaPm+AbwAgBWnrIiYllu7BNNyealdVLvRwEmTHWXvJwew==:";
 
     const res = LollipopContentDigest.decode(value);
     expect(res).toMatchObject(E.left(expect.any(Array)));


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->

- Added new `lollipop_definitions.yaml` in `openapi/generated`
- Added tests for verifying regex

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Enable LolliPoP endpoint definition.
Lollipop will require following header:

- `x-pagopa-lollipop-original-method` (custom)
-  `x-pagopa-lollipop-original-url` (custom)
- `content-type`
- `content-length`
- `content-digest`
- `signature-input` (it contains `nonce`, `alg` and `keyid` (the fingerprint) )

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Unit tests

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
