### PR TITLE
[#IOCOM-227] fixed using iun instead of messageId for third party precondition api

### DIFF
--- a/src/services/__tests__/newMessagesService.test.ts
+++ b/src/services/__tests__/newMessagesService.test.ts
@@ -1278,7 +1278,7 @@ describe("MessageService#getThirdPartyMessagePrecondition", () => {
       id: aValidMessageIdWithThirdPartyData
     });
     expect(mockGetTPMessagePrecondition).toHaveBeenCalledWith({
-      id: validApiMessageResponse.value.message.id
+      id: validApiThirdPartyMessageResponse.value.message.content.third_party_data.id
     });
     expect(res).toMatchObject({
       kind: "IResponseSuccessJson",
@@ -1374,7 +1374,7 @@ describe("MessageService#getThirdPartyMessagePrecondition", () => {
       fiscal_code: mockedUser.fiscal_code,
       id: aValidMessageIdWithThirdPartyData
     });
-    expect(mockGetTPMessagePrecondition).toHaveBeenCalledWith({ id: validApiMessageResponse.value.message.id });
+    expect(mockGetTPMessagePrecondition).toHaveBeenCalledWith({ id: validApiThirdPartyMessageResponse.value.message.content.third_party_data.id });
     expect(res).toMatchObject({
       kind: "IResponseErrorInternal",
       detail: "Internal server error: Third Party Service failed with code 500"
@@ -1408,7 +1408,7 @@ describe("MessageService#getThirdPartyMessagePrecondition", () => {
       fiscal_code: mockedUser.fiscal_code,
       id: aValidMessageIdWithThirdPartyData
     });
-    expect(mockGetTPMessagePrecondition).toHaveBeenCalledWith({ id: validApiMessageResponse.value.message.id });
+    expect(mockGetTPMessagePrecondition).toHaveBeenCalledWith({ id: validApiThirdPartyMessageResponse.value.message.content.third_party_data.id });
     expect(res).toMatchObject({
       kind: "IResponseErrorValidation",
       detail: "Bad request: Third party service returned 400"

--- a/src/services/newMessagesService.ts
+++ b/src/services/newMessagesService.ts
@@ -551,7 +551,10 @@ export default class NewMessagesService {
       ),
       TE.chain((client) =>
         TE.tryCatch(
-          () => client.getThirdPartyMessagePrecondition({ id: message.id }),
+          () =>
+            client.getThirdPartyMessagePrecondition({
+              id: message.content.third_party_data.id,
+            }),
           (e) => ResponseErrorInternal(E.toError(e).message)
         )
       ),


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->
- [fixed using iun instead of messageId for third party precondition api](https://github.com/pagopa/io-backend/pull/1014/commits/30acdf8df3aa11ae601b513ffeb6e38f7e14c2a6)

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
