### PR TITLE
Fix parse SamlResponse to get InResponseTo value

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ WORKDIR /usr/src/app
 COPY /package.json /usr/src/app/package.json
 COPY /public /usr/src/app/public
 COPY --from=builder /usr/src/app/dist /usr/src/app/dist
+COPY --from=builder /usr/src/app/openapi /usr/src/app/openapi
 COPY --from=builder /usr/src/app/node_modules /usr/src/app/node_modules
 
 EXPOSE 80

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
     image: node:10.14.2-alpine
     command: ["yarn", "hot-reload"]
     volumes:
-      - ".:/usr/src/app:cached"
+      - ".:/usr/src/app"
     networks:
       - io-be
 

--- a/src/controllers/__tests__/authenticationController.test.ts
+++ b/src/controllers/__tests__/authenticationController.test.ts
@@ -71,13 +71,15 @@ const validUserPayload = {
   issuer: "xxx",
   dateOfBirth: aValidDateofBirth,
   name: aValidName,
-  getAssertionXml: () => aLollipopAssertion
+  getAssertionXml: () => aLollipopAssertion,
+  getSamlResponseXml: () => aLollipopAssertion
 };
 // invalidUser lacks the required familyName and optional email fields.
 const invalidUserPayload = {
   authnContextClassRef: aValidSpidLevel,
   fiscalNumber: aFiscalCode,
   getAssertionXml: () => "",
+  getSamlResponseXml: () => "",
   issuer: "xxx",
   dateOfBirth: aValidDateofBirth,
   name: aValidName

--- a/src/controllers/authenticationController.ts
+++ b/src/controllers/authenticationController.ts
@@ -256,12 +256,17 @@ export default class AuthenticationController {
         TE.of(
           getRequestIDFromResponse(
             new DOMParser().parseFromString(
-              spidUser.getAssertionXml(),
+              spidUser.getSamlResponseXml(),
               "text/xml"
             )
           )
         )
       ),
+      TE.map(inResponseTo => {
+        log.info(inResponseTo);
+        log.info(spidUser.getSamlResponseXml());
+        return inResponseTo;
+      }),
       TE.chainW(
         flow(
           O.chain(O.fromPredicate(() => this.lollipopParams.isLollipopEnabled)),
@@ -275,7 +280,7 @@ export default class AuthenticationController {
             this.lollipopParams.lollipopService.activateLolliPoPKey(
               assertionRef,
               user.fiscal_code,
-              spidUser.getAssertionXml(),
+              spidUser.getSamlResponseXml(),
               () => addSeconds(new Date(), tokenDurationSecs)
             ),
             pipe(

--- a/src/strategies/localStrategy.ts
+++ b/src/strategies/localStrategy.ts
@@ -25,7 +25,8 @@ export const localStrategy = (
         dateOfBirth: "2000-06-02",
         familyName: "Rossi",
         fiscalNumber: username,
-        getAssertionXml: () => "",
+        getAssertionXml: () => "<xml></xml>",
+        getSamlResponseXml: () => "<xml></xml>",
         issuer: "IO",
         name: "Mario"
       };

--- a/src/types/__tests__/user.test.ts
+++ b/src/types/__tests__/user.test.ts
@@ -12,7 +12,15 @@ import {
   User,
   validateSpidUser
 } from "../user";
-import { mockBPDToken, mockedUser, mockFIMSToken, mockMyPortalToken, mockSessionToken, mockWalletToken, mockZendeskToken } from "../../__mocks__/user_mock";
+import {
+  mockBPDToken,
+  mockedUser,
+  mockFIMSToken,
+  mockMyPortalToken,
+  mockSessionToken,
+  mockWalletToken,
+  mockZendeskToken
+} from "../../__mocks__/user_mock";
 
 const anIssuer = "onelogin_saml" as Issuer;
 const SESSION_TOKEN_LENGTH_BYTES = 48;
@@ -26,6 +34,7 @@ const mockedSpidUser: any = {
   familyName: mockedUser.family_name,
   fiscalNumber: mockedUser.fiscal_code,
   getAssertionXml: () => "",
+  getSamlResponseXml: () => "",
   issuer: anIssuer,
   name: mockedUser.name
 };

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -111,6 +111,7 @@ export const SpidUser = t.intersection([
     familyName: t.string,
     fiscalNumber: FiscalCode,
     getAssertionXml: t.Function,
+    getSamlResponseXml: t.Function,
     issuer: Issuer,
     name: t.string
   }),
@@ -179,7 +180,8 @@ export function exactUserIdentityDecode(
 const SpidObject = t.intersection([
   t.interface({
     fiscalNumber: t.string,
-    getAssertionXml: t.any
+    getAssertionXml: t.Function,
+    getSamlResponseXml: t.Function
   }),
   t.partial({
     authnContextClassRef: t.any,


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->
Add `getSamlResponseXML` method in SpidUser.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
We need to extract the whole SAML Response to initialize Lollipop and/or complete a login with test-login endpoint.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
unit test

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
