### PR TITLE
[#IOPID-257] Handle new login type on `acs` callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,93 +137,93 @@ IDP is reachable at [https://spid-testenv2:8088]() \
 
 Those are all Environment variables needed by the application:
 
-| Variable name                          | Description                                                                       | type   |
-|----------------------------------------|-----------------------------------------------------------------------------------|--------|
-| API_KEY                                | The key used to authenticate to the io-functions-app API                          | string |
-| API_URL                                | The io-functions-app URL                                                          | string |
-| API_BASE_PATH                          | The root path for the backend api endpoints                                       | string |
-| BACKEND_HOST                           | The absolute URL of the app service containing the FQDN                           | string |
-| BONUS_API_KEY                          | The key used to authenticate to the io-functions-bonus API                        | string |
-| BONUS_API_URL                          | The io-functions-bonus  URL                                                       | string |
-| BONUS_API_BASE_PATH                    | The root path for the backend bonus api endpoints                                 | string |
-| CGN_API_KEY                            | The key used to authenticate to the io-functions-cgn API                          | string |
-| CGN_API_URL                            | The io-functions-cgn  URL                                                         | string |
-| CGN_API_BASE_PATH                      | The root path for the backend cgn api endpoints                                   | string |
-| CLIENT_REDIRECTION_URL                 | (Optional)The path where the user will be redirected after a successful SPID login| string |
-| PORT                                   | The HTTP port the Express server is listening to                                  | int    |
-| REDIS_URL                              | The URL of a Redis instance                                                       | string |
-| TOKEN_DURATION_IN_SECONDS              | The number of seconds a session token is considered valid                         | int    |
-| LV_TOKEN_DURATION_IN_SECONDS           | The number of seconds a session token is considered valid if LV is enabled        | int    |
-| SAML_CALLBACK_URL                      | The absolute URL of the assertion consumer service endpoint                       | string |
-| SAML_ISSUER                            | The issuer id for this Service Provider                                           | string |
-| SAML_ACCEPTED_CLOCK_SKEW_MS            | Maximum skew between SAML Client and Server (empty or -1 disable datetime checks) | int    |
-| SAML_ATTRIBUTE_CONSUMING_SERVICE_INDEX | The index in the attribute consumer list                                          | int    |
-| SAML_KEY                               | Private Key used by SAML protocol                                                 | string |
-| SAML_CERT                              | Certificate used by SAML protocol                                                 | string |
-| SAML_REQUEST_EXPIRATION_PERIOD_MS      | (Optional) The TTL in milliseconds that the SAML Request was stored in cache (defaults to `600.000`) | number |
-| PRE_SHARED_KEY                         | The key shared with the API backend to authenticate the webhook notifications     | string |
-| ALLOW_NOTIFY_IP_SOURCE_RANGE           | The range in CIDR form of allowed IPs for the webhook notifications               | string |
-| NOTIFICATIONS_STORAGE_CONNECTION_STRING | Connection string to Azure queue storage for notification hub messages           | string |
-| NOTIFICATIONS_QUEUE_NAME                | Queue name of Azure queue storage for notification hub messages                  | string |
-| USERS_LOGIN_STORAGE_CONNECTION_STRING  | Connection string to Azure queue storage for usersLogin messages                  | string |
-| USERS_LOGIN_QUEUE_NAME                 | Queue name of Azure queue storage for usersLogin messages                         | string |
-| ALLOW_PAGOPA_IP_SOURCE_RANGE           | The range in CIDR form of allowed IPs for the PagoPA API                          | string |
-| ALLOW_MYPORTAL_IP_SOURCE_RANGE         | The range in CIDR form of allowed IPs for the MyPortal API                        | string |
-| ALLOW_BPD_IP_SOURCE_RANGE              | The range in CIDR form of allowed IPs for the BPD API                             | string |
-| ALLOW_SESSION_HANDLER_IP_SOURCE_RANGE  | The range in CIDR form of IPs of service allowed to handle user sessions          | string |
-| AUTHENTICATION_BASE_PATH               | The root path for the authentication endpoints                                    | string |
-| PAGOPA_API_URL_PROD                    | The url for the PagoPA api endpoints in prod mode                                 | string |
-| PAGOPA_API_KEY_PROD                    | The api-key needed to call the pagopa proxy API                                   | string |
-| PAGOPA_API_URL_TEST                    | The url for the PagoPA api endpoints in test mode                                 | string |
-| PAGOPA_API_KEY_UAT                     | The api-key needed to call the pagopa proxy API for UAT instance                  | string |
-| PAGOPA_BASE_PATH                       | The root path for the PagoPA endpoints                                            | string |
-| MYPORTAL_BASE_PATH                     | The root path for the MyPortal endpoints                                          | string |
-| BPD_BASE_PATH                          | The root path for the BPD endpoints                                               | string |
-| FIMS_BASE_PATH                         | The root path for the FIMS endpoints                                              | string |
-| STARTUP_IDPS_METADATA                  | Stringified JSON containing idps metadata `Record<string, string>`                | string |
-| CIE_METADATA_URL                       | Url to download CIE metadata from                                                 | string |
-| IDP_METADATA_URL                       | Url to download SPID IDPs metadata from                                           | string |
-| SPID_TESTENV_URL                       | Url to SPID Testenv 2                                                             | string |
-| SPID_VALIDATOR_URL                     | Url to SPID Validator                                                             | string |
-| IDP_METADATA_REFRESH_INTERVAL_SECONDS  | The number of seconds when the IDPs Metadata are refreshed                        | int    |
-| CACHE_MAX_AGE_SECONDS                  | The value in seconds for duration of in-memory api cache                          | int    |
-| APICACHE_DEBUG                         | When is `true` enable the apicache debug mode                                     | boolean |
-| GITHUB_TOKEN                           | The value of your Github Api Key, used in build phase                             | string |
-| FETCH_KEEPALIVE_ENABLED                | When is `true` enables `keepalive` agent in the API client (defaults to `false`)  | boolean |
-| ENABLE_NOTICE_EMAIL_CACHE              | (Optional) Enable `notice_email` cache in PagoPA getUser (defaults to `false`)    | boolean |
-| SPID_LEVEL_WHITELIST                   | (Optional) Spid Level whitelist csv (defaults L2 and L3 for prod, all for dev)    | string |
-| TEST_LOGIN_FISCAL_CODES                | (Optional) Enabled username for password based login (coma separated Fiscal Code) | string |
-| TEST_LOGIN_PASSWORD                    | (Optional) Password for password based login                                      | string |
-| FETCH_KEEPALIVE_MAX_SOCKETS            | (Optional) See [agentkeepalive](https://github.com/node-modules/agentkeepalive#readme)  | |
-| FETCH_KEEPALIVE_FREE_SOCKET_TIMEOUT_MS | (Optional) See [agentkeepalive](https://github.com/node-modules/agentkeepalive#readme)  | |
-| FETCH_KEEPALIVE_KEEPALIVE_MSECS        | (Optional) See [agentkeepalive](https://github.com/node-modules/agentkeepalive#readme)  | |
-| FETCH_KEEPALIVE_MAX_FREE_SOCKETS       | (Optional) See [agentkeepalive](https://github.com/node-modules/agentkeepalive#readme)  | |
-| FETCH_KEEPALIVE_TIMEOUT                | (Optional) See [agentkeepalive](https://github.com/node-modules/agentkeepalive#readme)  | |
-| FETCH_KEEPALIVE_SOCKET_ACTIVE_TTL      | (Optional) See [agentkeepalive](https://github.com/node-modules/agentkeepalive#readme)  | |
-| FF_CGN_ENABLED                         | When is `true` (namely `1`) enables CGN API to be registered into backend app     | boolean |
-| FF_CGN_ENABLED                         | When is `true` (namely `1`) enables CGN API to be registered into backend app     | boolean |
-| APP_MESSAGES_API_KEY                   | The key used to authenticate to the io-functions-app-messages API                 | string |
-| APP_MESSAGES_API_URL                   | The io-functions-app-messages URL                                                 | string |
-| THIRD_PARTY_CONFIG_LIST                | (Optional, default empty) A list of ThirdParty Configuration                      | stringified JSON |
-| IS_APPBACKENDLI                        | (Optional, default false) Enables notify and session lock endpoints working only on appbackendli | boolean |
-| FF_PN_ACTIVATION_ENABLED               | (Optional) Enable the integration with PN for Service Activation (1 enabled)      | int     |
-| PN_ACTIVATION_BASE_PATH                | (Required if FF_PN_ACTIVATION_ENABLED = 1) base path for activation endpoint      | string  |
-| PN_API_KEY                             | (Required if FF_PN_ACTIVATION_ENABLED = 1) PN API key for production environment  | string  |
-| PN_API_KEY_UAT                         | (Required if FF_PN_ACTIVATION_ENABLED = 1) PN API key for UAT environment         | string  |
-| PN_API_URL                             | (Required if FF_PN_ACTIVATION_ENABLED = 1) PN API base url for production         | string  |
-| PN_API_URL_UAT                         | (Required if FF_PN_ACTIVATION_ENABLED = 1) PN API base url for UAT environment    | string  |
-| FF_IO_SIGN_ENABLED                     | When is `true` (namely `1`) enables IO SIGN API to be registered into backend app | boolean |
-| IO_SIGN_API_BASE_PATH                  | The root path for the backend io-sign api endpoints                               | string  |
-| IO_SIGN_API_KEY                        | The key used to authenticate to the io-func-sign-user API                         | string  |
-| IO_SIGN_API_URL                        | The io-func-sign-user  URL                                                        | string  |
-| LOLLIPOP_API_KEY                       | The key used to authenticate to the io-function-lollipop API                      | string  |
-| LOLLIPOP_API_URL                       | The io-function-lollipop URL                                                      | string  |
-| LOLLIPOP_API_BASE_PATH                 | The io-function-lollipop api base path                                            | string  |
-| FF_LOLLIPOP_ENABLED                    | (Optional) Enable Lollipop flows default false                                    | boolean |
-| LOLLIPOP_REVOKE_STORAGE_CONNECTION_STRING | Connection string to Azure queue storage for revoke Users lollipop PubKeys     | string  |
-| LOLLIPOP_REVOKE_QUEUE_NAME             | Queue name of Azure queue storage for revoke Users lollipop PubKeys               | string  |
-| FF_FAST_LOGIN                          | (Optional) Enable Fast Login flow. Default: NONE                                  | string (enum) |
-| LV_TEST_USERS                          | (Optional) Comma separated list of LV beta testers. Default: empty array          | srting |
+| Variable name                             | Description                                                                                          | type   |
+|----------------------------------------   |-----------------------------------------------------------------------------------                   |--------|
+| API_KEY                                   | The key used to authenticate to the io-functions-app API                                             | string |
+| API_URL                                   | The io-functions-app URL                                                                             | string |
+| API_BASE_PATH                             | The root path for the backend api endpoints                                                          | string |
+| BACKEND_HOST                              | The absolute URL of the app service containing the FQDN                                              | string |
+| BONUS_API_KEY                             | The key used to authenticate to the io-functions-bonus API                                           | string |
+| BONUS_API_URL                             | The io-functions-bonus  URL                                                                          | string |
+| BONUS_API_BASE_PATH                       | The root path for the backend bonus api endpoints                                                    | string |
+| CGN_API_KEY                               | The key used to authenticate to the io-functions-cgn API                                             | string |
+| CGN_API_URL                               | The io-functions-cgn  URL                                                                            | string |
+| CGN_API_BASE_PATH                         | The root path for the backend cgn api endpoints                                                      | string |
+| CLIENT_REDIRECTION_URL                    | (Optional)The path where the user will be redirected after a successful SPID login                   | string |
+| PORT                                      | The HTTP port the Express server is listening to                                                     | int    |
+| REDIS_URL                                 | The URL of a Redis instance                                                                          | string |
+| TOKEN_DURATION_IN_SECONDS                 | The number of seconds a session token is considered valid                                            | int    |
+| LV_TOKEN_DURATION_IN_SECONDS              | (Optional) The number of seconds a session token is considered valid if LV is enabled                | int    |
+| SAML_CALLBACK_URL                         | The absolute URL of the assertion consumer service endpoint                                          | string |
+| SAML_ISSUER                               | The issuer id for this Service Provider                                                              | string |
+| SAML_ACCEPTED_CLOCK_SKEW_MS               | Maximum skew between SAML Client and Server (empty or -1 disable datetime checks)                    | int    |
+| SAML_ATTRIBUTE_CONSUMING_SERVICE_INDEX    | The index in the attribute consumer list                                                             | int    |
+| SAML_KEY                                  | Private Key used by SAML protocol                                                                    | string |
+| SAML_CERT                                 | Certificate used by SAML protocol                                                                    | string |
+| SAML_REQUEST_EXPIRATION_PERIOD_MS         | (Optional) The TTL in milliseconds that the SAML Request was stored in cache (defaults to `600.000`) | number |
+| PRE_SHARED_KEY                            | The key shared with the API backend to authenticate the webhook notifications                        | string |
+| ALLOW_NOTIFY_IP_SOURCE_RANGE              | The range in CIDR form of allowed IPs for the webhook notifications                                  | string |
+| NOTIFICATIONS_STORAGE_CONNECTION_STRING   | Connection string to Azure queue storage for notification hub messages                               | string |
+| NOTIFICATIONS_QUEUE_NAME                  | Queue name of Azure queue storage for notification hub messages                                      | string |
+| USERS_LOGIN_STORAGE_CONNECTION_STRING     | Connection string to Azure queue storage for usersLogin messages                                     | string |
+| USERS_LOGIN_QUEUE_NAME                    | Queue name of Azure queue storage for usersLogin messages                                            | string |
+| ALLOW_PAGOPA_IP_SOURCE_RANGE              | The range in CIDR form of allowed IPs for the PagoPA API                                             | string |
+| ALLOW_MYPORTAL_IP_SOURCE_RANGE            | The range in CIDR form of allowed IPs for the MyPortal API                                           | string |
+| ALLOW_BPD_IP_SOURCE_RANGE                 | The range in CIDR form of allowed IPs for the BPD API                                                | string |
+| ALLOW_SESSION_HANDLER_IP_SOURCE_RANGE     | The range in CIDR form of IPs of service allowed to handle user sessions                             | string |
+| AUTHENTICATION_BASE_PATH                  | The root path for the authentication endpoints                                                       | string |
+| PAGOPA_API_URL_PROD                       | The url for the PagoPA api endpoints in prod mode                                                    | string |
+| PAGOPA_API_KEY_PROD                       | The api-key needed to call the pagopa proxy API                                                      | string |
+| PAGOPA_API_URL_TEST                       | The url for the PagoPA api endpoints in test mode                                                    | string |
+| PAGOPA_API_KEY_UAT                        | The api-key needed to call the pagopa proxy API for UAT instance                                     | string |
+| PAGOPA_BASE_PATH                          | The root path for the PagoPA endpoints                                                               | string |
+| MYPORTAL_BASE_PATH                        | The root path for the MyPortal endpoints                                                             | string |
+| BPD_BASE_PATH                             | The root path for the BPD endpoints                                                                  | string |
+| FIMS_BASE_PATH                            | The root path for the FIMS endpoints                                                                 | string |
+| STARTUP_IDPS_METADATA                     | Stringified JSON containing idps metadata `Record<string, string>`                                   | string |
+| CIE_METADATA_URL                          | Url to download CIE metadata from                                                                    | string |
+| IDP_METADATA_URL                          | Url to download SPID IDPs metadata from                                                              | string |
+| SPID_TESTENV_URL                          | Url to SPID Testenv 2                                                                                | string |
+| SPID_VALIDATOR_URL                        | Url to SPID Validator                                                                                | string |
+| IDP_METADATA_REFRESH_INTERVAL_SECONDS     | The number of seconds when the IDPs Metadata are refreshed                                           | int    |
+| CACHE_MAX_AGE_SECONDS                     | The value in seconds for duration of in-memory api cache                                             | int    |
+| APICACHE_DEBUG                            | When is `true` enable the apicache debug mode                                                        | boolean |
+| GITHUB_TOKEN                              | The value of your Github Api Key, used in build phase                                                | string |
+| FETCH_KEEPALIVE_ENABLED                   | When is `true` enables `keepalive` agent in the API client (defaults to `false`)                     | boolean |
+| ENABLE_NOTICE_EMAIL_CACHE                 | (Optional) Enable `notice_email` cache in PagoPA getUser (defaults to `false`)                       | boolean |
+| SPID_LEVEL_WHITELIST                      | (Optional) Spid Level whitelist csv (defaults L2 and L3 for prod, all for dev)                       | string |
+| TEST_LOGIN_FISCAL_CODES                   | (Optional) Enabled username for password based login (coma separated Fiscal Code)                    | string |
+| TEST_LOGIN_PASSWORD                       | (Optional) Password for password based login                                                         | string |
+| FETCH_KEEPALIVE_MAX_SOCKETS               | (Optional) See [agentkeepalive](https://github.com/node-modules/agentkeepalive#readme)               | |
+| FETCH_KEEPALIVE_FREE_SOCKET_TIMEOUT_MS    | (Optional) See [agentkeepalive](https://github.com/node-modules/agentkeepalive#readme)               | |
+| FETCH_KEEPALIVE_KEEPALIVE_MSECS           | (Optional) See [agentkeepalive](https://github.com/node-modules/agentkeepalive#readme)               | |
+| FETCH_KEEPALIVE_MAX_FREE_SOCKETS          | (Optional) See [agentkeepalive](https://github.com/node-modules/agentkeepalive#readme)               | |
+| FETCH_KEEPALIVE_TIMEOUT                   | (Optional) See [agentkeepalive](https://github.com/node-modules/agentkeepalive#readme)               | |
+| FETCH_KEEPALIVE_SOCKET_ACTIVE_TTL         | (Optional) See [agentkeepalive](https://github.com/node-modules/agentkeepalive#readme)               | |
+| FF_CGN_ENABLED                            | When is `true` (namely `1`) enables CGN API to be registered into backend app                        | boolean |
+| FF_CGN_ENABLED                            | When is `true` (namely `1`) enables CGN API to be registered into backend app                        | boolean |
+| APP_MESSAGES_API_KEY                      | The key used to authenticate to the io-functions-app-messages API                                    | string |
+| APP_MESSAGES_API_URL                      | The io-functions-app-messages URL                                                                    | string |
+| THIRD_PARTY_CONFIG_LIST                   | (Optional, default empty) A list of ThirdParty Configuration                                         | stringified JSON |
+| IS_APPBACKENDLI                           | (Optional, default false) Enables notify and session lock endpoints working only on appbackendli     | boolean |
+| FF_PN_ACTIVATION_ENABLED                  | (Optional) Enable the integration with PN for Service Activation (1 enabled)                         | int     |
+| PN_ACTIVATION_BASE_PATH                   | (Required if FF_PN_ACTIVATION_ENABLED = 1) base path for activation endpoint                         | string  |
+| PN_API_KEY                                | (Required if FF_PN_ACTIVATION_ENABLED = 1) PN API key for production environment                     | string  |
+| PN_API_KEY_UAT                            | (Required if FF_PN_ACTIVATION_ENABLED = 1) PN API key for UAT environment                            | string  |
+| PN_API_URL                                | (Required if FF_PN_ACTIVATION_ENABLED = 1) PN API base url for production                            | string  |
+| PN_API_URL_UAT                            | (Required if FF_PN_ACTIVATION_ENABLED = 1) PN API base url for UAT environment                       | string  |
+| FF_IO_SIGN_ENABLED                        | When is `true` (namely `1`) enables IO SIGN API to be registered into backend app                    | boolean |
+| IO_SIGN_API_BASE_PATH                     | The root path for the backend io-sign api endpoints                                                  | string  |
+| IO_SIGN_API_KEY                           | The key used to authenticate to the io-func-sign-user API                                            | string  |
+| IO_SIGN_API_URL                           | The io-func-sign-user  URL                                                                           | string  |
+| LOLLIPOP_API_KEY                          | The key used to authenticate to the io-function-lollipop API                                         | string  |
+| LOLLIPOP_API_URL                          | The io-function-lollipop URL                                                                         | string  |
+| LOLLIPOP_API_BASE_PATH                    | The io-function-lollipop api base path                                                               | string  |
+| FF_LOLLIPOP_ENABLED                       | (Optional) Enable Lollipop flows default false                                                       | boolean |
+| LOLLIPOP_REVOKE_STORAGE_CONNECTION_STRING | Connection string to Azure queue storage for revoke Users lollipop PubKeys                           | string  |
+| LOLLIPOP_REVOKE_QUEUE_NAME                | Queue name of Azure queue storage for revoke Users lollipop PubKeys                                  | string  |
+| FF_FAST_LOGIN                             | (Optional) Enable Fast Login flow. Default: NONE                                                     | string (enum) |
+| LV_TEST_USERS                             | (Optional) Comma separated list of LV beta testers. Default: empty array                             | srting |
 
 Notes:
 

--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ Those are all Environment variables needed by the application:
 | PORT                                   | The HTTP port the Express server is listening to                                  | int    |
 | REDIS_URL                              | The URL of a Redis instance                                                       | string |
 | TOKEN_DURATION_IN_SECONDS              | The number of seconds a session token is considered valid                         | int    |
+| LV_TOKEN_DURATION_IN_SECONDS           | The number of seconds a session token is considered valid if LV is enabled        | int    |
 | SAML_CALLBACK_URL                      | The absolute URL of the assertion consumer service endpoint                       | string |
 | SAML_ISSUER                            | The issuer id for this Service Provider                                           | string |
 | SAML_ACCEPTED_CLOCK_SKEW_MS            | Maximum skew between SAML Client and Server (empty or -1 disable datetime checks) | int    |
@@ -221,6 +222,8 @@ Those are all Environment variables needed by the application:
 | FF_LOLLIPOP_ENABLED                    | (Optional) Enable Lollipop flows default false                                    | boolean |
 | LOLLIPOP_REVOKE_STORAGE_CONNECTION_STRING | Connection string to Azure queue storage for revoke Users lollipop PubKeys     | string  |
 | LOLLIPOP_REVOKE_QUEUE_NAME             | Queue name of Azure queue storage for revoke Users lollipop PubKeys               | string  |
+| FF_FAST_LOGIN                          | (Optional) Enable Fast Login flow. Default: NONE                                  | string (enum) |
+| LV_TEST_USERS                          | (Optional) Comma separated list of LV beta testers. Default: empty array          | srting |
 
 Notes:
 

--- a/api_public.yaml
+++ b/api_public.yaml
@@ -62,6 +62,7 @@ paths:
         - $ref: "#/parameters/AuthLevel"
         - $ref: "#/parameters/JwkPubKeyToken"
         - $ref: "#/parameters/JwkPubKeyHashAlgorithm"
+        - $ref: "#/parameters/LoginType"
       responses:
         "302":
           description: Redirect to IDP
@@ -164,6 +165,13 @@ parameters:
     description: SPID AuthLevel
     required: true
     x-example: SpidL2
+  LoginType:
+    name: loginType
+    in: header
+    type: string
+    enum: [LV, LEGACY]
+    required: false
+    x-example: LEGACY
   JwkPubKeyToken:
     $ref: "./api_lollipop.yaml#/parameters/JwkPubKeyToken"
   JwkPubKeyHashAlgorithm:

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "@pagopa/io-functions-cgn-sdk": "x",
     "@pagopa/io-functions-commons": "^28.1.0",
     "@pagopa/io-functions-eucovidcerts-sdk": "x",
-    "@pagopa/io-spid-commons": "^13.0.0",
+    "@pagopa/io-spid-commons": "file:../io-spid-commons",
     "@pagopa/ts-commons": "^12.0.0",
     "@pagopa/winston-ts": "^2.2.0",
     "applicationinsights": "^1.8.10",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "@pagopa/io-functions-cgn-sdk": "x",
     "@pagopa/io-functions-commons": "^28.1.0",
     "@pagopa/io-functions-eucovidcerts-sdk": "x",
-    "@pagopa/io-spid-commons": "file:../io-spid-commons",
+    "@pagopa/io-spid-commons": "^13.1.0",
     "@pagopa/ts-commons": "^12.0.0",
     "@pagopa/winston-ts": "^2.2.0",
     "applicationinsights": "^1.8.10",

--- a/src/app.ts
+++ b/src/app.ts
@@ -83,7 +83,10 @@ import {
   IO_SIGN_SERVICE_ID,
   FIRST_LOLLIPOP_CONSUMER_CLIENT,
 } from "./config";
-import AuthenticationController from "./controllers/authenticationController";
+import AuthenticationController, {
+  AdditionalLoginProps,
+  AdditionalLoginPropsT,
+} from "./controllers/authenticationController";
 import MessagesController from "./controllers/messagesController";
 import NotificationController from "./controllers/notificationController";
 import PagoPAController from "./controllers/pagoPAController";
@@ -700,7 +703,7 @@ export async function newApp({
       return pipe(
         TE.tryCatch(
           () =>
-            withSpid({
+            withSpid<AdditionalLoginPropsT>({
               acs: _.acsController.acs.bind(_.acsController),
               app: _.app,
               appConfig: {
@@ -713,6 +716,13 @@ export async function newApp({
                       ...event.data,
                     },
                   });
+                },
+                extraLoginRequestParamConfig: {
+                  codec: AdditionalLoginProps,
+                  requestMapper: (_req) =>
+                    E.of({
+                      loginType: _req.header("x-pagopa-login-type"),
+                    }),
                 },
               },
               doneCb: spidLogCallback,

--- a/src/app.ts
+++ b/src/app.ts
@@ -85,10 +85,7 @@ import {
   FIRST_LOLLIPOP_CONSUMER_CLIENT,
   lvTokenDurationSecs,
 } from "./config";
-import AuthenticationController, {
-  AdditionalLoginProps,
-  acsRequestMapper,
-} from "./controllers/authenticationController";
+import AuthenticationController from "./controllers/authenticationController";
 import MessagesController from "./controllers/messagesController";
 import NotificationController from "./controllers/notificationController";
 import PagoPAController from "./controllers/pagoPAController";
@@ -177,6 +174,7 @@ import { expressLollipopMiddleware } from "./utils/middleware/lollipop";
 import { LollipopApiClient } from "./clients/lollipop";
 import { ISessionStorage } from "./services/ISessionStorage";
 import { FirstLollipopConsumerClient } from "./clients/firstLollipopConsumer";
+import { AdditionalLoginProps, acsRequestMapper } from "./utils/fastLogin";
 
 const defaultModule = {
   // eslint-disable-next-line @typescript-eslint/no-use-before-define

--- a/src/config.ts
+++ b/src/config.ts
@@ -592,7 +592,7 @@ export const tokenDurationSecs: number = process.env.TOKEN_DURATION_IN_SECONDS
 log.info("Session token duration set to %s seconds", tokenDurationSecs);
 
 // Set default LV session duration
-const DEFAULT_LV_TOKEN_DURATION_IN_SECONDS = 60 * 1;
+const DEFAULT_LV_TOKEN_DURATION_IN_SECONDS = 60 * 15;
 export const lvTokenDurationSecs: number = process.env
   .LV_TOKEN_DURATION_IN_SECONDS
   ? parseInt(process.env.LV_TOKEN_DURATION_IN_SECONDS, 10)

--- a/src/config.ts
+++ b/src/config.ts
@@ -32,7 +32,10 @@ import {
   setFetchTimeout,
   toFetch,
 } from "@pagopa/ts-commons/lib/fetch";
-import { IntegerFromString } from "@pagopa/ts-commons/lib/numbers";
+import {
+  IntegerFromString,
+  NonNegativeIntegerFromString,
+} from "@pagopa/ts-commons/lib/numbers";
 import { NonEmptyString } from "@pagopa/ts-commons/lib/strings";
 import { FiscalCode } from "@pagopa/ts-commons/lib/strings";
 import { Millisecond, Second } from "@pagopa/ts-commons/lib/units";
@@ -593,10 +596,11 @@ log.info("Session token duration set to %s seconds", tokenDurationSecs);
 
 // Set default LV session duration
 const DEFAULT_LV_TOKEN_DURATION_IN_SECONDS = 60 * 15;
-export const lvTokenDurationSecs: number = process.env
-  .LV_TOKEN_DURATION_IN_SECONDS
-  ? parseInt(process.env.LV_TOKEN_DURATION_IN_SECONDS, 10)
-  : DEFAULT_LV_TOKEN_DURATION_IN_SECONDS;
+export const lvTokenDurationSecs: number = pipe(
+  process.env.LV_TOKEN_DURATION_IN_SECONDS,
+  NonNegativeIntegerFromString.decode,
+  E.getOrElse(() => DEFAULT_LV_TOKEN_DURATION_IN_SECONDS)
+);
 log.info("LV Session token duration set to %s seconds", lvTokenDurationSecs);
 
 // HTTPs-only fetch with optional keepalive agent

--- a/src/config.ts
+++ b/src/config.ts
@@ -778,8 +778,8 @@ export const IOLOGIN_CANARY_USERS_SHA_REGEX = pipe(
 );
 
 // LV FF variable
-export const FF_LOGIN_VELOCE = pipe(
-  process.env.FF_LOGIN_VELOCE,
+export const FF_FAST_LOGIN = pipe(
+  process.env.FF_FAST_LOGIN,
   FeatureFlag.decode,
   E.getOrElseW(() => FeatureFlagEnum.NONE)
 );

--- a/src/config.ts
+++ b/src/config.ts
@@ -591,6 +591,14 @@ export const tokenDurationSecs: number = process.env.TOKEN_DURATION_IN_SECONDS
   : DEFAULT_TOKEN_DURATION_IN_SECONDS;
 log.info("Session token duration set to %s seconds", tokenDurationSecs);
 
+// Set default LV session duration
+const DEFAULT_LV_TOKEN_DURATION_IN_SECONDS = 60 * 1;
+export const lvTokenDurationSecs: number = process.env
+  .LV_TOKEN_DURATION_IN_SECONDS
+  ? parseInt(process.env.LV_TOKEN_DURATION_IN_SECONDS, 10)
+  : DEFAULT_LV_TOKEN_DURATION_IN_SECONDS;
+log.info("LV Session token duration set to %s seconds", lvTokenDurationSecs);
+
 // HTTPs-only fetch with optional keepalive agent
 // @see https://github.com/pagopa/io-ts-commons/blob/master/src/agent.ts#L10
 const simpleHttpsApiFetch = agent.getHttpsFetch(process.env);
@@ -767,6 +775,21 @@ export const IOLOGIN_CANARY_USERS_SHA_REGEX = pipe(
   NonEmptyString.decode,
   // allow ~6% of users by default
   E.getOrElse(() => "^([(0-9)|(a-f)|(A-F)]{63}0)$" as NonEmptyString)
+);
+
+// LV FF variable
+export const FF_LOGIN_VELOCE = pipe(
+  process.env.FF_LOGIN_VELOCE,
+  FeatureFlag.decode,
+  E.getOrElseW(() => FeatureFlagEnum.NONE)
+);
+
+export const LV_TEST_USERS = pipe(
+  process.env.LV_TEST_USERS,
+  CommaSeparatedListOf(FiscalCode).decode,
+  E.getOrElseW((err) => {
+    throw new Error(`Invalid LV_TEST_USERS value: ${readableReport(err)}`);
+  })
 );
 
 // Support Token

--- a/src/controllers/__tests__/authenticationController.test.ts
+++ b/src/controllers/__tests__/authenticationController.test.ts
@@ -1022,16 +1022,16 @@ describe("AuthenticationController|>LV|>acs", () => {
   );
 
   it.each`
-    loginType                 | isUserEligible | expectedTtlDuration
-    ${LoginTypeEnum.LV}       | ${true}        | ${tokenDurationSecs}
-    ${LoginTypeEnum.LV}       | ${false}       | ${tokenDurationSecs}
-    ${LoginTypeEnum.STANDARD} | ${true}        | ${tokenDurationSecs}
-    ${LoginTypeEnum.STANDARD} | ${false}       | ${tokenDurationSecs}
-    ${undefined}              | ${true}        | ${tokenDurationSecs}
-    ${undefined}              | ${false}       | ${tokenDurationSecs}
+    loginType                 | isUserEligible
+    ${LoginTypeEnum.LV}       | ${true}
+    ${LoginTypeEnum.LV}       | ${false}
+    ${LoginTypeEnum.STANDARD} | ${true}
+    ${LoginTypeEnum.STANDARD} | ${false}
+    ${undefined}              | ${true}
+    ${undefined}              | ${false}
   `(
-    "should succeed and return a new token with duration $expectedTtlDuration, if lollipop is disabled, ff is $isUserElegible and login is of type $loginType",
-    async ({ loginType, expectedTtlDuration, isUserElegible }) => {
+    "should succeed and return a new token with standard duration, if lollipop is disabled, ff is $isUserElegible and login is of type $loginType",
+    async ({ loginType, isUserElegible }) => {
       const res = mockRes();
 
       jest
@@ -1075,7 +1075,7 @@ describe("AuthenticationController|>LV|>acs", () => {
       );
       response.apply(res);
 
-      expect(mockSet).toHaveBeenCalledWith(mockedUser, expectedTtlDuration);
+      expect(mockSet).toHaveBeenCalledWith(mockedUser, tokenDurationSecs);
       expect(mockSetLollipop).not.toHaveBeenCalled();
       expect(mockActivateLolliPoPKey).not.toHaveBeenCalled();
 

--- a/src/controllers/__tests__/authenticationController.test.ts
+++ b/src/controllers/__tests__/authenticationController.test.ts
@@ -940,13 +940,13 @@ describe("AuthenticationController#acs", () => {
 
 describe("AuthenticationController|>LV|>acs", () => {
   it.each`
-    loginType                 | isUserElegible | expectedTtlDuration
-    ${LoginTypeEnum.LV}       | ${true}        | ${lvTokenDurationSecs}
-    ${LoginTypeEnum.LV}       | ${false}       | ${tokenDurationSecs}
-    ${LoginTypeEnum.STANDARD} | ${true}        | ${tokenDurationSecs}
-    ${LoginTypeEnum.STANDARD} | ${false}       | ${tokenDurationSecs}
-    ${undefined}              | ${true}        | ${tokenDurationSecs}
-    ${undefined}              | ${false}       | ${tokenDurationSecs}
+    loginType               | isUserElegible | expectedTtlDuration
+    ${LoginTypeEnum.LV}     | ${true}        | ${lvTokenDurationSecs}
+    ${LoginTypeEnum.LV}     | ${false}       | ${tokenDurationSecs}
+    ${LoginTypeEnum.LEGACY} | ${true}        | ${tokenDurationSecs}
+    ${LoginTypeEnum.LEGACY} | ${false}       | ${tokenDurationSecs}
+    ${undefined}            | ${true}        | ${tokenDurationSecs}
+    ${undefined}            | ${false}       | ${tokenDurationSecs}
   `(
     "should succeed and return a new token with duration $expectedTtlDuration, if lollipop is enabled, ff is $isUserElegible and login is of type $loginType",
     async ({ loginType, expectedTtlDuration, isUserElegible }) => {
@@ -1022,13 +1022,13 @@ describe("AuthenticationController|>LV|>acs", () => {
   );
 
   it.each`
-    loginType                 | isUserEligible
-    ${LoginTypeEnum.LV}       | ${true}
-    ${LoginTypeEnum.LV}       | ${false}
-    ${LoginTypeEnum.STANDARD} | ${true}
-    ${LoginTypeEnum.STANDARD} | ${false}
-    ${undefined}              | ${true}
-    ${undefined}              | ${false}
+    loginType               | isUserEligible
+    ${LoginTypeEnum.LV}     | ${true}
+    ${LoginTypeEnum.LV}     | ${false}
+    ${LoginTypeEnum.LEGACY} | ${true}
+    ${LoginTypeEnum.LEGACY} | ${false}
+    ${undefined}            | ${true}
+    ${undefined}            | ${false}
   `(
     "should succeed and return a new token with standard duration, if lollipop is disabled, ff is $isUserElegible and login is of type $loginType",
     async ({ loginType, isUserElegible }) => {

--- a/src/controllers/__tests__/authenticationController.test.ts
+++ b/src/controllers/__tests__/authenticationController.test.ts
@@ -285,6 +285,17 @@ afterEach(() => {
   clock = clock.uninstall();
 });
 
+const setupMocks = () => {
+  mockGetNewToken
+    .mockReturnValueOnce(mockSessionToken)
+    .mockReturnValueOnce(mockWalletToken)
+    .mockReturnValueOnce(mockMyPortalToken)
+    .mockReturnValueOnce(mockBPDToken)
+    .mockReturnValueOnce(mockZendeskToken)
+    .mockReturnValueOnce(mockFIMSToken)
+    .mockReturnValueOnce(aSessionTrackingId);
+};
+
 describe("AuthenticationController#acs", () => {
   it("redirects to the correct url if userPayload is a valid User and a profile not exists", async () => {
     const res = mockRes();
@@ -296,14 +307,7 @@ describe("AuthenticationController#acs", () => {
 
     mockSet.mockReturnValue(Promise.resolve(E.right(true)));
     mockIsBlockedUser.mockReturnValue(Promise.resolve(E.right(false)));
-    mockGetNewToken
-      .mockReturnValueOnce(mockSessionToken)
-      .mockReturnValueOnce(mockWalletToken)
-      .mockReturnValueOnce(mockMyPortalToken)
-      .mockReturnValueOnce(mockBPDToken)
-      .mockReturnValueOnce(mockZendeskToken)
-      .mockReturnValueOnce(mockFIMSToken)
-      .mockReturnValueOnce(aSessionTrackingId);
+    setupMocks();
 
     mockGetProfile.mockReturnValue(
       ResponseErrorNotFound("Not Found.", "Profile not found")
@@ -331,14 +335,7 @@ describe("AuthenticationController#acs", () => {
 
     mockSet.mockReturnValue(Promise.resolve(E.right(true)));
     mockIsBlockedUser.mockReturnValue(Promise.resolve(E.right(false)));
-    mockGetNewToken
-      .mockReturnValueOnce(mockSessionToken)
-      .mockReturnValueOnce(mockWalletToken)
-      .mockReturnValueOnce(mockMyPortalToken)
-      .mockReturnValueOnce(mockBPDToken)
-      .mockReturnValueOnce(mockZendeskToken)
-      .mockReturnValueOnce(mockFIMSToken)
-      .mockReturnValueOnce(aSessionTrackingId);
+    setupMocks();
 
     mockGetProfile.mockReturnValue(
       ResponseSuccessJson(mockedInitializedProfile)
@@ -365,14 +362,7 @@ describe("AuthenticationController#acs", () => {
 
     mockSet.mockReturnValue(Promise.resolve(E.right(true)));
     mockIsBlockedUser.mockReturnValue(Promise.resolve(E.right(false)));
-    mockGetNewToken
-      .mockReturnValueOnce(mockSessionToken)
-      .mockReturnValueOnce(mockWalletToken)
-      .mockReturnValueOnce(mockMyPortalToken)
-      .mockReturnValueOnce(mockBPDToken)
-      .mockReturnValueOnce(mockZendeskToken)
-      .mockReturnValueOnce(mockFIMSToken)
-      .mockReturnValueOnce(aSessionTrackingId);
+    setupMocks();
 
     mockGetProfile.mockReturnValue(
       ResponseErrorNotFound("Not Found.", "Profile not found")
@@ -402,14 +392,7 @@ describe("AuthenticationController#acs", () => {
 
     mockSet.mockReturnValue(Promise.resolve(E.right(true)));
     mockIsBlockedUser.mockReturnValue(Promise.resolve(E.right(false)));
-    mockGetNewToken
-      .mockReturnValueOnce(mockSessionToken)
-      .mockReturnValueOnce(mockWalletToken)
-      .mockReturnValueOnce(mockMyPortalToken)
-      .mockReturnValueOnce(mockBPDToken)
-      .mockReturnValueOnce(mockZendeskToken)
-      .mockReturnValueOnce(mockFIMSToken)
-      .mockReturnValueOnce(aSessionTrackingId);
+    setupMocks();
 
     mockGetProfile.mockReturnValue(
       ResponseErrorInternal("Error reading the user profile")
@@ -565,14 +548,7 @@ describe("AuthenticationController#acs", () => {
 
     mockSet.mockReturnValue(Promise.resolve(E.right(true)));
     mockIsBlockedUser.mockReturnValue(Promise.resolve(E.right(false)));
-    mockGetNewToken
-      .mockReturnValueOnce(mockSessionToken)
-      .mockReturnValueOnce(mockWalletToken)
-      .mockReturnValueOnce(mockMyPortalToken)
-      .mockReturnValueOnce(mockBPDToken)
-      .mockReturnValueOnce(mockZendeskToken)
-      .mockReturnValueOnce(mockFIMSToken)
-      .mockReturnValueOnce(aSessionTrackingId);
+    setupMocks();
 
     mockGetProfile.mockReturnValue(
       ResponseErrorNotFound("Not Found.", "Profile not found")
@@ -628,14 +604,7 @@ describe("AuthenticationController#acs", () => {
     );
     mockSet.mockReturnValue(Promise.resolve(E.right(true)));
     mockIsBlockedUser.mockReturnValue(Promise.resolve(E.right(false)));
-    mockGetNewToken
-      .mockReturnValueOnce(mockSessionToken)
-      .mockReturnValueOnce(mockWalletToken)
-      .mockReturnValueOnce(mockMyPortalToken)
-      .mockReturnValueOnce(mockBPDToken)
-      .mockReturnValueOnce(mockZendeskToken)
-      .mockReturnValueOnce(mockFIMSToken)
-      .mockReturnValueOnce(aSessionTrackingId);
+    setupMocks();
 
     mockGetProfile.mockReturnValue(
       ResponseSuccessJson(mockedInitializedProfile)
@@ -760,14 +729,7 @@ describe("AuthenticationController#acs", () => {
     );
 
     mockIsBlockedUser.mockReturnValue(Promise.resolve(E.right(false)));
-    mockGetNewToken
-      .mockReturnValueOnce(mockSessionToken)
-      .mockReturnValueOnce(mockWalletToken)
-      .mockReturnValueOnce(mockMyPortalToken)
-      .mockReturnValueOnce(mockBPDToken)
-      .mockReturnValueOnce(mockZendeskToken)
-      .mockReturnValueOnce(mockFIMSToken)
-      .mockReturnValueOnce(aSessionTrackingId);
+    setupMocks();
 
     const response = await lollipopActivatedController.acs(validUserPayload);
     response.apply(res);
@@ -860,14 +822,7 @@ describe("AuthenticationController#acs", () => {
     mockGetLollipop.mockResolvedValueOnce(E.left(new Error("Error")));
 
     mockIsBlockedUser.mockReturnValue(Promise.resolve(E.right(false)));
-    mockGetNewToken
-      .mockReturnValueOnce(mockSessionToken)
-      .mockReturnValueOnce(mockWalletToken)
-      .mockReturnValueOnce(mockMyPortalToken)
-      .mockReturnValueOnce(mockBPDToken)
-      .mockReturnValueOnce(mockZendeskToken)
-      .mockReturnValueOnce(mockFIMSToken)
-      .mockReturnValueOnce(aSessionTrackingId);
+    setupMocks();
 
     const response = await lollipopActivatedController.acs(validUserPayload);
     response.apply(res);

--- a/src/controllers/__tests__/authenticationController.test.ts
+++ b/src/controllers/__tests__/authenticationController.test.ts
@@ -1127,7 +1127,7 @@ describe("AuthenticationController#acsTest", () => {
   it("should return ResponseErrorInternal if the token is missing", async () => {
     acsSpyOn.mockImplementation(async (_: unknown) => {
       return ResponsePermanentRedirect({
-        href: "http://invalid-url",
+        href: "https://invalid-url",
       } as ValidUrl);
     });
     const response = await controller.acsTest(validUserPayload);

--- a/src/controllers/__tests__/authenticationController.test.ts
+++ b/src/controllers/__tests__/authenticationController.test.ts
@@ -64,6 +64,7 @@ import {
 } from "../../__mocks__/lollipop";
 import * as authCtrl from "../authenticationController";
 import { withoutUndefinedValues } from "@pagopa/ts-commons/lib/types";
+import { LoginTypeEnum } from "../../utils/fastLogin";
 
 // validUser has all every field correctly set.
 const validUserPayload = {
@@ -939,14 +940,21 @@ describe("AuthenticationController#acs", () => {
 
 describe("AuthenticationController|>LV|>acs", () => {
   it.each`
-    loginType                          | expectedTtlDuration
-    ${authCtrl.LoginTypeEnum.LV}       | ${lvTokenDurationSecs}
-    ${authCtrl.LoginTypeEnum.STANDARD} | ${tokenDurationSecs}
-    ${undefined}                       | ${tokenDurationSecs}
+    loginType                 | isUserElegible | expectedTtlDuration
+    ${LoginTypeEnum.LV}       | ${true}        | ${lvTokenDurationSecs}
+    ${LoginTypeEnum.LV}       | ${false}       | ${tokenDurationSecs}
+    ${LoginTypeEnum.STANDARD} | ${true}        | ${tokenDurationSecs}
+    ${LoginTypeEnum.STANDARD} | ${false}       | ${tokenDurationSecs}
+    ${undefined}              | ${true}        | ${tokenDurationSecs}
+    ${undefined}              | ${false}       | ${tokenDurationSecs}
   `(
-    "should succeed and return a new token with duration $expectedTtlDuration, if lollipop is enabled and login is of type $loginType",
-    async ({ loginType, expectedTtlDuration }) => {
+    "should succeed and return a new token with duration $expectedTtlDuration, if lollipop is enabled, ff is $isUserElegible and login is of type $loginType",
+    async ({ loginType, expectedTtlDuration, isUserElegible }) => {
       const res = mockRes();
+
+      jest
+        .spyOn(authCtrl, "isUserElegibleForFastLogin")
+        .mockImplementationOnce((_) => isUserElegible);
 
       mockGetLollipop.mockResolvedValueOnce(
         E.right(O.some(anotherAssertionRef))
@@ -1014,14 +1022,21 @@ describe("AuthenticationController|>LV|>acs", () => {
   );
 
   it.each`
-    loginType                          | expectedTtlDuration
-    ${authCtrl.LoginTypeEnum.LV}       | ${tokenDurationSecs}
-    ${authCtrl.LoginTypeEnum.STANDARD} | ${tokenDurationSecs}
-    ${undefined}                       | ${tokenDurationSecs}
+    loginType                 | isUserEligible | expectedTtlDuration
+    ${LoginTypeEnum.LV}       | ${true}        | ${tokenDurationSecs}
+    ${LoginTypeEnum.LV}       | ${false}       | ${tokenDurationSecs}
+    ${LoginTypeEnum.STANDARD} | ${true}        | ${tokenDurationSecs}
+    ${LoginTypeEnum.STANDARD} | ${false}       | ${tokenDurationSecs}
+    ${undefined}              | ${true}        | ${tokenDurationSecs}
+    ${undefined}              | ${false}       | ${tokenDurationSecs}
   `(
-    "should succeed and return a new token with duration $expectedTtlDuration, if lollipop is disabled and login is of type $loginType",
-    async ({ loginType, expectedTtlDuration }) => {
+    "should succeed and return a new token with duration $expectedTtlDuration, if lollipop is disabled, ff is $isUserElegible and login is of type $loginType",
+    async ({ loginType, expectedTtlDuration, isUserElegible }) => {
       const res = mockRes();
+
+      jest
+        .spyOn(authCtrl, "isUserElegibleForFastLogin")
+        .mockImplementationOnce((_) => isUserElegible);
 
       mockGetLollipop.mockResolvedValueOnce(
         E.right(O.some(anotherAssertionRef))

--- a/src/controllers/authenticationController.ts
+++ b/src/controllers/authenticationController.ts
@@ -190,6 +190,10 @@ export default class AuthenticationController {
       );
     }
 
+    // LV functionality is enable only if Lollipop is enabled.
+    // With FF set to BETA or CANARY, only whitelisted CF can use the LV functionality (the token TTL is reduced if login type is `LV`).
+    // With FF set to ALL all the user can use the LV (the token TTL is reduced if login type is `LV`).
+    // Otherwise LV is disabled.
     const sessionTTL =
       this.lollipopParams.isLollipopEnabled &&
       isUserElegibleForFastLogin(spidUser.fiscalNumber) &&

--- a/src/controllers/authenticationController.ts
+++ b/src/controllers/authenticationController.ts
@@ -9,6 +9,7 @@ import * as B from "fp-ts/lib/boolean";
 import * as E from "fp-ts/lib/Either";
 import * as O from "fp-ts/lib/Option";
 import * as AP from "fp-ts/lib/Apply";
+import * as t from "io-ts";
 import {
   IResponseErrorForbiddenNotAuthorized,
   IResponseErrorInternal,
@@ -94,6 +95,9 @@ export const isUserElegibleForIoLoginUrlScheme =
     FF_IOLOGIN
   );
 
+export type AdditionalLoginPropsT = t.TypeOf<typeof AdditionalLoginProps>;
+export const AdditionalLoginProps = t.partial({ loginType: t.string });
+
 export default class AuthenticationController {
   // eslint-disable-next-line max-params
   constructor(
@@ -119,7 +123,8 @@ export default class AuthenticationController {
    */
   // eslint-disable-next-line max-lines-per-function, sonarjs/cognitive-complexity
   public async acs(
-    userPayload: unknown
+    userPayload: unknown,
+    additionalProps?: AdditionalLoginPropsT
   ): Promise<
     | IResponseErrorInternal
     | IResponseErrorValidation
@@ -130,6 +135,9 @@ export default class AuthenticationController {
     // decode the SPID assertion into a SPID user
     //
     const errorOrSpidUser = validateSpidUser(userPayload);
+
+    // eslint-disable-next-line no-console
+    console.log("additionalProps", additionalProps);
 
     if (E.isLeft(errorOrSpidUser)) {
       log.error(
@@ -491,7 +499,7 @@ export default class AuthenticationController {
     | IResponseErrorForbiddenNotAuthorized
     | IResponseSuccessJson<AccessToken>
   > {
-    const acsResponse = await this.acs(userPayload);
+    const acsResponse = await this.acs(userPayload, {});
     // When the login succeeded with a ResponsePermanentRedirect (301)
     // the token was extract from the response and returned into the body
     // of a ResponseSuccessJson (200)

--- a/src/controllers/authenticationController.ts
+++ b/src/controllers/authenticationController.ts
@@ -56,6 +56,7 @@ import {
   FF_FAST_LOGIN,
   IOLOGIN_CANARY_USERS_SHA_REGEX,
   IOLOGIN_USERS_LIST,
+  LV_TEST_USERS,
 } from "../config";
 import { ISessionStorage } from "../services/ISessionStorage";
 import ProfileService from "../services/profileService";
@@ -101,7 +102,7 @@ export const isUserElegibleForIoLoginUrlScheme =
   );
 
 export const isUserElegibleForFastLogin = getIsUserElegibleForfastLogin(
-  IOLOGIN_USERS_LIST,
+  LV_TEST_USERS,
   FF_FAST_LOGIN
 );
 

--- a/src/utils/fastLogin.ts
+++ b/src/utils/fastLogin.ts
@@ -1,0 +1,36 @@
+import * as t from "io-ts";
+import * as express from "express";
+import { FiscalCode } from "@pagopa/ts-commons/lib/strings";
+import { enumType } from "@pagopa/ts-commons/lib/types";
+import { FeatureFlag, getIsUserEligibleForNewFeature } from "./featureFlag";
+
+export enum LoginTypeEnum {
+  "LV" = "LV",
+  "STANDARD" = "STANDARD",
+}
+export type LoginTypeT = t.TypeOf<typeof LoginType>;
+export const LoginType = enumType<LoginTypeEnum>(LoginTypeEnum, "LoginType");
+
+export type AdditionalLoginPropsT = t.TypeOf<typeof AdditionalLoginProps>;
+export const AdditionalLoginProps = t.partial({ loginType: LoginType });
+
+export const acsRequestMapper = (
+  _req: express.Request
+): t.Validation<AdditionalLoginPropsT> =>
+  AdditionalLoginProps.decode({
+    loginType: _req.header("x-pagopa-login-type"),
+  });
+
+// ----------------------------
+// FF management
+// ----------------------------
+
+export const getIsUserElegibleForfastLogin = (
+  betaTesters: ReadonlyArray<FiscalCode>,
+  FF_FastLogin: FeatureFlag
+) =>
+  getIsUserEligibleForNewFeature<FiscalCode>(
+    (fiscalCode) => betaTesters.includes(fiscalCode),
+    (_fiscalCode) => false,
+    FF_FastLogin
+  );

--- a/src/utils/fastLogin.ts
+++ b/src/utils/fastLogin.ts
@@ -15,10 +15,10 @@ export type AdditionalLoginPropsT = t.TypeOf<typeof AdditionalLoginProps>;
 export const AdditionalLoginProps = t.partial({ loginType: LoginType });
 
 export const acsRequestMapper = (
-  _req: express.Request
+  req: express.Request
 ): t.Validation<AdditionalLoginPropsT> =>
   AdditionalLoginProps.decode({
-    loginType: _req.header("x-pagopa-login-type"),
+    loginType: req.header("x-pagopa-login-type"),
   });
 
 // ----------------------------

--- a/src/utils/fastLogin.ts
+++ b/src/utils/fastLogin.ts
@@ -6,7 +6,7 @@ import { FeatureFlag, getIsUserEligibleForNewFeature } from "./featureFlag";
 
 export enum LoginTypeEnum {
   "LV" = "LV",
-  "STANDARD" = "STANDARD",
+  "LEGACY" = "LEGACY",
 }
 export type LoginTypeT = t.TypeOf<typeof LoginType>;
 export const LoginType = enumType<LoginTypeEnum>(LoginTypeEnum, "LoginType");

--- a/yarn.lock
+++ b/yarn.lock
@@ -971,8 +971,10 @@
     fp-ts "^2.10.5"
     io-ts "^2.2.16"
 
-"@pagopa/io-spid-commons@file:../io-spid-commons":
-  version "13.0.1"
+"@pagopa/io-spid-commons@^13.1.0":
+  version "13.1.0"
+  resolved "https://registry.yarnpkg.com/@pagopa/io-spid-commons/-/io-spid-commons-13.1.0.tgz#a470eef4869e318085710528a6f9d080377b9737"
+  integrity sha512-doiXA3pEXWbENCu6jYqgThlAIhGAKgsI9oIsRGBXWSQBY4JgG/vn9OnrtWArNgKBdxzyWY5kA+EqFu0C8AhI5Q==
   dependencies:
     "@pagopa/ts-commons" "^12.0.0"
     "@xmldom/xmldom" "^0.8.7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -971,12 +971,11 @@
     fp-ts "^2.10.5"
     io-ts "^2.2.16"
 
-"@pagopa/io-spid-commons@^13.0.0":
-  version "13.0.0"
-  resolved "https://registry.yarnpkg.com/@pagopa/io-spid-commons/-/io-spid-commons-13.0.0.tgz#4cddcbd941fc00db3bf82b6237cd266313e319ef"
-  integrity sha512-GoCoui4r3XmodfOHIwACmsfr/kRr9fEo6e9G1grGoDgdzMsPsQWMe8+d1eMHBMUuNgtof2zvsge0H0FeIAMq3g==
+"@pagopa/io-spid-commons@file:../io-spid-commons":
+  version "13.0.1"
   dependencies:
     "@pagopa/ts-commons" "^12.0.0"
+    "@xmldom/xmldom" "^0.8.7"
     date-fns "^1.30.1"
     fp-ts "2.14.0"
     io-ts "2.2.20"
@@ -991,7 +990,6 @@
     winston "^3.0.0"
     xml-crypto "^1.4.0"
     xml2js "^0.4.23"
-    xmldom "^0.6.0"
     yargs "^15.3.0"
 
 "@pagopa/openapi-codegen-ts@^13.0.1":
@@ -1705,6 +1703,11 @@
   version "0.7.4"
   resolved "https://registry.yarnpkg.com/@xmldom/xmldom/-/xmldom-0.7.4.tgz#93b2f9486c88b6464e97f76c9ab49b0a548fbe57"
   integrity sha512-wdxC79cvO7PjSM34jATd/RYZuYWQ8y/R7MidZl1NYYlbpFn1+spfjkiR3ZsJfcaTs2IyslBN7VwBBJwrYKM+zw==
+
+"@xmldom/xmldom@^0.8.7":
+  version "0.8.8"
+  resolved "https://registry.yarnpkg.com/@xmldom/xmldom/-/xmldom-0.8.8.tgz#d0d11511cbc1de77e53342ad1546a4d487d6ea72"
+  integrity sha512-0LNz4EY8B/8xXY86wMrQ4tz6zEHZv9ehFMJPm8u2gq5lQ71cfRKdaKyxfJAx5aUoyzx0qzgURblTisPGgz3d+Q==
 
 a-sync-waterfall@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

This PR depends on https://github.com/pagopa/io-spid-commons/pull/148

#### List of Changes
<!--- Describe your changes in detail -->

- Update io-spid-commons
- Enable new io-spid-commons functionality for handling additional data between login and acs steps.
- Add new FF management for LV functionality
- Create user's token based on LV FF

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Enable new Fast Login management (based on FF).

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Unit test, io-mock

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
