### PR TITLE
[#IOCIT-320] RedisSessionStorage can manage CF-assertionRef link for lollipop

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -79,7 +79,8 @@ import {
   FF_ROUTING_PUSH_NOTIF,
   FF_ROUTING_PUSH_NOTIF_CANARY_SHA_USERS_REGEX,
   LOLLIPOP_API_CLIENT,
-  FF_LOLLIPOP_ENABLED
+  FF_LOLLIPOP_ENABLED,
+  DEFAULT_LOLLIPOP_ASSERTION_REF_DURATION
 } from "./config";
 import AuthenticationController from "./controllers/authenticationController";
 import MessagesController from "./controllers/messagesController";
@@ -244,7 +245,8 @@ export function newApp({
   // Create the Session Storage service
   const SESSION_STORAGE = new RedisSessionStorage(
     REDIS_CLIENT,
-    tokenDurationSecs
+    tokenDurationSecs,
+    DEFAULT_LOLLIPOP_ASSERTION_REF_DURATION
   );
   // Setup Passport.
   // Add the strategy to authenticate proxy clients.

--- a/src/config.ts
+++ b/src/config.ts
@@ -251,6 +251,11 @@ log.info(
   IDP_METADATA_REFRESH_INTERVAL_SECONDS
 );
 
+// LolliPoP protocol configuration params
+export const DEFAULT_LOLLIPOP_ASSERTION_REF_DURATION = (3600 *
+  24 *
+  365 *
+  2) as Second; // 2y default assertionRef duration on redis cache
 export const LOLLIPOP_ALLOWED_USER_AGENTS = pipe(
   process.env.LOLLIPOP_ALLOWED_USER_AGENTS,
   PipeSeparatedListOf(SemverFromFromUserAgentString).decode,
@@ -260,6 +265,8 @@ export const LOLLIPOP_ALLOWED_USER_AGENTS = pipe(
     );
   })
 );
+
+// Spid/Cie Service Provider Config.
 export const serviceProviderConfig: IServiceProviderConfig = {
   IDPMetadataUrl: IDP_METADATA_URL,
   lollipopProviderConfig: pipe(

--- a/src/controllers/__tests__/authenticationController.test.ts
+++ b/src/controllers/__tests__/authenticationController.test.ts
@@ -46,6 +46,7 @@ import { addDays, addMonths, format, subYears } from "date-fns";
 import { getClientErrorRedirectionUrl } from "../../config";
 import * as appInsights from "applicationinsights";
 import { FiscalCode } from "@pagopa/ts-commons/lib/strings";
+import { Second } from "@pagopa/ts-commons/lib/units";
 
 // validUser has all every field correctly set.
 const validUserPayload = {
@@ -147,9 +148,11 @@ const redisClient = {} as redis.RedisClient;
 const tokenService = new TokenService();
 
 const tokenDurationSecs = 0;
+const aDefaultLollipopAssertionRefDurationSec = (3600 * 24 * 365 * 2) as Second;
 const redisSessionStorage = new RedisSessionStorage(
   redisClient,
-  tokenDurationSecs
+  tokenDurationSecs,
+  aDefaultLollipopAssertionRefDurationSec
 );
 
 const getClientProfileRedirectionUrl = (token: string): UrlFromString => {

--- a/src/controllers/__tests__/notificationController.test.ts
+++ b/src/controllers/__tests__/notificationController.test.ts
@@ -21,6 +21,7 @@ import {
 } from "../../__mocks__/user_mock";
 import { MessageSubject } from "../../../generated/notifications/MessageSubject";
 import * as redis from "redis";
+import { Second } from "@pagopa/ts-commons/lib/units";
 
 const aTimestamp = 1518010929530;
 const aFiscalNumber = "GRBGPP87L04L741X" as FiscalCode;
@@ -109,9 +110,11 @@ jest.mock("../../services/redisSessionStorage");
 const redisClient = {} as redis.RedisClient;
 
 const tokenDurationSecs = 0;
+const aDefaultLollipopAssertionRefDurationSec = (3600 * 24 * 365 * 2) as Second;
 const redisSessionStorage = new RedisSessionStorage(
   redisClient,
-  tokenDurationSecs
+  tokenDurationSecs,
+  aDefaultLollipopAssertionRefDurationSec
 );
 
 const mockUserHasActiveSessions = (redisSessionStorage.userHasActiveSessions = jest.fn());

--- a/src/controllers/__tests__/pagoPAController.test.ts
+++ b/src/controllers/__tests__/pagoPAController.test.ts
@@ -1,6 +1,5 @@
 import * as redis from "redis";
 
-
 import { PagoPAUser } from "../../../generated/pagopa/PagoPAUser";
 
 import mockReq from "../../__mocks__/request";
@@ -12,7 +11,12 @@ import ProfileService from "../../services/profileService";
 import RedisSessionStorage from "../../services/redisSessionStorage";
 import { User } from "../../types/user";
 import PagoPAController from "../pagoPAController";
-import { aCustomEmailAddress, mockedInitializedProfile, mockedUser } from "../../__mocks__/user_mock";
+import {
+  aCustomEmailAddress,
+  mockedInitializedProfile,
+  mockedUser
+} from "../../__mocks__/user_mock";
+import { Second } from "@pagopa/ts-commons/lib/units";
 
 const proxyUserResponse: PagoPAUser = {
   family_name: mockedUser.family_name,
@@ -53,9 +57,11 @@ jest.mock("../../services/profileService", () => {
 const redisClient = {} as redis.RedisClient;
 
 const tokenDurationSecs = 0;
+const aDefaultLollipopAssertionRefDurationSec = (3600 * 24 * 365 * 2) as Second;
 const redisSessionStorage = new RedisSessionStorage(
   redisClient,
-  tokenDurationSecs
+  tokenDurationSecs,
+  aDefaultLollipopAssertionRefDurationSec
 );
 
 describe("PagoPaController#getUser", () => {

--- a/src/controllers/__tests__/profileController.test.ts
+++ b/src/controllers/__tests__/profileController.test.ts
@@ -29,6 +29,7 @@ import { ServicesPreferencesModeEnum } from "../../../generated/backend/Services
 import { AppVersion } from "../../../generated/backend/AppVersion";
 import { PushNotificationsContentTypeEnum } from "../../../generated/backend/PushNotificationsContentType";
 import { ReminderStatusEnum } from "../../../generated/backend/ReminderStatus";
+import { Second } from "@pagopa/ts-commons/lib/units";
 
 const aTimestamp = 1518010929530;
 
@@ -118,9 +119,11 @@ jest.mock("../../services/redisSessionStorage", () => {
 const redisClient = {} as redis.RedisClient;
 
 const tokenDurationSecs = 0;
+const aDefaultLollipopAssertionRefDurationSec = (3600 * 24 * 365 * 2) as Second;
 const redisSessionStorage = new RedisSessionStorage(
   redisClient,
-  tokenDurationSecs
+  tokenDurationSecs,
+  aDefaultLollipopAssertionRefDurationSec
 );
 
 describe("ProfileController#getProfile", () => {

--- a/src/controllers/__tests__/sessionController.test.ts
+++ b/src/controllers/__tests__/sessionController.test.ts
@@ -21,8 +21,10 @@ import ApiClient from "../../services/apiClientFactory";
 import ProfileService from "../../services/profileService";
 import { ResponseSuccessJson } from "@pagopa/ts-commons/lib/responses";
 import * as crypto from "crypto";
+import { Second } from "@pagopa/ts-commons/lib/units";
 
 const aTokenDurationSecs = 3600;
+const aDefaultLollipopAssertionRefDurationSec = (3600 * 24 * 365 * 2) as Second;
 const mockGet = jest.fn();
 const mockSet = jest.fn();
 const mockMget = jest.fn();
@@ -61,7 +63,11 @@ const tokenService = new TokenService();
 const mockGetNewToken = jest.spyOn(tokenService, "getNewToken");
 
 const controller = new SessionController(
-  new RedisSessionStorage(mockRedisClient, aTokenDurationSecs),
+  new RedisSessionStorage(
+    mockRedisClient,
+    aTokenDurationSecs,
+    aDefaultLollipopAssertionRefDurationSec
+  ),
   tokenService,
   profileService
 );

--- a/src/services/ISessionStorage.ts
+++ b/src/services/ISessionStorage.ts
@@ -96,7 +96,7 @@ export interface ISessionStorage {
    * @param user The AppUser value used to get the related fiscalCode
    */
   readonly delLollipopAssertionRefForUser: (
-    user: UserV5
+    fiscalCode: FiscalCode
   ) => Promise<Either<Error, boolean>>;
 
   /**

--- a/src/services/ISessionStorage.ts
+++ b/src/services/ISessionStorage.ts
@@ -93,7 +93,7 @@ export interface ISessionStorage {
   /**
    * Delete the Lollipop assertionRef related to an user
    *
-   * @param user The AppUser value used to get the related fiscalCode
+   * @param fiscalCode A user fiscal code
    */
   readonly delLollipopAssertionRefForUser: (
     fiscalCode: FiscalCode

--- a/src/services/ISessionStorage.ts
+++ b/src/services/ISessionStorage.ts
@@ -5,6 +5,8 @@
 import { Either } from "fp-ts/lib/Either";
 import { Option } from "fp-ts/lib/Option";
 import { EmailString, FiscalCode } from "@pagopa/ts-commons/lib/strings";
+import { Second } from "@pagopa/ts-commons/lib/units";
+import { AssertionRef } from "../../generated/lollipop-api/AssertionRef";
 import {
   BPDToken,
   FIMSToken,
@@ -65,6 +67,37 @@ export interface ISessionStorage {
   readonly getByFIMSToken: (
     token: FIMSToken
   ) => Promise<Either<Error, Option<User>>>;
+
+  /**
+   * Retrieve the LolliPoP assertionRef related to an user
+   *
+   * @param user The AppUser value used to get the related fiscalCode
+   */
+  readonly getLollipopAssertionRefForUser: (
+    user: UserV5
+  ) => Promise<Either<Error, AssertionRef>>;
+
+  /**
+   * Upsert the LolliPoP assertionRef related to an user
+   *
+   * @param user The AppUser value used to get the related fiscalCode
+   * @param assertionRef The identifier for the pubkey
+   * @param expireAssertionRefSec The ttl for the key, default value is configured in RedisSessionStorage instance
+   */
+  readonly setLollipopAssertionRefForUser: (
+    user: UserV5,
+    assertionRef: AssertionRef,
+    expireAssertionRefSec?: Second
+  ) => Promise<Either<Error, boolean>>;
+
+  /**
+   * Delete the Lollipop assertionRef related to an user
+   *
+   * @param user The AppUser value used to get the related fiscalCode
+   */
+  readonly delLollipopAssertionRefForUser: (
+    user: UserV5
+  ) => Promise<Either<Error, boolean>>;
 
   /**
    * Removes a value from the cache.

--- a/src/services/__tests__/redisSessionStorage.test.ts
+++ b/src/services/__tests__/redisSessionStorage.test.ts
@@ -1643,7 +1643,10 @@ describe("RedisSessionStorage#getLollipopAssertionRefForUser", () => {
     );
 
     expect(mockGet).toHaveBeenCalledTimes(1);
-    expect(mockGet.mock.calls[0][0]).toBe(`KEYS-${aValidUser.fiscal_code}`);
+    expect(mockGet).toBeCalledWith(
+      `KEYS-${aValidUser.fiscal_code}`,
+      expect.any(Function)
+    );
     expect(E.isRight(response)).toBeTruthy();
     if (E.isRight(response)) expect(response.right).toEqual(anAssertionRef);
   });
@@ -1656,7 +1659,10 @@ describe("RedisSessionStorage#getLollipopAssertionRefForUser", () => {
     );
 
     expect(mockGet).toHaveBeenCalledTimes(1);
-    expect(mockGet.mock.calls[0][0]).toBe(`KEYS-${aValidUser.fiscal_code}`);
+    expect(mockGet).toBeCalledWith(
+      `KEYS-${aValidUser.fiscal_code}`,
+      expect.any(Function)
+    );
     expect(E.isLeft(response)).toBeTruthy();
     if (E.isLeft(response)) expect(response.left).toEqual(expectedError);
   });
@@ -1670,7 +1676,10 @@ describe("RedisSessionStorage#getLollipopAssertionRefForUser", () => {
     );
 
     expect(mockGet).toHaveBeenCalledTimes(1);
-    expect(mockGet.mock.calls[0][0]).toBe(`KEYS-${aValidUser.fiscal_code}`);
+    expect(mockGet).toBeCalledWith(
+      `KEYS-${aValidUser.fiscal_code}`,
+      expect.any(Function)
+    );
     expect(E.isLeft(response)).toBeTruthy();
   });
 });
@@ -1686,11 +1695,12 @@ describe("RedisSessionStorage#setLollipopAssertionRefForUser", () => {
     );
 
     expect(mockSet).toHaveBeenCalledTimes(1);
-    expect(mockSet.mock.calls[0][0]).toBe(`KEYS-${aValidUser.fiscal_code}`);
-    expect(mockSet.mock.calls[0][1]).toBe(anAssertionRef);
-    expect(mockSet.mock.calls[0][2]).toBe("EX");
-    expect(mockSet.mock.calls[0][3]).toBe(
-      aDefaultLollipopAssertionRefDurationSec
+    expect(mockSet).toBeCalledWith(
+      `KEYS-${aValidUser.fiscal_code}`,
+      anAssertionRef,
+      "EX",
+      aDefaultLollipopAssertionRefDurationSec,
+      expect.any(Function)
     );
     expect(E.isRight(response)).toBeTruthy();
     if (E.isRight(response)) expect(response.right).toEqual(true);
@@ -1708,10 +1718,13 @@ describe("RedisSessionStorage#setLollipopAssertionRefForUser", () => {
     );
 
     expect(mockSet).toHaveBeenCalledTimes(1);
-    expect(mockSet.mock.calls[0][0]).toBe(`KEYS-${aValidUser.fiscal_code}`);
-    expect(mockSet.mock.calls[0][1]).toBe(anAssertionRef);
-    expect(mockSet.mock.calls[0][2]).toBe("EX");
-    expect(mockSet.mock.calls[0][3]).toBe(expectedAssertionRefTtl);
+    expect(mockSet).toBeCalledWith(
+      `KEYS-${aValidUser.fiscal_code}`,
+      anAssertionRef,
+      "EX",
+      expectedAssertionRefTtl,
+      expect.any(Function)
+    );
     expect(E.isRight(response)).toBeTruthy();
     if (E.isRight(response)) expect(response.right).toEqual(true);
   });
@@ -1727,11 +1740,12 @@ describe("RedisSessionStorage#setLollipopAssertionRefForUser", () => {
     );
 
     expect(mockSet).toHaveBeenCalledTimes(1);
-    expect(mockSet.mock.calls[0][0]).toBe(`KEYS-${aValidUser.fiscal_code}`);
-    expect(mockSet.mock.calls[0][1]).toBe(anAssertionRef);
-    expect(mockSet.mock.calls[0][2]).toBe("EX");
-    expect(mockSet.mock.calls[0][3]).toBe(
-      aDefaultLollipopAssertionRefDurationSec
+    expect(mockSet).toBeCalledWith(
+      `KEYS-${aValidUser.fiscal_code}`,
+      anAssertionRef,
+      "EX",
+      aDefaultLollipopAssertionRefDurationSec,
+      expect.any(Function)
     );
     expect(E.isLeft(response)).toBeTruthy();
     if (E.isLeft(response)) expect(response.left).toEqual(expectedError);
@@ -1747,11 +1761,12 @@ describe("RedisSessionStorage#setLollipopAssertionRefForUser", () => {
     );
 
     expect(mockSet).toHaveBeenCalledTimes(1);
-    expect(mockSet.mock.calls[0][0]).toBe(`KEYS-${aValidUser.fiscal_code}`);
-    expect(mockSet.mock.calls[0][1]).toBe(anAssertionRef);
-    expect(mockSet.mock.calls[0][2]).toBe("EX");
-    expect(mockSet.mock.calls[0][3]).toBe(
-      aDefaultLollipopAssertionRefDurationSec
+    expect(mockSet).toBeCalledWith(
+      `KEYS-${aValidUser.fiscal_code}`,
+      anAssertionRef,
+      "EX",
+      aDefaultLollipopAssertionRefDurationSec,
+      expect.any(Function)
     );
     expect(E.isLeft(response)).toBeTruthy();
   });
@@ -1765,7 +1780,10 @@ describe("RedisSessionStorage#delLollipopAssertionRefForUser", () => {
     );
 
     expect(mockDel).toHaveBeenCalledTimes(1);
-    expect(mockDel.mock.calls[0][0]).toBe(`KEYS-${aValidUser.fiscal_code}`);
+    expect(mockDel).toBeCalledWith(
+      `KEYS-${aValidUser.fiscal_code}`,
+      expect.any(Function)
+    );
     expect(E.isRight(response)).toBeTruthy();
     if (E.isRight(response)) expect(response.right).toEqual(true);
   });
@@ -1778,7 +1796,10 @@ describe("RedisSessionStorage#delLollipopAssertionRefForUser", () => {
     );
 
     expect(mockDel).toHaveBeenCalledTimes(1);
-    expect(mockDel.mock.calls[0][0]).toBe(`KEYS-${aValidUser.fiscal_code}`);
+    expect(mockDel).toBeCalledWith(
+      `KEYS-${aValidUser.fiscal_code}`,
+      expect.any(Function)
+    );
     expect(E.isLeft(response)).toBeTruthy();
     if (E.isLeft(response)) expect(response.left).toEqual(expectedError);
   });
@@ -1790,7 +1811,10 @@ describe("RedisSessionStorage#delLollipopAssertionRefForUser", () => {
     );
 
     expect(mockDel).toHaveBeenCalledTimes(1);
-    expect(mockDel.mock.calls[0][0]).toBe(`KEYS-${aValidUser.fiscal_code}`);
+    expect(mockDel).toBeCalledWith(
+      `KEYS-${aValidUser.fiscal_code}`,
+      expect.any(Function)
+    );
     expect(E.isRight(response)).toBeTruthy();
     if (E.isRight(response)) expect(response.right).toEqual(true);
   });

--- a/src/services/__tests__/redisSessionStorage.test.ts
+++ b/src/services/__tests__/redisSessionStorage.test.ts
@@ -1776,7 +1776,7 @@ describe("RedisSessionStorage#delLollipopAssertionRefForUser", () => {
   it("should return a right either with true value on success", async () => {
     mockDel.mockImplementationOnce((_, callback) => callback(null, 1));
     const response = await sessionStorage.delLollipopAssertionRefForUser(
-      aValidUser
+      aValidUser.fiscal_code
     );
 
     expect(mockDel).toHaveBeenCalledTimes(1);
@@ -1792,7 +1792,7 @@ describe("RedisSessionStorage#delLollipopAssertionRefForUser", () => {
     const expectedError = new Error("redis Error");
     mockDel.mockImplementationOnce((_, callback) => callback(expectedError));
     const response = await sessionStorage.delLollipopAssertionRefForUser(
-      aValidUser
+      aValidUser.fiscal_code
     );
 
     expect(mockDel).toHaveBeenCalledTimes(1);
@@ -1807,7 +1807,7 @@ describe("RedisSessionStorage#delLollipopAssertionRefForUser", () => {
   it("should success if no element are removed from redis", async () => {
     mockDel.mockImplementationOnce((_, callback) => callback(null, 0));
     const response = await sessionStorage.delLollipopAssertionRefForUser(
-      aValidUser
+      aValidUser.fiscal_code
     );
 
     expect(mockDel).toHaveBeenCalledTimes(1);

--- a/src/services/__tests__/redisSessionStorage.test.ts
+++ b/src/services/__tests__/redisSessionStorage.test.ts
@@ -39,6 +39,7 @@ import {
   mockWalletToken,
   mockZendeskToken
 } from "../../__mocks__/user_mock";
+import { Second } from "@pagopa/ts-commons/lib/units";
 
 // utils that extracts the last argument as callback and calls it
 const callCallback = (err: any, value?: any) => (...args: readonly any[]) => {
@@ -47,6 +48,7 @@ const callCallback = (err: any, value?: any) => (...args: readonly any[]) => {
 };
 
 const aTokenDurationSecs = 3600;
+const aDefaultLollipopAssertionRefDurationSec = (3600 * 24 * 365 * 2) as Second;
 const theCurrentTimestampMillis = 1518010929530;
 
 const aFiscalCode = "GRBGPP87L04L741X" as FiscalCode;
@@ -119,7 +121,8 @@ mockRedisClient.ttl = mockTtl;
 
 const sessionStorage = new RedisSessionStorage(
   mockRedisClient,
-  aTokenDurationSecs
+  aTokenDurationSecs,
+  aDefaultLollipopAssertionRefDurationSec
 );
 
 let clock: any;

--- a/src/services/__tests__/redisSessionStorage.test.ts
+++ b/src/services/__tests__/redisSessionStorage.test.ts
@@ -1758,7 +1758,7 @@ describe("RedisSessionStorage#setLollipopAssertionRefForUser", () => {
 });
 
 describe("RedisSessionStorage#delLollipopAssertionRefForUser", () => {
-  it("should return a right eather with true value on success", async () => {
+  it("should return a right either with true value on success", async () => {
     mockDel.mockImplementationOnce((_, callback) => callback(null, 1));
     const response = await sessionStorage.delLollipopAssertionRefForUser(
       aValidUser

--- a/src/services/redisSessionStorage.ts
+++ b/src/services/redisSessionStorage.ts
@@ -828,11 +828,7 @@ export default class RedisSessionStorage extends RedisStorageUtils
   }
 
   /**
-   *
-   * @param user
-   * @param assertionRef
-   * @param expireAssertionRefSec
-   * @returns
+   * {@inheritDoc}
    */
   public async delLollipopAssertionRefForUser(user: UserV5) {
     return new Promise<Either<Error, boolean>>(resolve => {

--- a/src/services/redisSessionStorage.ts
+++ b/src/services/redisSessionStorage.ts
@@ -830,10 +830,10 @@ export default class RedisSessionStorage extends RedisStorageUtils
   /**
    * {@inheritDoc}
    */
-  public async delLollipopAssertionRefForUser(user: UserV5) {
+  public async delLollipopAssertionRefForUser(fiscalCode: FiscalCode) {
     return new Promise<Either<Error, boolean>>(resolve => {
       this.redisClient.del(
-        `${lollipopFingerprintPrefix}${user.fiscal_code}`,
+        `${lollipopFingerprintPrefix}${fiscalCode}`,
         (err, value) => {
           resolve(this.integerReply(err, value));
         }

--- a/src/services/redisSessionStorage.ts
+++ b/src/services/redisSessionStorage.ts
@@ -15,6 +15,8 @@ import { TaskEither } from "fp-ts/lib/TaskEither";
 import { Either } from "fp-ts/lib/Either";
 import { Option } from "fp-ts/lib/Option";
 import { flow, pipe } from "fp-ts/lib/function";
+import { Second } from "@pagopa/ts-commons/lib/units";
+import { AssertionRef } from "../../generated/lollipop-api/AssertionRef";
 import { SessionInfo } from "../../generated/backend/SessionInfo";
 import { SessionsList } from "../../generated/backend/SessionsList";
 import { assertUnreachable } from "../types/commons";
@@ -42,6 +44,7 @@ const userSessionsSetKeyPrefix = "USERSESSIONS-";
 const sessionInfoKeyPrefix = "SESSIONINFO-";
 const noticeEmailPrefix = "NOTICEEMAIL-";
 const blockedUserSetKey = "BLOCKEDUSERS";
+const lollipopFingerprintPrefix = "KEYS-";
 export const keyPrefixes = [
   sessionKeyPrefix,
   walletKeyPrefix,
@@ -52,7 +55,8 @@ export const keyPrefixes = [
   userSessionsSetKeyPrefix,
   sessionInfoKeyPrefix,
   noticeEmailPrefix,
-  blockedUserSetKey
+  blockedUserSetKey,
+  lollipopFingerprintPrefix
 ];
 export const sessionNotFoundError = new Error("Session not found");
 
@@ -67,7 +71,8 @@ export default class RedisSessionStorage extends RedisStorageUtils
   private readonly ttlTask: (key: string) => TaskEither<Error, number>;
   constructor(
     private readonly redisClient: redis.RedisClient,
-    private readonly tokenDurationSecs: number
+    private readonly tokenDurationSecs: number,
+    private readonly defaultDurationAssertionRefSec: Second
   ) {
     super();
     this.mgetTask = TE.taskify(this.redisClient.mget.bind(this.redisClient));
@@ -755,6 +760,86 @@ export default class RedisSessionStorage extends RedisStorageUtils
             )
           );
           return resolve(errorOrNoticeEmail);
+        }
+      );
+    });
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public async getLollipopAssertionRefForUser(user: UserV5) {
+    return new Promise<Either<Error, AssertionRef>>(resolve => {
+      this.redisClient.get(
+        `${lollipopFingerprintPrefix}${user.fiscal_code}`,
+        (err, value) => {
+          if (err) {
+            // Client returns an error.
+            return resolve(E.left(err));
+          }
+
+          if (value === null) {
+            return resolve(
+              E.left(new Error("The User have not registered a key"))
+            );
+          }
+          const errorOrLollipopFingerprint = pipe(
+            value,
+            AssertionRef.decode,
+            E.mapLeft(
+              validationErrors =>
+                new Error(errorsToReadableMessages(validationErrors).join("/"))
+            )
+          );
+          return resolve(errorOrLollipopFingerprint);
+        }
+      );
+    });
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public async setLollipopAssertionRefForUser(
+    user: UserV5,
+    assertionRef: AssertionRef,
+    expireAssertionRefSec: Second = this.defaultDurationAssertionRefSec
+  ) {
+    return new Promise<Either<Error, boolean>>(resolve => {
+      this.redisClient.set(
+        `${lollipopFingerprintPrefix}${user.fiscal_code}`,
+        assertionRef,
+        "EX",
+        expireAssertionRefSec,
+        (err, value) => {
+          if (err) {
+            // Client returns an error.
+            return resolve(E.left(err));
+          }
+
+          const saveSessionInfoResult = this.falsyResponseToError(
+            this.singleStringReply(err, value),
+            new Error("Error setting user key")
+          );
+          resolve(saveSessionInfoResult);
+        }
+      );
+    });
+  }
+
+  /**
+   *
+   * @param user
+   * @param assertionRef
+   * @param expireAssertionRefSec
+   * @returns
+   */
+  public async delLollipopAssertionRefForUser(user: UserV5) {
+    return new Promise<Either<Error, boolean>>(resolve => {
+      this.redisClient.del(
+        `${lollipopFingerprintPrefix}${user.fiscal_code}`,
+        (err, value) => {
+          resolve(this.integerReply(err, value));
         }
       );
     });

--- a/src/strategies/__tests__/bearerZendeskTokenStrategy.test.ts
+++ b/src/strategies/__tests__/bearerZendeskTokenStrategy.test.ts
@@ -8,8 +8,10 @@ import * as E from "fp-ts/lib/Either";
 import mockReq from "../../__mocks__/request";
 import mockRes from "../../__mocks__/response";
 import { ZendeskToken } from "../../types/token";
+import { Second } from "@pagopa/ts-commons/lib/units";
 
 const aTokenDurationSecs = 3600;
+const aDefaultLollipopAssertionRefDurationSec = (3600 * 24 * 365 * 2) as Second;
 const mockGet = jest.fn();
 const mockSet = jest.fn();
 const mockMget = jest.fn();
@@ -53,7 +55,8 @@ jest.mock("../../services/redisSessionStorage", () => {
 
 const sessionService = new RedisSessionStorage(
   mockRedisClient,
-  aTokenDurationSecs
+  aTokenDurationSecs,
+  aDefaultLollipopAssertionRefDurationSec
 );
 
 const res = mockRes();


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->
Created utility into the `RedisSessionStorage` for reading, writing and deleting reference from user fiscal codes and assertionRefs for the lollipop protocol.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
To be able to retrieve the key related to a user is needed the introduction of a new key on redis with the fiscalCode as key and the key thumbprint as value. The value has the algorithm used to calculate the thumbprint as prefix.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
unit test

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
