### PR TITLE
fix:[#IOPID-343] Discriminate if is a session creation or update

### DIFF
--- a/src/controllers/__tests__/sessionController.test.ts
+++ b/src/controllers/__tests__/sessionController.test.ts
@@ -57,6 +57,11 @@ jest.mock("../../services/profileService", () => {
   };
 });
 
+const mockSetRedisSessionStorage = jest.spyOn(
+  RedisSessionStorage.prototype,
+  "set"
+);
+
 mockGetProfile.mockReturnValue(
   Promise.resolve(ResponseSuccessJson(mockedInitializedProfile))
 );
@@ -154,6 +159,8 @@ describe("SessionController#getSessionState", () => {
     const response = await controller.getSessionState(req);
     response.apply(res);
 
+    expect(mockSetRedisSessionStorage).not.toHaveBeenCalled();
+
     expect(mockGet).toBeCalledWith(`KEYS-${mockedUser.fiscal_code}`);
     expect(res.status).toHaveBeenCalledWith(500);
     expect(res.json).toHaveBeenCalledWith(
@@ -191,6 +198,12 @@ describe("SessionController#getSessionState", () => {
 
     const response = await controller.getSessionState(req);
     response.apply(res);
+
+    expect(mockSetRedisSessionStorage).toHaveBeenCalledWith(
+      expect.any(Object),
+      expect.any(Number),
+      true
+    );
 
     expect(controller).toBeTruthy();
     expect(mockGetNewToken).toBeCalledTimes(4);

--- a/src/services/ISessionStorage.ts
+++ b/src/services/ISessionStorage.ts
@@ -20,11 +20,17 @@ import { User, UserV5 } from "../types/user";
 
 export interface ISessionStorage {
   /**
-   * Stores a value to the cache.
+   * Stores or updated a value to the cache.
+   *
+   * @param user the user to store or update
+   * @param expireSec the ttl of all the session-related tokens
+   * @param isUserSessionUpdate a boolean that defines if we are updating an existing session or creating a new one
+   * @returns a promise of either an error or boolena
    */
   readonly set: (
     user: UserV5,
-    expireSec?: number
+    expireSec?: number,
+    isUserSessionUpdate?: boolean
   ) => Promise<Either<Error, boolean>>;
 
   /**

--- a/src/services/__tests__/redisSessionStorage.test.ts
+++ b/src/services/__tests__/redisSessionStorage.test.ts
@@ -397,9 +397,29 @@ describe("RedisSessionStorage#set", () => {
       expect(JSON.parse(mockSetEx.mock.calls[6][2])).toHaveProperty(
         "createdAt"
       );
+
+      expect(mockSadd).toHaveBeenCalled();
+
       expect(response).toEqual(expected);
     }
   );
+
+  it("should not call sAdd if is an update", async () => {
+    redisMethodImplFromError(mockSetEx, "OK");
+    redisMethodImplFromError(mockSetEx, "OK");
+    redisMethodImplFromError(mockSetEx, "OK");
+    redisMethodImplFromError(mockSetEx, "OK");
+    redisMethodImplFromError(mockSetEx, "OK");
+    // FIMS Token
+    redisMethodImplFromError(mockSetEx, "OK");
+    redisMethodImplFromError(mockSetEx, "OK");
+    redisMethodImplFromError(mockSadd, 1);
+    redisMethodImplFromError(mockSmembers, []);
+
+    await sessionStorage.set(aValidUser, 100, true);
+
+    expect(mockSadd).not.toHaveBeenCalled();
+  });
 });
 
 describe("RedisSessionStorage#removeOtherUserSessions", () => {

--- a/src/services/redisSessionStorage.ts
+++ b/src/services/redisSessionStorage.ts
@@ -91,7 +91,8 @@ export default class RedisSessionStorage
   // eslint-disable-next-line max-lines-per-function
   public async set(
     user: UserV5,
-    expireSec: number = this.tokenDurationSecs
+    expireSec: number = this.tokenDurationSecs,
+    isUserSessionUpdate: boolean = false
   ): Promise<Either<Error, boolean>> {
     const setSessionTokenV2 = pipe(
       TE.tryCatch(
@@ -182,7 +183,7 @@ export default class RedisSessionStorage
     // If is a session update, the session info key doesn't must be updated.
     // eslint-disable-next-line functional/no-let
     let saveSessionInfoPromise: TE.TaskEither<Error, boolean> = TE.right(true);
-    if (expireSec === this.tokenDurationSecs) {
+    if (!isUserSessionUpdate) {
       const sessionInfo: SessionInfo = {
         createdAt: new Date(),
         sessionToken: user.session_token,
@@ -677,7 +678,11 @@ export default class RedisSessionStorage
     }
 
     // We here update all the token but we can optimize it updating only missing tokens
-    const errorOrIsSessionUpdated = await this.set(updatedUser, sessionTtl);
+    const errorOrIsSessionUpdated = await this.set(
+      updatedUser,
+      sessionTtl,
+      true
+    );
     if (E.isLeft(errorOrIsSessionUpdated)) {
       return E.left(
         new Error(


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->

- add new isUserSessionUpdate in RedisSessionStorage `set` function, for discriminating between creation and update

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Bugfix for LV tokens

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Unit tests

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
