### PR TITLE
[#IOCIT-296] Modified logout to delete lollipop data before destroying session.

### DIFF
--- a/src/controllers/__tests__/authenticationController.test.ts
+++ b/src/controllers/__tests__/authenticationController.test.ts
@@ -1078,7 +1078,6 @@ describe("AuthenticationController|>LollipopDisabled|>logout", () => {
     req.user = mockedUser;
 
     mockDelLollipop.mockResolvedValueOnce(E.left(new Error("Redis error")));
-    mockDel.mockResolvedValueOnce(E.right(false));
 
     expect(controller).toBeTruthy();
     const response = await controller.logout(req);

--- a/src/controllers/__tests__/authenticationController.test.ts
+++ b/src/controllers/__tests__/authenticationController.test.ts
@@ -176,9 +176,11 @@ const anActivatedPubKey = ({
 const mockRevokePreviousAssertionRef = jest
   .fn()
   .mockImplementation(_ => Promise.resolve({}));
+
 const mockActivateLolliPoPKey = jest
   .fn()
   .mockImplementation((_, __, ___) => TE.of(anActivatedPubKey));
+
 jest.mock("../../services/lollipopService", () => {
   return {
     default: jest.fn().mockImplementation(() => ({
@@ -637,7 +639,6 @@ describe("AuthenticationController#acs", () => {
       ResponseSuccessJson(mockedInitializedProfile)
     );
 
-    expect(lollipopActivatedController).toBeTruthy();
     const response = await lollipopActivatedController.acs(validUserPayload);
     response.apply(res);
 
@@ -705,7 +706,7 @@ describe("AuthenticationController#acs", () => {
         .mockReturnValueOnce(mockFIMSToken)
         .mockReturnValueOnce(aSessionTrackingId);
 
-      expect(lollipopActivatedController).toBeTruthy();
+  
       const response = await lollipopActivatedController.acs(validUserPayload);
       response.apply(res);
 
@@ -764,7 +765,6 @@ describe("AuthenticationController#acs", () => {
       .mockReturnValueOnce(mockFIMSToken)
       .mockReturnValueOnce(aSessionTrackingId);
 
-    expect(lollipopActivatedController).toBeTruthy();
     const response = await lollipopActivatedController.acs(validUserPayload);
     response.apply(res);
 
@@ -821,7 +821,7 @@ describe("AuthenticationController#acs", () => {
         .mockReturnValueOnce(mockFIMSToken)
         .mockReturnValueOnce(aSessionTrackingId);
 
-      expect(lollipopActivatedController).toBeTruthy();
+  
       const response = await lollipopActivatedController.acs(validUserPayload);
       response.apply(res);
 
@@ -866,7 +866,6 @@ describe("AuthenticationController#acs", () => {
       .mockReturnValueOnce(mockFIMSToken)
       .mockReturnValueOnce(aSessionTrackingId);
 
-    expect(lollipopActivatedController).toBeTruthy();
     const response = await lollipopActivatedController.acs(validUserPayload);
     response.apply(res);
 
@@ -1162,7 +1161,6 @@ describe("AuthenticationController|>LollipopEnabled|>logout", () => {
     const response = await lollipopActivatedController.logout(req);
     response.apply(res);
 
-    expect(lollipopActivatedController).toBeTruthy();
     expect(mockGetLollipop).toHaveBeenCalledWith(mockedUser);
     expect(mockDelLollipop).toHaveBeenCalledWith(mockedUser.fiscal_code);
     expect(mockRevokePreviousAssertionRef).toHaveBeenCalledWith(anAssertionRef);
@@ -1196,7 +1194,6 @@ describe("AuthenticationController|>LollipopEnabled|>logout", () => {
     const response = await lollipopActivatedController.logout(req);
     response.apply(res);
 
-    expect(lollipopActivatedController).toBeTruthy();
     expect(mockGetLollipop).toHaveBeenCalledWith(mockedUser);
     expect(mockDelLollipop).toHaveBeenCalledWith(mockedUser.fiscal_code);
     expect(mockRevokePreviousAssertionRef).not.toHaveBeenCalled();
@@ -1233,7 +1230,6 @@ describe("AuthenticationController|>LollipopEnabled|>logout", () => {
     const response = await lollipopActivatedController.logout(req);
     response.apply(res);
 
-    expect(lollipopActivatedController).toBeTruthy();
     expect(mockGetLollipop).toHaveBeenCalledWith(mockedUser);
     expect(mockDelLollipop).toHaveBeenCalledWith(mockedUser.fiscal_code);
     expect(mockRevokePreviousAssertionRef).toHaveBeenCalledWith(anAssertionRef);
@@ -1253,7 +1249,6 @@ describe("AuthenticationController|>LollipopEnabled|>logout", () => {
     const response = await lollipopActivatedController.logout(req);
     response.apply(res);
 
-    expect(lollipopActivatedController).toBeTruthy();
     expect(mockGetLollipop).not.toHaveBeenCalled();
     expect(mockDelLollipop).not.toHaveBeenCalled();
     expect(mockRevokePreviousAssertionRef).not.toHaveBeenCalled();
@@ -1270,9 +1265,7 @@ describe("AuthenticationController|>LollipopEnabled|>logout", () => {
     const req = mockReq();
     req.user = mockedUser;
 
-    mockGetLollipop.mockImplementationOnce(() => {
-      throw "error";
-    });
+    mockGetLollipop.mockImplementationOnce(() => Promise.reject("error"));
     mockDelLollipop.mockResolvedValueOnce(E.right(true));
     mockRevokePreviousAssertionRef.mockResolvedValueOnce({
       messageId: "anid",
@@ -1286,7 +1279,6 @@ describe("AuthenticationController|>LollipopEnabled|>logout", () => {
     const response = await lollipopActivatedController.logout(req);
     response.apply(res);
 
-    expect(lollipopActivatedController).toBeTruthy();
     expect(mockGetLollipop).toHaveBeenCalledWith(mockedUser);
     expect(mockDelLollipop).not.toBeCalled();
     expect(mockRevokePreviousAssertionRef).not.toBeCalled();
@@ -1307,9 +1299,7 @@ describe("AuthenticationController|>LollipopEnabled|>logout", () => {
     req.user = mockedUser;
 
     mockGetLollipop.mockResolvedValueOnce(E.right(O.some(anAssertionRef)));
-    mockDelLollipop.mockImplementationOnce(() => {
-      throw "error";
-    });
+    mockDelLollipop.mockImplementationOnce(() => Promise.reject("error"));
     mockRevokePreviousAssertionRef.mockResolvedValueOnce({
       messageId: "anid",
       popReceipt: "1234",
@@ -1322,7 +1312,6 @@ describe("AuthenticationController|>LollipopEnabled|>logout", () => {
     const response = await lollipopActivatedController.logout(req);
     response.apply(res);
 
-    expect(lollipopActivatedController).toBeTruthy();
     expect(mockGetLollipop).toHaveBeenCalledWith(mockedUser);
     expect(mockDelLollipop).toHaveBeenCalledWith(mockedUser.fiscal_code);
     expect(mockRevokePreviousAssertionRef).not.toBeCalled();
@@ -1352,7 +1341,6 @@ describe("AuthenticationController|>LollipopEnabled|>logout", () => {
     const response = await lollipopActivatedController.logout(req);
     response.apply(res);
 
-    expect(lollipopActivatedController).toBeTruthy();
     expect(mockGetLollipop).toHaveBeenCalledWith(mockedUser);
     expect(mockDelLollipop).toHaveBeenCalledWith(mockedUser.fiscal_code);
     expect(mockRevokePreviousAssertionRef).toHaveBeenCalledWith(anAssertionRef);
@@ -1374,15 +1362,12 @@ describe("AuthenticationController|>LollipopEnabled|>logout", () => {
 
     mockGetLollipop.mockResolvedValueOnce(E.right(O.some(anAssertionRef)));
     mockDelLollipop.mockResolvedValueOnce(E.right(true));
-    mockRevokePreviousAssertionRef.mockImplementation(() => {
-      throw "error";
-    });
+    mockRevokePreviousAssertionRef.mockImplementationOnce(() => Promise.reject("error"));
     mockDel.mockReturnValue(Promise.resolve(E.right(false)));
 
     const response = await lollipopActivatedController.logout(req);
     response.apply(res);
 
-    expect(lollipopActivatedController).toBeTruthy();
     expect(mockGetLollipop).toHaveBeenCalledWith(mockedUser);
     expect(mockDelLollipop).toHaveBeenCalledWith(mockedUser.fiscal_code);
     expect(mockRevokePreviousAssertionRef).toHaveBeenCalledWith(anAssertionRef);
@@ -1415,7 +1400,6 @@ describe("AuthenticationController|>LollipopEnabled|>logout", () => {
     const response = await lollipopActivatedController.logout(req);
     response.apply(res);
 
-    expect(lollipopActivatedController).toBeTruthy();
     expect(mockGetLollipop).toHaveBeenCalledWith(mockedUser);
     expect(mockDelLollipop).toHaveBeenCalledWith(mockedUser.fiscal_code);
     expect(mockRevokePreviousAssertionRef).toHaveBeenCalledWith(anAssertionRef);
@@ -1448,7 +1432,6 @@ describe("AuthenticationController|>LollipopEnabled|>logout", () => {
     const response = await lollipopActivatedController.logout(req);
     response.apply(res);
 
-    expect(lollipopActivatedController).toBeTruthy();
     expect(mockGetLollipop).toHaveBeenCalledWith(mockedUser);
     expect(mockDelLollipop).toHaveBeenCalledWith(mockedUser.fiscal_code);
     expect(mockRevokePreviousAssertionRef).toHaveBeenCalledWith(anAssertionRef);

--- a/src/controllers/__tests__/authenticationController.test.ts
+++ b/src/controllers/__tests__/authenticationController.test.ts
@@ -213,55 +213,51 @@ const getClientProfileRedirectionUrl = (token: string): UrlFromString => {
   } as UrlFromString;
 };
 
-let controller: AuthenticationController;
-let lollipopActivatedController: AuthenticationController;
-beforeAll(async () => {
-  const api = new ApiClientFactory("", "");
-  const profileService = new ProfileService(api);
-  const lollipopService = new LollipopService(
-    {} as ReturnType<LollipopApiClient>,
-    "",
-    ""
-  );
-  const notificationService = new NotificationService("", "");
-  const notificationServiceFactory = (_fiscalCode: FiscalCode) =>
-    notificationService;
-  const usersLoginLogService = new UsersLoginLogService("", "");
+const api = new ApiClientFactory("", "");
+const profileService = new ProfileService(api);
+const lollipopService = new LollipopService(
+  {} as ReturnType<LollipopApiClient>,
+  "",
+  ""
+);
+const notificationService = new NotificationService("", "");
+const notificationServiceFactory = (_fiscalCode: FiscalCode) =>
+  notificationService;
+const usersLoginLogService = new UsersLoginLogService("", "");
 
-  controller = new AuthenticationController(
-    redisSessionStorage,
-    tokenService,
-    getClientProfileRedirectionUrl,
-    getClientErrorRedirectionUrl,
-    profileService,
-    notificationServiceFactory,
-    usersLoginLogService,
-    [],
-    true,
-    {
-      isLollipopEnabled: false,
-      lollipopService: lollipopService
-    },
-    mockTelemetryClient
-  );
+const controller = new AuthenticationController(
+  redisSessionStorage,
+  tokenService,
+  getClientProfileRedirectionUrl,
+  getClientErrorRedirectionUrl,
+  profileService,
+  notificationServiceFactory,
+  usersLoginLogService,
+  [],
+  true,
+  {
+    isLollipopEnabled: false,
+    lollipopService: lollipopService
+  },
+  mockTelemetryClient
+);
 
-  lollipopActivatedController = new AuthenticationController(
-    redisSessionStorage,
-    tokenService,
-    getClientProfileRedirectionUrl,
-    getClientErrorRedirectionUrl,
-    profileService,
-    notificationServiceFactory,
-    usersLoginLogService,
-    [],
-    true,
-    {
-      isLollipopEnabled: true,
-      lollipopService: lollipopService
-    },
-    mockTelemetryClient
-  );
-});
+const lollipopActivatedController = new AuthenticationController(
+  redisSessionStorage,
+  tokenService,
+  getClientProfileRedirectionUrl,
+  getClientErrorRedirectionUrl,
+  profileService,
+  notificationServiceFactory,
+  usersLoginLogService,
+  [],
+  true,
+  {
+    isLollipopEnabled: true,
+    lollipopService: lollipopService
+  },
+  mockTelemetryClient
+);
 
 let clock: any;
 beforeEach(() => {
@@ -694,7 +690,6 @@ describe("AuthenticationController#acs", () => {
         .mockReturnValueOnce(mockFIMSToken)
         .mockReturnValueOnce(aSessionTrackingId);
 
-  
       const response = await lollipopActivatedController.acs(validUserPayload);
       response.apply(res);
 
@@ -809,7 +804,6 @@ describe("AuthenticationController#acs", () => {
         .mockReturnValueOnce(mockFIMSToken)
         .mockReturnValueOnce(aSessionTrackingId);
 
-  
       const response = await lollipopActivatedController.acs(validUserPayload);
       response.apply(res);
 
@@ -1338,7 +1332,9 @@ describe("AuthenticationController|>LollipopEnabled|>logout", () => {
 
     mockGetLollipop.mockResolvedValueOnce(E.right(O.some(anAssertionRef)));
     mockDelLollipop.mockResolvedValueOnce(E.right(true));
-    mockRevokePreviousAssertionRef.mockImplementationOnce(() => Promise.reject("error"));
+    mockRevokePreviousAssertionRef.mockImplementationOnce(() =>
+      Promise.reject("error")
+    );
     mockDel.mockReturnValue(Promise.resolve(E.right(false)));
 
     const response = await lollipopActivatedController.logout(req);

--- a/src/controllers/__tests__/authenticationController.test.ts
+++ b/src/controllers/__tests__/authenticationController.test.ts
@@ -303,7 +303,6 @@ describe("AuthenticationController#acs", () => {
     const response = await controller.acs(validUserPayload);
     response.apply(res);
 
-    expect(controller).toBeTruthy();
     expect(res.redirect).toHaveBeenCalledWith(
       301,
       "/profile.html?token=" + mockSessionToken
@@ -336,7 +335,6 @@ describe("AuthenticationController#acs", () => {
     const response = await controller.acs(validUserPayload);
     response.apply(res);
 
-    expect(controller).toBeTruthy();
     expect(res.redirect).toHaveBeenCalledWith(
       301,
       "/profile.html?token=" + mockSessionToken
@@ -374,7 +372,6 @@ describe("AuthenticationController#acs", () => {
     const response = await controller.acs(validUserPayload);
     response.apply(res);
 
-    expect(controller).toBeTruthy();
     expect(mockSet).toHaveBeenCalledWith(mockedUser);
 
     expect(mockGetProfile).toHaveBeenCalledWith(mockedUser);
@@ -409,7 +406,6 @@ describe("AuthenticationController#acs", () => {
     const response = await controller.acs(validUserPayload);
     response.apply(res);
 
-    expect(controller).toBeTruthy();
     expect(mockSet).toHaveBeenCalledWith(mockedUser);
 
     expect(mockGetProfile).toHaveBeenCalledWith(mockedUser);
@@ -427,7 +423,6 @@ describe("AuthenticationController#acs", () => {
     const response = await controller.acs(invalidUserPayload);
     response.apply(res);
 
-    expect(controller).toBeTruthy();
     expect(res.status).toHaveBeenCalledWith(400);
 
     expect(res.json).toHaveBeenCalledWith(badRequestErrorResponse);
@@ -442,7 +437,6 @@ describe("AuthenticationController#acs", () => {
     const response = await controller.acs(validUserPayload);
     response.apply(res);
 
-    expect(controller).toBeTruthy();
     expect(res.status).toHaveBeenCalledWith(500);
     expect(res.json).toHaveBeenCalledWith({
       ...anErrorResponse,
@@ -457,7 +451,6 @@ describe("AuthenticationController#acs", () => {
     const response = await controller.acs(validUserPayload);
     response.apply(res);
 
-    expect(controller).toBeTruthy();
     expect(res.status).toHaveBeenCalledWith(403);
   });
 
@@ -470,7 +463,6 @@ describe("AuthenticationController#acs", () => {
     const response = await controller.acs(validUserPayload);
     response.apply(res);
 
-    expect(controller).toBeTruthy();
     expect(res.status).toHaveBeenCalledWith(500);
     expect(res.json).toHaveBeenCalledWith({
       ...anErrorResponse,
@@ -486,7 +478,6 @@ describe("AuthenticationController#acs", () => {
     const response = await controller.acs(validUserPayload);
     response.apply(res);
 
-    expect(controller).toBeTruthy();
     expect(res.status).toHaveBeenCalledWith(500);
     expect(res.json).toHaveBeenCalledWith({
       ...anErrorResponse,
@@ -507,7 +498,6 @@ describe("AuthenticationController#acs", () => {
     const response = await controller.acs(aYoungUserPayload);
     response.apply(res);
 
-    expect(controller).toBeTruthy();
     expect(mockTelemetryClient.trackEvent).toBeCalledWith(
       expect.objectContaining({
         name: "spid.error.generic",
@@ -538,7 +528,6 @@ describe("AuthenticationController#acs", () => {
     const response = await controller.acs(aYoungUserPayload);
     response.apply(res);
 
-    expect(controller).toBeTruthy();
     expect(mockTelemetryClient.trackEvent).toBeCalledWith(
       expect.objectContaining({
         name: "spid.error.generic",
@@ -587,7 +576,6 @@ describe("AuthenticationController#acs", () => {
     const response = await controller.acs(aYoungUserPayload);
     response.apply(res);
 
-    expect(controller).toBeTruthy();
     expect(mockTelemetryClient.trackEvent).not.toBeCalled();
     expect(res.redirect).toHaveBeenCalledWith(
       301,
@@ -917,7 +905,6 @@ describe("AuthenticationController#acsTest", () => {
     const response = await controller.acsTest(validUserPayload);
     response.apply(res);
 
-    expect(controller).toBeTruthy();
     expect(response.kind).toEqual("IResponseSuccessJson");
     expect(res.json).toHaveBeenCalledWith({ token: expectedToken });
   });
@@ -930,7 +917,6 @@ describe("AuthenticationController#acsTest", () => {
     const response = await controller.acsTest(validUserPayload);
     response.apply(res);
 
-    expect(controller).toBeTruthy();
     expect(response).toEqual(expectedResponse);
   });
   it("should return ResponseErrorInternal if the token is missing", async () => {
@@ -942,7 +928,6 @@ describe("AuthenticationController#acsTest", () => {
     const response = await controller.acsTest(validUserPayload);
     response.apply(res);
 
-    expect(controller).toBeTruthy();
     expect(response.kind).toEqual("IResponseErrorInternal");
   });
 });
@@ -967,8 +952,6 @@ describe("AuthenticationController#getUserIdentity", () => {
 
     const response = await controller.getUserIdentity(req);
     response.apply(res);
-
-    expect(controller).toBeTruthy();
 
     const expectedValue = exactUserIdentityDecode(
       (mockedUser as unknown) as UserIdentity
@@ -997,7 +980,6 @@ describe("AuthenticationController#getUserIdentity", () => {
     const response = await controller.getUserIdentity(req);
     response.apply(res);
 
-    expect(controller).toBeTruthy();
     expect(res.status).toHaveBeenCalledWith(500);
     expect(response).toEqual({
       apply: expect.any(Function),
@@ -1018,7 +1000,6 @@ describe("AuthenticationController#slo", () => {
     const response = await controller.slo();
     response.apply(res);
 
-    expect(controller).toBeTruthy();
     expect(res.redirect).toHaveBeenCalledWith(301, "/");
   });
 });
@@ -1039,7 +1020,6 @@ describe("AuthenticationController|>LollipopDisabled|>logout", () => {
     const response = await controller.logout(req);
     response.apply(res);
 
-    expect(controller).toBeTruthy();
     expect(mockGetLollipop).not.toHaveBeenCalled();
     expect(mockDelLollipop).not.toHaveBeenCalled();
     expect(mockRevokePreviousAssertionRef).not.toHaveBeenCalled();
@@ -1066,7 +1046,6 @@ describe("AuthenticationController|>LollipopDisabled|>logout", () => {
     const response = await controller.logout(req);
     response.apply(res);
 
-    expect(controller).toBeTruthy();
     expect(mockGetLollipop).not.toHaveBeenCalled();
     expect(mockDelLollipop).not.toHaveBeenCalled();
     expect(mockRevokePreviousAssertionRef).not.toHaveBeenCalled();
@@ -1086,7 +1065,6 @@ describe("AuthenticationController|>LollipopDisabled|>logout", () => {
     const response = await controller.logout(req);
     response.apply(res);
 
-    expect(controller).toBeTruthy();
     expect(mockGetLollipop).not.toHaveBeenCalled();
     expect(mockDelLollipop).not.toHaveBeenCalled();
     expect(mockRevokePreviousAssertionRef).not.toHaveBeenCalled();
@@ -1104,7 +1082,6 @@ describe("AuthenticationController|>LollipopDisabled|>logout", () => {
     const response = await controller.logout(req);
     response.apply(res);
 
-    expect(controller).toBeTruthy();
     expect(mockGetLollipop).not.toHaveBeenCalled();
     expect(mockDelLollipop).not.toHaveBeenCalled();
     expect(mockRevokePreviousAssertionRef).not.toHaveBeenCalled();
@@ -1124,7 +1101,6 @@ describe("AuthenticationController|>LollipopDisabled|>logout", () => {
     const response = await controller.logout(req);
     response.apply(res);
 
-    expect(controller).toBeTruthy();
     expect(mockGetLollipop).not.toHaveBeenCalled();
     expect(mockDelLollipop).not.toHaveBeenCalled();
     expect(mockRevokePreviousAssertionRef).not.toHaveBeenCalled();

--- a/src/controllers/__tests__/authenticationController.test.ts
+++ b/src/controllers/__tests__/authenticationController.test.ts
@@ -1012,7 +1012,6 @@ describe("AuthenticationController|>LollipopDisabled|>logout", () => {
     mockDelLollipop.mockResolvedValueOnce(E.right(true));
     mockDel.mockResolvedValueOnce(E.right(true));
 
-    expect(controller).toBeTruthy();
     const response = await controller.logout(req);
     response.apply(res);
 
@@ -1041,14 +1040,13 @@ describe("AuthenticationController|>LollipopDisabled|>logout", () => {
     mockDelLollipop.mockResolvedValueOnce(E.right(true));
     mockDel.mockResolvedValueOnce(E.right(true));
 
-    expect(controller).toBeTruthy();
     const response = await controller.logout(req);
     response.apply(res);
 
     expect(mockGetLollipop).not.toHaveBeenCalled();
+    expect(mockRevokePreviousAssertionRef).not.toHaveBeenCalled();
     expect(mockDelLollipop).toHaveBeenCalledWith(mockedUser.fiscal_code);
     expect(mockDel).toHaveBeenCalledWith(userWithExternalToken);
-    expect(mockRevokePreviousAssertionRef).not.toHaveBeenCalled();
     expect(response).toEqual({
       apply: expect.any(Function),
       kind: "IResponseSuccessJson",
@@ -1065,8 +1063,8 @@ describe("AuthenticationController|>LollipopDisabled|>logout", () => {
     response.apply(res);
 
     expect(mockGetLollipop).not.toHaveBeenCalled();
-    expect(mockDelLollipop).not.toHaveBeenCalled();
     expect(mockRevokePreviousAssertionRef).not.toHaveBeenCalled();
+    expect(mockDelLollipop).not.toHaveBeenCalled();
     expect(mockDel).not.toBeCalled();
     expect(res.status).toHaveBeenCalledWith(400);
     expect(res.json).toHaveBeenCalledWith(badRequestErrorResponse);
@@ -1079,7 +1077,6 @@ describe("AuthenticationController|>LollipopDisabled|>logout", () => {
 
     mockDelLollipop.mockResolvedValueOnce(E.left(new Error("Redis error")));
 
-    expect(controller).toBeTruthy();
     const response = await controller.logout(req);
     response.apply(res);
 
@@ -1102,7 +1099,6 @@ describe("AuthenticationController|>LollipopDisabled|>logout", () => {
     mockDelLollipop.mockResolvedValueOnce(E.right(true));
     mockDel.mockResolvedValueOnce(E.right(false));
 
-    expect(controller).toBeTruthy();
     const response = await controller.logout(req);
     response.apply(res);
 
@@ -1125,7 +1121,6 @@ describe("AuthenticationController|>LollipopDisabled|>logout", () => {
     mockDelLollipop.mockResolvedValueOnce(E.right(true));
     mockDel.mockResolvedValueOnce(E.left(new Error("Redis error")));
 
-    expect(controller).toBeTruthy();
     const response = await controller.logout(req);
     response.apply(res);
 
@@ -1161,7 +1156,6 @@ describe("AuthenticationController|>LollipopEnabled|>logout", () => {
     mockDelLollipop.mockResolvedValueOnce(E.right(true));
     mockDel.mockResolvedValueOnce(E.right(true));
 
-    expect(lollipopActivatedController).toBeTruthy();
     const response = await lollipopActivatedController.logout(req);
     response.apply(res);
 
@@ -1186,11 +1180,9 @@ describe("AuthenticationController|>LollipopEnabled|>logout", () => {
     req.user = mockedUser;
 
     mockGetLollipop.mockResolvedValueOnce(E.right(O.none));
-    mockRevokePreviousAssertionRef.mockResolvedValueOnce({});
     mockDelLollipop.mockResolvedValueOnce(E.right(true));
     mockDel.mockResolvedValueOnce(E.right(true));
 
-    expect(lollipopActivatedController).toBeTruthy();
     const response = await lollipopActivatedController.logout(req);
     response.apply(res);
 
@@ -1220,13 +1212,12 @@ describe("AuthenticationController|>LollipopEnabled|>logout", () => {
     mockDelLollipop.mockResolvedValueOnce(E.right(true));
     mockDel.mockResolvedValueOnce(E.right(true));
 
-    expect(lollipopActivatedController).toBeTruthy();
     const response = await lollipopActivatedController.logout(req);
     response.apply(res);
 
     expect(mockGetLollipop).toHaveBeenCalledWith(mockedUser);
-    expect(mockDelLollipop).toHaveBeenCalledWith(mockedUser.fiscal_code);
     expect(mockRevokePreviousAssertionRef).toHaveBeenCalledWith(anAssertionRef);
+    expect(mockDelLollipop).toHaveBeenCalledWith(mockedUser.fiscal_code);
     expect(mockDel).toHaveBeenCalledWith(mockedUser);
     expect(response).toEqual({
       apply: expect.any(Function),
@@ -1243,13 +1234,12 @@ describe("AuthenticationController|>LollipopEnabled|>logout", () => {
     const req = mockReq();
     req.user = invalidUserPayload;
 
-    expect(lollipopActivatedController).toBeTruthy();
     const response = await lollipopActivatedController.logout(req);
     response.apply(res);
 
     expect(mockGetLollipop).not.toHaveBeenCalled();
-    expect(mockDelLollipop).not.toHaveBeenCalled();
     expect(mockRevokePreviousAssertionRef).not.toHaveBeenCalled();
+    expect(mockDelLollipop).not.toHaveBeenCalled();
     expect(mockDel).not.toBeCalled();
     expect(res.status).toHaveBeenCalledWith(400);
     expect(res.json).toHaveBeenCalledWith(badRequestErrorResponse);
@@ -1264,17 +1254,13 @@ describe("AuthenticationController|>LollipopEnabled|>logout", () => {
     req.user = mockedUser;
 
     mockGetLollipop.mockImplementationOnce(() => Promise.reject("error"));
-    mockRevokePreviousAssertionRef.mockResolvedValueOnce({});
-    mockDelLollipop.mockResolvedValueOnce(E.right(true));
-    mockDel.mockResolvedValueOnce(E.right(true));
 
-    expect(lollipopActivatedController).toBeTruthy();
     const response = await lollipopActivatedController.logout(req);
     response.apply(res);
 
     expect(mockGetLollipop).toHaveBeenCalledWith(mockedUser);
-    expect(mockDelLollipop).not.toBeCalled();
     expect(mockRevokePreviousAssertionRef).not.toBeCalled();
+    expect(mockDelLollipop).not.toBeCalled();
     expect(mockDel).not.toBeCalled();
     expect(res.status).toHaveBeenCalledWith(500);
     expect(res.json).toHaveBeenCalledWith({
@@ -1294,9 +1280,7 @@ describe("AuthenticationController|>LollipopEnabled|>logout", () => {
     mockGetLollipop.mockResolvedValueOnce(E.right(O.some(anAssertionRef)));
     mockRevokePreviousAssertionRef.mockResolvedValueOnce({});
     mockDelLollipop.mockImplementationOnce(() => Promise.reject("error"));
-    mockDel.mockResolvedValueOnce(E.right(true));
 
-    expect(lollipopActivatedController).toBeTruthy();
     const response = await lollipopActivatedController.logout(req);
     response.apply(res);
 
@@ -1324,7 +1308,6 @@ describe("AuthenticationController|>LollipopEnabled|>logout", () => {
     mockDelLollipop.mockResolvedValueOnce(E.right(true));
     mockDel.mockResolvedValueOnce(E.right(false));
 
-    expect(lollipopActivatedController).toBeTruthy();
     const response = await lollipopActivatedController.logout(req);
     response.apply(res);
 
@@ -1352,7 +1335,6 @@ describe("AuthenticationController|>LollipopEnabled|>logout", () => {
     mockDelLollipop.mockResolvedValueOnce(E.right(true));
     mockDel.mockResolvedValueOnce(E.left(new Error("Redis error")));
 
-    expect(lollipopActivatedController).toBeTruthy();
     const response = await lollipopActivatedController.logout(req);
     response.apply(res);
 

--- a/src/controllers/authenticationController.ts
+++ b/src/controllers/authenticationController.ts
@@ -507,7 +507,7 @@ export default class AuthenticationController {
                               response => new Error(response.errorCode)
                             )
                           ),
-                          TE.map(__ => true)
+                          TE.map(___ => true)
                         )
                       ),
                       // continue if there's no assertionRef on redis

--- a/src/controllers/authenticationController.ts
+++ b/src/controllers/authenticationController.ts
@@ -456,7 +456,7 @@ export default class AuthenticationController {
   /**
    * Retrieves the logout url from the IDP.
    */
-  public async logout(
+  public logout(
     req: express.Request
   ): Promise<
     | IResponseErrorInternal
@@ -464,7 +464,7 @@ export default class AuthenticationController {
     | IResponseSuccessJson<SuccessResponse>
   > {
     return withUserFromRequest(req, user =>
-      withCatchAsInternalError(async () =>
+      withCatchAsInternalError(() =>
         pipe(
           this.lollipopParams.isLollipopEnabled,
           O.fromPredicate(identity),
@@ -491,7 +491,7 @@ export default class AuthenticationController {
                     E.toError
                   ),
                   TE.chainEitherK(identity),
-                  TE.chainW(_ =>
+                  TE.chainW(__ =>
                     pipe(
                       maybeAssertionRef,
                       O.map(assertionRef =>
@@ -513,7 +513,7 @@ export default class AuthenticationController {
                           TE.map(__ => true)
                         )
                       ),
-                      // ignore if there's no assertionRef on redis
+                      // continue if there's no assertionRef on redis
                       O.getOrElseW(() => TE.of(true))
                     )
                   )

--- a/src/controllers/authenticationController.ts
+++ b/src/controllers/authenticationController.ts
@@ -473,10 +473,7 @@ export default class AuthenticationController {
             pipe(
               // retrieve the assertionRef for the user
               TE.tryCatch(
-                async () =>
-                  await this.sessionStorage.getLollipopAssertionRefForUser(
-                    user
-                  ),
+                () => this.sessionStorage.getLollipopAssertionRefForUser(user),
                 E.toError
               ),
               TE.chainEitherK(identity),
@@ -484,8 +481,8 @@ export default class AuthenticationController {
                 pipe(
                   // delete the assertionRef for the user
                   TE.tryCatch(
-                    async () =>
-                      await this.sessionStorage.delLollipopAssertionRefForUser(
+                    () =>
+                      this.sessionStorage.delLollipopAssertionRefForUser(
                         user.fiscal_code
                       ),
                     E.toError
@@ -498,8 +495,8 @@ export default class AuthenticationController {
                         pipe(
                           // send the revoke pubkey message with the assertionRef for the user
                           TE.tryCatch(
-                            async () =>
-                              await this.lollipopParams.lollipopService.revokePreviousAssertionRef(
+                            () =>
+                              this.lollipopParams.lollipopService.revokePreviousAssertionRef(
                                 assertionRef
                               ),
                             E.toError
@@ -526,10 +523,7 @@ export default class AuthenticationController {
           TE.chain(_ =>
             pipe(
               // delete the session for the user
-              TE.tryCatch(
-                async () => await this.sessionStorage.del(user),
-                E.toError
-              ),
+              TE.tryCatch(() => this.sessionStorage.del(user), E.toError),
               TE.chainEitherK(identity),
               TE.chain(
                 TE.fromPredicate(

--- a/src/controllers/authenticationController.ts
+++ b/src/controllers/authenticationController.ts
@@ -469,7 +469,7 @@ export default class AuthenticationController {
           this.lollipopParams.isLollipopEnabled,
           O.fromPredicate(identity),
           // if lollipop is enabled we delete the reference and send the revoke pub key message
-          O.map(_ =>
+          O.map(() =>
             pipe(
               // retrieve the assertionRef for the user
               TE.tryCatch(
@@ -488,7 +488,7 @@ export default class AuthenticationController {
                     E.toError
                   ),
                   TE.chainEitherK(identity),
-                  TE.chainW(__ =>
+                  TE.chainW(() =>
                     pipe(
                       maybeAssertionRef,
                       O.map(assertionRef =>
@@ -507,7 +507,7 @@ export default class AuthenticationController {
                               response => new Error(response.errorCode)
                             )
                           ),
-                          TE.map(___ => true)
+                          TE.map(() => true)
                         )
                       ),
                       // continue if there's no assertionRef on redis
@@ -520,7 +520,7 @@ export default class AuthenticationController {
           ),
           // if lollipop is not enabled we go on
           O.getOrElse(() => TE.of(true)),
-          TE.chain(_ =>
+          TE.chain(() =>
             pipe(
               // delete the session for the user
               TE.tryCatch(() => this.sessionStorage.del(user), E.toError),
@@ -528,7 +528,7 @@ export default class AuthenticationController {
               TE.chain(
                 TE.fromPredicate(
                   identity,
-                  __ => new Error("Error destroying the user session")
+                  () => new Error("Error destroying the user session")
                 )
               )
             )
@@ -539,7 +539,7 @@ export default class AuthenticationController {
               log.error(errorMessage);
               return ResponseErrorInternal(errorMessage);
             },
-            _ => ResponseSuccessJson({ message: "ok" })
+            () => ResponseSuccessJson({ message: "ok" })
           ),
           TE.toUnion
         )()

--- a/src/services/ISessionStorage.ts
+++ b/src/services/ISessionStorage.ts
@@ -75,7 +75,7 @@ export interface ISessionStorage {
    * @param user The AppUser value used to get the related fiscalCode
    */
   readonly getLollipopAssertionRefForUser: (
-    user: UserV5
+    user: User
   ) => Promise<Either<Error, O.Option<AssertionRef>>>;
 
   /**

--- a/src/services/redisSessionStorage.ts
+++ b/src/services/redisSessionStorage.ts
@@ -768,7 +768,7 @@ export default class RedisSessionStorage extends RedisStorageUtils
   /**
    * {@inheritDoc}
    */
-  public async getLollipopAssertionRefForUser(user: UserV5) {
+  public async getLollipopAssertionRefForUser(user: User) {
     return new Promise<Either<Error, O.Option<AssertionRef>>>(resolve => {
       this.redisClient.get(
         `${lollipopFingerprintPrefix}${user.fiscal_code}`,


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->
If lollipop is enabled:
- retrieve of assertionRef from redis
- delete of CF-assertionRef binding from redis
- sending of public key revoke message

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
When lollipop is enabled and user log out from the app all lollipop data must be deleted.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- yarn build
- yarn test
- yarn lint

TODO: lollipop data flow tests, now lollipop is disabled on tests.

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
