### PR TITLE
[#IOCIT-323] Add support for pubKey reservation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -148,3 +148,5 @@ FF_ROUTING_PUSH_NOTIF_CANARY_SHA_USERS_REGEX="XYZ"
 # LOLLIPOP
 # ------------------------------------
 LOLLIPOP_ALLOWED_USER_AGENTS=IOApp/2.23.0
+LOLLIPOP_API_KEY=put_your_api_key_here
+LOLLIPOP_API_URL="http://host.docker.internal:7078/api/v1"

--- a/.env.example
+++ b/.env.example
@@ -149,4 +149,5 @@ FF_ROUTING_PUSH_NOTIF_CANARY_SHA_USERS_REGEX="XYZ"
 # ------------------------------------
 LOLLIPOP_ALLOWED_USER_AGENTS=IOApp/2.23.0
 LOLLIPOP_API_KEY=put_your_api_key_here
+LOLLIPOP_API_BASE_PATH="api/v1"
 LOLLIPOP_API_URL="http://host.docker.internal:7078/api/v1"

--- a/.env.example
+++ b/.env.example
@@ -148,6 +148,7 @@ FF_ROUTING_PUSH_NOTIF_CANARY_SHA_USERS_REGEX="XYZ"
 # LOLLIPOP
 # ------------------------------------
 LOLLIPOP_ALLOWED_USER_AGENTS=IOApp/2.23.0
+FF_LOLLIPOP_ENABLED=true
 LOLLIPOP_API_KEY=put_your_api_key_here
 LOLLIPOP_API_BASE_PATH="api/v1"
 LOLLIPOP_API_URL="http://host.docker.internal:7078/api/v1"

--- a/README.md
+++ b/README.md
@@ -217,8 +217,8 @@ Those are all Environment variables needed by the application:
 | IO_SIGN_API_URL                        | The io-func-sign-user  URL                                                        | string  |
 | LOLLIPOP_ALLOWED_USER_AGENTS           | Pipe separated list of allowed user agents for Lollipop Login flow                | string  |
 | LOLLIPOP_API_KEY                       | The key used to authenticate to the io-function-lollipop API                      | string  |
-| LOLLIPOP_API_URL                       | The io-function-lollipop  URL                                                     | string  |
-
+| LOLLIPOP_API_URL                       | The io-function-lollipop URL                                                      | string  |
+| LOLLIPOP_API_BASE_PATH                 | The io-function-lollipop api base path                                            | string  |
 
 Notes:
 

--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ Those are all Environment variables needed by the application:
 | LOLLIPOP_API_KEY                       | The key used to authenticate to the io-function-lollipop API                      | string  |
 | LOLLIPOP_API_URL                       | The io-function-lollipop URL                                                      | string  |
 | LOLLIPOP_API_BASE_PATH                 | The io-function-lollipop api base path                                            | string  |
-| FF_LOLLIPOP_ENABLED                    | Enable Lollipop flows                                                             | boolean  |
+| FF_LOLLIPOP_ENABLED                    | (Optional) Enable Lollipop flows default false                                    | boolean |
 
 Notes:
 

--- a/README.md
+++ b/README.md
@@ -219,6 +219,7 @@ Those are all Environment variables needed by the application:
 | LOLLIPOP_API_KEY                       | The key used to authenticate to the io-function-lollipop API                      | string  |
 | LOLLIPOP_API_URL                       | The io-function-lollipop URL                                                      | string  |
 | LOLLIPOP_API_BASE_PATH                 | The io-function-lollipop api base path                                            | string  |
+| FF_LOLLIPOP_ENABLED                    | Enable Lollipop flows                                                             | boolean  |
 
 Notes:
 

--- a/README.md
+++ b/README.md
@@ -216,7 +216,8 @@ Those are all Environment variables needed by the application:
 | IO_SIGN_API_KEY                        | The key used to authenticate to the io-func-sign-user API                         | string  |
 | IO_SIGN_API_URL                        | The io-func-sign-user  URL                                                        | string  |
 | LOLLIPOP_ALLOWED_USER_AGENTS           | Pipe separated list of allowed user agents for Lollipop Login flow                | string  |
-
+| LOLLIPOP_API_KEY                       | The key used to authenticate to the io-function-lollipop API                      | string  |
+| LOLLIPOP_API_URL                       | The io-function-lollipop  URL                                                     | string  |
 
 
 Notes:

--- a/src/__mocks__/request.ts
+++ b/src/__mocks__/request.ts
@@ -5,6 +5,7 @@
 
 export default function mockReq({
   params = {},
+  headers = {},
   body = {},
   query = {}
 }: any = {}): any {
@@ -18,6 +19,7 @@ export default function mockReq({
     acceptsLanguages: jest.fn(),
     body,
     header: jest.fn(),
+    headers,
     is: jest.fn(),
     param: jest.fn(),
     params,

--- a/src/app.ts
+++ b/src/app.ts
@@ -78,7 +78,8 @@ import {
   FF_ROUTING_PUSH_NOTIF_BETA_TESTER_SHA_LIST,
   FF_ROUTING_PUSH_NOTIF,
   FF_ROUTING_PUSH_NOTIF_CANARY_SHA_USERS_REGEX,
-  LOLLIPOP_API_CLIENT
+  LOLLIPOP_API_CLIENT,
+  FF_LOLLIPOP_ENABLED
 } from "./config";
 import AuthenticationController from "./controllers/authenticationController";
 import MessagesController from "./controllers/messagesController";
@@ -677,7 +678,7 @@ export function newApp({
               doneCb: spidLogCallback,
               logout: _.acsController.slo.bind(_.acsController),
               lollipopMiddleware: toExpressMiddleware(
-                lollipopLoginHandler(LOLLIPOP_API_CLIENT)
+                lollipopLoginHandler(FF_LOLLIPOP_ENABLED, LOLLIPOP_API_CLIENT)
               ),
               redisClient: REDIS_CLIENT,
               samlConfig,

--- a/src/app.ts
+++ b/src/app.ts
@@ -77,7 +77,8 @@ import {
   IO_SIGN_API_CLIENT,
   FF_ROUTING_PUSH_NOTIF_BETA_TESTER_SHA_LIST,
   FF_ROUTING_PUSH_NOTIF,
-  FF_ROUTING_PUSH_NOTIF_CANARY_SHA_USERS_REGEX
+  FF_ROUTING_PUSH_NOTIF_CANARY_SHA_USERS_REGEX,
+  LOLLIPOP_API_CLIENT
 } from "./config";
 import AuthenticationController from "./controllers/authenticationController";
 import MessagesController from "./controllers/messagesController";
@@ -675,7 +676,9 @@ export function newApp({
               },
               doneCb: spidLogCallback,
               logout: _.acsController.slo.bind(_.acsController),
-              lollipopMiddleware: toExpressMiddleware(lollipopLoginHandler()),
+              lollipopMiddleware: toExpressMiddleware(
+                lollipopLoginHandler(LOLLIPOP_API_CLIENT)
+              ),
               redisClient: REDIS_CLIENT,
               samlConfig,
               serviceProviderConfig

--- a/src/config.ts
+++ b/src/config.ts
@@ -471,12 +471,10 @@ export const CGN_API_CLIENT = CgnAPIClient(
 );
 
 export const LOLLIPOP_API_KEY = getRequiredENVVar("LOLLIPOP_API_KEY");
-export const LOLLIPOP_API_URL = getRequiredENVVar("CGN_API_URL");
-export const LOLLIPOP_API_BASE_PATH = getRequiredENVVar("CGN_API_BASE_PATH");
+export const LOLLIPOP_API_URL = getRequiredENVVar("LOLLIPOP_API_URL");
 export const LOLLIPOP_API_CLIENT = LollipopApiClient(
   LOLLIPOP_API_KEY,
   LOLLIPOP_API_URL,
-  LOLLIPOP_API_BASE_PATH,
   httpOrHttpsApiFetch
 );
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -471,6 +471,7 @@ export const CGN_API_CLIENT = CgnAPIClient(
   httpOrHttpsApiFetch
 );
 
+export const FF_LOLLIPOP_ENABLED = process.env.FF_LOLLIPOP_ENABLED === "1";
 export const LOLLIPOP_API_KEY = getRequiredENVVar("LOLLIPOP_API_KEY");
 export const LOLLIPOP_API_URL = getRequiredENVVar("LOLLIPOP_API_URL");
 export const LOLLIPOP_API_BASE_PATH = getRequiredENVVar(

--- a/src/config.ts
+++ b/src/config.ts
@@ -404,6 +404,7 @@ const fetchWithTimeout = setFetchTimeout(
   DEFAULT_REQUEST_TIMEOUT_MS,
   abortableFetch
 );
+
 const httpOrHttpsApiFetch = toFetch(fetchWithTimeout);
 
 const bearerAuthFetch = (
@@ -472,9 +473,13 @@ export const CGN_API_CLIENT = CgnAPIClient(
 
 export const LOLLIPOP_API_KEY = getRequiredENVVar("LOLLIPOP_API_KEY");
 export const LOLLIPOP_API_URL = getRequiredENVVar("LOLLIPOP_API_URL");
+export const LOLLIPOP_API_BASE_PATH = getRequiredENVVar(
+  "LOLLIPOP_API_BASE_PATH"
+);
 export const LOLLIPOP_API_CLIENT = LollipopApiClient(
   LOLLIPOP_API_KEY,
   LOLLIPOP_API_URL,
+  LOLLIPOP_API_BASE_PATH,
   httpOrHttpsApiFetch
 );
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -62,6 +62,7 @@ import {
   CommaSeparatedListOf,
   PipeSeparatedListOf
 } from "./utils/separated-list";
+import { LollipopApiClient } from "./clients/lollipop";
 
 // Without this, the environment variables loaded by dotenv aren't available in
 // this file.
@@ -466,6 +467,16 @@ export const CGN_API_CLIENT = CgnAPIClient(
   CGN_API_KEY,
   CGN_API_URL,
   CGN_API_BASE_PATH,
+  httpOrHttpsApiFetch
+);
+
+export const LOLLIPOP_API_KEY = getRequiredENVVar("LOLLIPOP_API_KEY");
+export const LOLLIPOP_API_URL = getRequiredENVVar("CGN_API_URL");
+export const LOLLIPOP_API_BASE_PATH = getRequiredENVVar("CGN_API_BASE_PATH");
+export const LOLLIPOP_API_CLIENT = LollipopApiClient(
+  LOLLIPOP_API_KEY,
+  LOLLIPOP_API_URL,
+  LOLLIPOP_API_BASE_PATH,
   httpOrHttpsApiFetch
 );
 

--- a/src/handlers/__tests__/lollipop.test.ts
+++ b/src/handlers/__tests__/lollipop.test.ts
@@ -29,7 +29,7 @@ const aNewPubKey: NewPubKey = {
   version: 0 as NonNegativeNumber
 };
 
-const getJwkPubKeyInHeader = (jwk: JwkPubKey) =>
+const tokenizeJwk = (jwk: JwkPubKey) =>
   jose.base64url.encode(JSON.stringify(jwk));
 
 const buildResponse = <T>(statusCode: number, value: T) =>
@@ -50,9 +50,7 @@ describe("lollipopLoginHandler", () => {
 
   it("should not perform pubkey reservation if Lollipop FF is disabled", async () => {
     const req = mockReq();
-    req.headers[LOLLIPOP_PUB_KEY_HEADER_NAME] = getJwkPubKeyInHeader(
-      aJwkPubKey
-    );
+    req.headers[LOLLIPOP_PUB_KEY_HEADER_NAME] = tokenizeJwk(aJwkPubKey);
     req.headers[LOLLIPOP_PUB_KEY_HASHING_ALGO_HEADER_NAME] = "sha512";
     const result = await lollipopLoginHandler(
       false,
@@ -64,9 +62,7 @@ describe("lollipopLoginHandler", () => {
 
   it("should perform lollipop validation and pubkey reservation successfully if Lollipop pub key and algo headers are present", async () => {
     const req = mockReq();
-    req.headers[LOLLIPOP_PUB_KEY_HEADER_NAME] = getJwkPubKeyInHeader(
-      aJwkPubKey
-    );
+    req.headers[LOLLIPOP_PUB_KEY_HEADER_NAME] = tokenizeJwk(aJwkPubKey);
     req.headers[LOLLIPOP_PUB_KEY_HASHING_ALGO_HEADER_NAME] = "sha512";
     const result = await lollipopLoginHandler(true, lollipopApiClientMock)(req);
     expect(reservePubKeyMock).toHaveBeenCalledTimes(1);
@@ -81,9 +77,7 @@ describe("lollipopLoginHandler", () => {
 
   it("should perform lollipop validation and pubkey reservation successfully if Lollipop pub key is present with fallback on default hashing algorithm", async () => {
     const req = mockReq();
-    req.headers[LOLLIPOP_PUB_KEY_HEADER_NAME] = getJwkPubKeyInHeader(
-      aJwkPubKey
-    );
+    req.headers[LOLLIPOP_PUB_KEY_HEADER_NAME] = tokenizeJwk(aJwkPubKey);
     const result = await lollipopLoginHandler(true, lollipopApiClientMock)(req);
     expect(reservePubKeyMock).toHaveBeenCalledTimes(1);
     expect(reservePubKeyMock).toHaveBeenCalledWith({
@@ -104,9 +98,7 @@ describe("lollipopLoginHandler", () => {
 
   it("should return InternalServerError if reservePubKey cannot be parsed", async () => {
     const req = mockReq();
-    req.headers[LOLLIPOP_PUB_KEY_HEADER_NAME] = getJwkPubKeyInHeader(
-      aJwkPubKey
-    );
+    req.headers[LOLLIPOP_PUB_KEY_HEADER_NAME] = tokenizeJwk(aJwkPubKey);
     reservePubKeyMock.mockImplementationOnce(async () =>
       E.left("unparseable response")
     );
@@ -129,9 +121,7 @@ describe("lollipopLoginHandler", () => {
 
   it("should return a conflict error if pubKey is alredy reserved", async () => {
     const req = mockReq();
-    req.headers[LOLLIPOP_PUB_KEY_HEADER_NAME] = getJwkPubKeyInHeader(
-      aJwkPubKey
-    );
+    req.headers[LOLLIPOP_PUB_KEY_HEADER_NAME] = tokenizeJwk(aJwkPubKey);
     reservePubKeyMock.mockImplementationOnce(async () =>
       t.success(buildResponse(409, {}))
     );
@@ -154,9 +144,7 @@ describe("lollipopLoginHandler", () => {
 
   it("should return an internal server error if pubKey reservation fails", async () => {
     const req = mockReq();
-    req.headers[LOLLIPOP_PUB_KEY_HEADER_NAME] = getJwkPubKeyInHeader(
-      aJwkPubKey
-    );
+    req.headers[LOLLIPOP_PUB_KEY_HEADER_NAME] = tokenizeJwk(aJwkPubKey);
     reservePubKeyMock.mockImplementationOnce(async () =>
       t.success(buildResponse(500, {}))
     );
@@ -179,9 +167,7 @@ describe("lollipopLoginHandler", () => {
 
   it("should return an internal server error if pubKey reservation API is unreacheable", async () => {
     const req = mockReq();
-    req.headers[LOLLIPOP_PUB_KEY_HEADER_NAME] = getJwkPubKeyInHeader(
-      aJwkPubKey
-    );
+    req.headers[LOLLIPOP_PUB_KEY_HEADER_NAME] = tokenizeJwk(aJwkPubKey);
     reservePubKeyMock.mockRejectedValueOnce("Network Error");
     const result = await lollipopLoginHandler(true, lollipopApiClientMock)(req);
     expect(reservePubKeyMock).toHaveBeenCalledTimes(1);

--- a/src/handlers/__tests__/lollipop.test.ts
+++ b/src/handlers/__tests__/lollipop.test.ts
@@ -1,0 +1,174 @@
+import { NonNegativeNumber } from "@pagopa/ts-commons/lib/numbers";
+import * as t from "io-ts";
+import * as jose from "jose";
+import { AssertionRef } from "../../../generated/lollipop-api/AssertionRef";
+import { JwkPubKey } from "../../../generated/lollipop-api/JwkPubKey";
+import { NewPubKey } from "../../../generated/lollipop-api/NewPubKey";
+import { PubKeyStatusEnum } from "../../../generated/lollipop-api/PubKeyStatus";
+import { lollipopLoginHandler } from "../lollipop";
+import mockReq from "../../__mocks__/request";
+import {
+  LOLLIPOP_PUB_KEY_HASHING_ALGO_HEADER_NAME,
+  LOLLIPOP_PUB_KEY_HEADER_NAME
+} from "@pagopa/io-spid-commons/dist/types/lollipop";
+import { JwkPubKeyHashAlgorithmEnum } from "../../../generated/lollipop-api/JwkPubKeyHashAlgorithm";
+import { IResponseType } from "@pagopa/ts-commons/lib/requests";
+
+const aJwkPubKey: JwkPubKey = {
+  alg: "alg",
+  e: "e",
+  kty: "RSA",
+  n: "n"
+};
+const aNewPubKey: NewPubKey = {
+  assertion_ref: "sha256-123ac" as AssertionRef,
+  pub_key: aJwkPubKey,
+  status: PubKeyStatusEnum.PENDING,
+  ttl: 2 as NonNegativeNumber,
+  version: 0 as NonNegativeNumber
+};
+
+const getJwkPubKeyInHeader = (jwk: JwkPubKey) =>
+  jose.base64url.encode(JSON.stringify(jwk));
+
+const buildResponse = <T>(statusCode: number, value: T) =>
+  ({
+    headers: {},
+    status: statusCode,
+    value
+  } as IResponseType<number, T, never>);
+const reservePubKeyMock = jest
+  .fn()
+  .mockImplementation(async () => t.success(buildResponse(201, aNewPubKey)));
+const lollipopApiClientMock = {
+  reservePubKey: reservePubKeyMock
+} as any;
+
+describe("lollipopLoginHandler", () => {
+  afterEach(() => jest.clearAllMocks());
+  it("should perform lollipop validation and pubkey reservation successfully if Lollipop pub key and algo headers are present", async () => {
+    const req = mockReq();
+    req.headers[LOLLIPOP_PUB_KEY_HEADER_NAME] = getJwkPubKeyInHeader(
+      aJwkPubKey
+    );
+    req.headers[LOLLIPOP_PUB_KEY_HASHING_ALGO_HEADER_NAME] = "sha512";
+    const result = await lollipopLoginHandler(lollipopApiClientMock)(req);
+    expect(reservePubKeyMock).toHaveBeenCalledTimes(1);
+    expect(reservePubKeyMock).toHaveBeenCalledWith({
+      body: {
+        algo: JwkPubKeyHashAlgorithmEnum.sha512,
+        pub_key: aJwkPubKey
+      }
+    });
+    expect(result).toBeUndefined();
+  });
+
+  it("should perform lollipop validation and pubkey reservation successfully if Lollipop pub key is present with fallback on default hashing algorithm", async () => {
+    const req = mockReq();
+    req.headers[LOLLIPOP_PUB_KEY_HEADER_NAME] = getJwkPubKeyInHeader(
+      aJwkPubKey
+    );
+    const result = await lollipopLoginHandler(lollipopApiClientMock)(req);
+    expect(reservePubKeyMock).toHaveBeenCalledTimes(1);
+    expect(reservePubKeyMock).toHaveBeenCalledWith({
+      body: {
+        algo: JwkPubKeyHashAlgorithmEnum.sha256,
+        pub_key: aJwkPubKey
+      }
+    });
+    expect(result).toBeUndefined();
+  });
+
+  it("should not perform lollipop validation and pubkey reservation if no lollipop headers are present", async () => {
+    const req = mockReq();
+    const result = await lollipopLoginHandler(lollipopApiClientMock)(req);
+    expect(reservePubKeyMock).not.toHaveBeenCalled();
+    expect(result).toBeUndefined();
+  });
+
+  it("should return InternalServerError if reservePubKey cannot be parsed", async () => {
+    const req = mockReq();
+    req.headers[LOLLIPOP_PUB_KEY_HEADER_NAME] = getJwkPubKeyInHeader(
+      aJwkPubKey
+    );
+    reservePubKeyMock.mockRejectedValueOnce(new Error("network error"));
+    const result = await lollipopLoginHandler(lollipopApiClientMock)(req);
+    expect(reservePubKeyMock).toHaveBeenCalledTimes(1);
+    expect(reservePubKeyMock).toHaveBeenCalledWith({
+      body: {
+        algo: JwkPubKeyHashAlgorithmEnum.sha256,
+        pub_key: aJwkPubKey
+      }
+    });
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        kind: "IResponseErrorInternal",
+        detail: "Internal server error: Cannot parse reserve response"
+      })
+    );
+  });
+
+  it("should return a conflict error if pubKey is alredy reserved", async () => {
+    const req = mockReq();
+    req.headers[LOLLIPOP_PUB_KEY_HEADER_NAME] = getJwkPubKeyInHeader(
+      aJwkPubKey
+    );
+    reservePubKeyMock.mockImplementationOnce(async () =>
+      t.success(buildResponse(409, {}))
+    );
+    const result = await lollipopLoginHandler(lollipopApiClientMock)(req);
+    expect(reservePubKeyMock).toHaveBeenCalledTimes(1);
+    expect(reservePubKeyMock).toHaveBeenCalledWith({
+      body: {
+        algo: JwkPubKeyHashAlgorithmEnum.sha256,
+        pub_key: aJwkPubKey
+      }
+    });
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        kind: "IResponseErrorConflict",
+        detail: "Conflict: PubKey is already reserved"
+      })
+    );
+  });
+
+  it("should return an internal server error if pubKey reservation fails", async () => {
+    const req = mockReq();
+    req.headers[LOLLIPOP_PUB_KEY_HEADER_NAME] = getJwkPubKeyInHeader(
+      aJwkPubKey
+    );
+    reservePubKeyMock.mockImplementationOnce(async () =>
+      t.success(buildResponse(500, {}))
+    );
+    const result = await lollipopLoginHandler(lollipopApiClientMock)(req);
+    expect(reservePubKeyMock).toHaveBeenCalledTimes(1);
+    expect(reservePubKeyMock).toHaveBeenCalledWith({
+      body: {
+        algo: JwkPubKeyHashAlgorithmEnum.sha256,
+        pub_key: aJwkPubKey
+      }
+    });
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        kind: "IResponseErrorInternal",
+        detail: "Internal server error: Cannot reserve pubKey"
+      })
+    );
+  });
+
+  it("should return a validation error if request is not well formed", async () => {
+    const req = mockReq();
+    req.headers[LOLLIPOP_PUB_KEY_HEADER_NAME] = "wrong jwk";
+    const result = await lollipopLoginHandler(lollipopApiClientMock)(req);
+    expect(reservePubKeyMock).not.toHaveBeenCalled();
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        kind: "IResponseErrorValidation"
+      })
+    );
+  });
+});

--- a/src/handlers/lollipop.ts
+++ b/src/handlers/lollipop.ts
@@ -19,10 +19,10 @@ import {
   ResponseErrorInternal
 } from "@pagopa/ts-commons/lib/responses";
 import { LollipopApiClient } from "src/clients/lollipop";
-import { JwkPubKeyHashAlgorithmEnum } from "generated/lollipop-api/JwkPubKeyHashAlgorithm";
-import { errorsToError } from "src/utils/errorsFormatter";
-import { NewPubKey } from "generated/lollipop-api/NewPubKey";
 import { IResponseType } from "@pagopa/ts-commons/lib/requests";
+import { errorsToError } from "../utils/errorsFormatter";
+import { JwkPubKeyHashAlgorithmEnum } from "../../generated/lollipop-api/JwkPubKeyHashAlgorithm";
+import { NewPubKey } from "../../generated/lollipop-api/NewPubKey";
 import { withValidatedOrValidationError } from "../utils/responses";
 
 /**
@@ -59,7 +59,8 @@ export const lollipopLoginHandler = (
         pipe(
           req.headers[LOLLIPOP_PUB_KEY_HASHING_ALGO_HEADER_NAME],
           O.fromNullable,
-          O.chainNullableK(() => DEFAULT_LOLLIPOP_HASH_ALGORITHM),
+          O.getOrElseW(() => DEFAULT_LOLLIPOP_HASH_ALGORITHM),
+          O.of,
           O.map(LollipopHashAlgorithm.decode)
         )
       ),
@@ -81,7 +82,7 @@ export const lollipopLoginHandler = (
             E.toError
           ),
           TE.mapLeft(() =>
-            ResponseErrorInternal("Error while calling pubKey reservation")
+            ResponseErrorInternal("Error while calling reservePubKey API")
           ),
           TE.chainEitherKW(E.mapLeft(errorsToError)),
           TE.mapLeft(() =>

--- a/src/handlers/lollipop.ts
+++ b/src/handlers/lollipop.ts
@@ -1,13 +1,28 @@
-import { LOLLIPOP_PUB_KEY_HEADER_NAME } from "@pagopa/io-spid-commons/dist/types/lollipop";
+import {
+  DEFAULT_LOLLIPOP_HASH_ALGORITHM,
+  LollipopHashAlgorithm,
+  LOLLIPOP_PUB_KEY_HASHING_ALGO_HEADER_NAME,
+  LOLLIPOP_PUB_KEY_HEADER_NAME
+} from "@pagopa/io-spid-commons/dist/types/lollipop";
 import { JwkPublicKeyFromToken } from "@pagopa/ts-commons/lib/jwk";
 import * as express from "express";
-import { pipe } from "fp-ts/lib/function";
+import { constUndefined, flow, pipe } from "fp-ts/lib/function";
 import * as O from "fp-ts/lib/Option";
 import * as E from "fp-ts/lib/Either";
+import * as A from "fp-ts/lib/Apply";
+import * as TE from "fp-ts/lib/TaskEither";
 import {
+  IResponseErrorConflict,
   IResponseErrorInternal,
-  IResponseErrorValidation
+  IResponseErrorValidation,
+  ResponseErrorConflict,
+  ResponseErrorInternal
 } from "@pagopa/ts-commons/lib/responses";
+import { LollipopApiClient } from "src/clients/lollipop";
+import { JwkPubKeyHashAlgorithmEnum } from "generated/lollipop-api/JwkPubKeyHashAlgorithm";
+import { errorsToError } from "src/utils/errorsFormatter";
+import { NewPubKey } from "generated/lollipop-api/NewPubKey";
+import { IResponseType } from "@pagopa/ts-commons/lib/requests";
 import { withValidatedOrValidationError } from "../utils/responses";
 
 /**
@@ -20,17 +35,67 @@ import { withValidatedOrValidationError } from "../utils/responses";
  * 5. Reserve fingerprint (store pubKey)
  */
 
-export const lollipopLoginHandler = () => async (
+const isReservePubKeyResponseSuccess = (
+  res: IResponseType<number, unknown>
+): res is IResponseType<201, NewPubKey> => res.status === 201;
+
+export const lollipopLoginHandler = (
+  lollipopApiClient: ReturnType<LollipopApiClient>
+) => async (
   req: express.Request
-): Promise<IResponseErrorValidation | IResponseErrorInternal | undefined> =>
+): Promise<
+  | IResponseErrorValidation
+  | IResponseErrorInternal
+  | IResponseErrorConflict
+  | undefined
+> =>
   withValidatedOrValidationError(
     pipe(
       req.headers[LOLLIPOP_PUB_KEY_HEADER_NAME],
       O.fromNullable,
       O.map(JwkPublicKeyFromToken.decode),
+      O.bindTo("jwk"),
+      O.bind("algo", () =>
+        pipe(
+          req.headers[LOLLIPOP_PUB_KEY_HASHING_ALGO_HEADER_NAME],
+          O.fromNullable,
+          O.chainNullableK(() => DEFAULT_LOLLIPOP_HASH_ALGORITHM),
+          O.map(LollipopHashAlgorithm.decode)
+        )
+      ),
+      O.map(A.sequenceS(E.Applicative)),
       O.getOrElseW(() => E.right(void 0))
     ),
-    _ =>
-      // TODO: Not yet implemented
-      void 0
+    flow(
+      O.fromNullable,
+      O.map(({ algo, jwk }) =>
+        pipe(
+          TE.tryCatch(
+            () =>
+              lollipopApiClient.reservePubKey({
+                body: {
+                  algo: JwkPubKeyHashAlgorithmEnum[algo],
+                  pub_key: jwk
+                }
+              }),
+            E.toError
+          ),
+          TE.mapLeft(() =>
+            ResponseErrorInternal("Error while calling pubKey reservation")
+          ),
+          TE.chainEitherKW(E.mapLeft(errorsToError)),
+          TE.mapLeft(() =>
+            ResponseErrorInternal("Cannot parse reserve response")
+          ),
+          TE.filterOrElseW(isReservePubKeyResponseSuccess, errorResponse =>
+            errorResponse.status === 409
+              ? ResponseErrorConflict("PubKey is already reserved")
+              : ResponseErrorInternal("Cannot reserve pubKey")
+          ),
+          TE.map(constUndefined),
+          TE.toUnion
+        )()
+      ),
+      O.toUndefined
+    )
   );

--- a/src/handlers/lollipop.ts
+++ b/src/handlers/lollipop.ts
@@ -20,7 +20,6 @@ import {
 } from "@pagopa/ts-commons/lib/responses";
 import { LollipopApiClient } from "src/clients/lollipop";
 import { IResponseType } from "@pagopa/ts-commons/lib/requests";
-import { errorsToError } from "../utils/errorsFormatter";
 import { JwkPubKeyHashAlgorithmEnum } from "../../generated/lollipop-api/JwkPubKeyHashAlgorithm";
 import { NewPubKey } from "../../generated/lollipop-api/NewPubKey";
 import { withValidatedOrValidationError } from "../utils/responses";
@@ -84,10 +83,12 @@ export const lollipopLoginHandler = (
           TE.mapLeft(() =>
             ResponseErrorInternal("Error while calling reservePubKey API")
           ),
-          TE.chainEitherKW(E.mapLeft(errorsToError)),
-          TE.mapLeft(() =>
-            ResponseErrorInternal("Cannot parse reserve response")
+          TE.chainEitherKW(
+            E.mapLeft(() =>
+              ResponseErrorInternal("Cannot parse reserve response")
+            )
           ),
+
           TE.filterOrElseW(isReservePubKeyResponseSuccess, errorResponse =>
             errorResponse.status === 409
               ? ResponseErrorConflict("PubKey is already reserved")


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->
- Refactoring `lollipop` middleware on login flow
- Add Feature flag to enable/disable Lollipop flows globally
- Add Unit tests
- Add io-fn-lollipop env config variables
- Update README
- Update env.example
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This is required in order to accomplish client's public key reservation in the login flow, enabling lollipop activation's first step

This PR depends on https://github.com/pagopa/io-infra/pull/447
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Unit test
#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
