### PR TITLE
[#IOPID-376] The LolliPoP middleware can complete without an user session

### DIFF
--- a/src/__mocks__/lollipop.ts
+++ b/src/__mocks__/lollipop.ts
@@ -44,10 +44,13 @@ export const aLollipopAssertion =
 export const aSignature =
   `sig1=:hNojB+wWw4A7SYF3qK1S01Y4UP5i2JZFYa2WOlMB4Np5iWmJSO0bDe2hrYRbcIWqVAFjuuCBRsB7lYQJkzbb6g==:` as LollipopSignature;
 export const aSignatureInput =
-  `sig1=("x-pagopa-lollipop-original-method" "x-pagopa-lollipop-original-url"); created=1618884475; keyid="test-key-rsa-pss"` as LollipopSignatureInput;
+  `sig1=("x-pagopa-lollipop-original-method" "x-pagopa-lollipop-original-url"); created=1618884475; keyid="${anAssertionRef}"` as LollipopSignatureInput;
 export const aLollipopOriginalMethod = "POST" as LollipopMethod;
 export const aLollipopOriginalUrl =
   "https://api.pagopa.it" as LollipopOriginalURL;
+
+export const anInvalidSignatureInput =
+  `sig1=("x-pagopa-lollipop-original-method" "x-pagopa-lollipop-original-url"); created=1618884475; keyid="an-invalid-assertion-ref"` as LollipopSignatureInput;
 
 export const mockActivatePubKey = jest.fn();
 

--- a/src/__mocks__/pn.ts
+++ b/src/__mocks__/pn.ts
@@ -6,6 +6,7 @@ import { ServiceId } from "../../generated/io-messages-api/ServiceId";
 import { VALID_PDF } from "../utils/__mocks__/pdf_files";
 import { ThirdPartyMessage as PNThirdParthyMessage } from "../../generated/piattaforma-notifiche/ThirdPartyMessage";
 import { aFiscalCode } from "./user_mock";
+import { aSignatureInput, anAssertionRef } from "./lollipop";
 
 const STATUS_ACCEPTED = "ACCEPTED";
 
@@ -21,13 +22,13 @@ export const aDocIdx = "1";
 export const aPnNotificationRecipient = {
   recipientType: "PF",
   taxId: aFiscalCode,
-  denomination: "a-denomination"
+  denomination: "a-denomination",
 };
 export const aPnDocument = {
   digests: { sha256: "a-digest" },
   contentType: "application/pdf",
   ref: { key: "a-doc-key", versionToken: "1" },
-  docIdx: aDocIdx
+  docIdx: aDocIdx,
 };
 export const aPnNotificationDetails = {
   subject: "a-subject",
@@ -37,9 +38,9 @@ export const aPnNotificationDetails = {
     {
       activeFrom: aDate.toISOString(),
       status: STATUS_ACCEPTED,
-      relatedTimelineElements: [aTimelineId]
-    }
-  ]
+      relatedTimelineElements: [aTimelineId],
+    },
+  ],
 };
 
 export const aPNThirdPartyNotification = {
@@ -48,16 +49,16 @@ export const aPNThirdPartyNotification = {
       id: "JGQG-YPJT-AUQZ-202301-R-1_DOC0",
       content_type: "application/pdf",
       name: "Atto",
-      url: `/delivery/notifications/received/${aPnNotificationId}/attachments/documents/0`
+      url: `/delivery/notifications/received/${aPnNotificationId}/attachments/documents/0`,
     },
     {
       id: "JGQG-YPJT-AUQZ-202301-R-1_DOC1",
       content_type: "application/pdf",
       name: "Lettera di accompagnamento",
-      url: `/delivery/notifications/received/${aPnNotificationId}/attachments/documents/1`
-    }
+      url: `/delivery/notifications/received/${aPnNotificationId}/attachments/documents/1`,
+    },
   ],
-  details: aPnNotificationDetails
+  details: aPnNotificationDetails,
 };
 
 export const aPnThirdPartyMessage: PNThirdParthyMessage = pipe(
@@ -67,15 +68,32 @@ export const aPnThirdPartyMessage: PNThirdParthyMessage = pipe(
     throw new Error("a ThirdParty PN message is not valid");
   })
 );
-export const aPnNotificationDocument: NotificationAttachmentDownloadMetadataResponse = {
-  contentLength: 100,
-  contentType: "application/pdf",
-  filename: "a-file-name",
-  sha256: "a-digest",
-  url: aPnAttachmentUrl
-};
+export const aPnNotificationDocument: NotificationAttachmentDownloadMetadataResponse =
+  {
+    contentLength: 100,
+    contentType: "application/pdf",
+    filename: "a-file-name",
+    sha256: "a-digest",
+    url: aPnAttachmentUrl,
+  };
 export const documentBody = new util.TextEncoder().encode("a-document-body");
 export const aThirdPartyAttachmentForPnRelativeUrl =
   aPNThirdPartyNotification.attachments[1].url;
 
 export const base64File = VALID_PDF;
+
+export const lollipopPNHeaders = {
+  ApiKeyAuth: aPnKey,
+  iun: aPnNotificationId,
+  "x-pagopa-cx-taxid": aFiscalCode,
+  signature:
+    "sig1=:hNojB+wWw4A7SYF3qK1S01Y4UP5i2JZFYa2WOlMB4Np5iWmJSO0bDe2hrYRbcIWqVAFjuuCBRsB7lYQJkzbb6g==:",
+  "signature-input": aSignatureInput,
+  "x-pagopa-lollipop-assertion-ref": anAssertionRef,
+  "x-pagopa-lollipop-assertion-type": "SAML",
+  "x-pagopa-lollipop-auth-jwt": "a bearer token",
+  "x-pagopa-lollipop-original-method": "POST",
+  "x-pagopa-lollipop-original-url": "https://api.pagopa.it",
+  "x-pagopa-lollipop-public-key": "a pub key",
+  "x-pagopa-lollipop-user-id": "GRBGPP87L04L741X",
+};

--- a/src/adapters/__tests__/pnFetch.test.ts
+++ b/src/adapters/__tests__/pnFetch.test.ts
@@ -25,7 +25,11 @@ import {
   notificationDetailResponseExample,
   notificationDetailResponseExampleAsObject,
 } from "../../__mocks__/pn-response";
-import { lollipopParams } from "../../__mocks__/lollipop";
+import {
+  anAssertionRef,
+  aSignatureInput,
+  lollipopParams,
+} from "../../__mocks__/lollipop";
 import { aThirdPartyPrecondition } from "../../__mocks__/third-party";
 
 const dummyGetReceivedNotification = jest.fn();
@@ -146,10 +150,8 @@ describe("getThirdPartyMessageDetails", () => {
       "x-pagopa-cx-taxid": aFiscalCode,
       signature:
         "sig1=:hNojB+wWw4A7SYF3qK1S01Y4UP5i2JZFYa2WOlMB4Np5iWmJSO0bDe2hrYRbcIWqVAFjuuCBRsB7lYQJkzbb6g==:",
-      "signature-input":
-        'sig1=("x-pagopa-lollipop-original-method" "x-pagopa-lollipop-original-url"); created=1618884475; keyid="test-key-rsa-pss"',
-      "x-pagopa-lollipop-assertion-ref":
-        "sha256-6LvipIvFuhyorHpUqK3HjySC5Y6gshXHFBhU9EJ4DoM=",
+      "signature-input": aSignatureInput,
+      "x-pagopa-lollipop-assertion-ref": anAssertionRef,
       "x-pagopa-lollipop-assertion-type": "SAML",
       "x-pagopa-lollipop-auth-jwt": "a bearer token",
       "x-pagopa-lollipop-original-method": "POST",
@@ -246,10 +248,8 @@ describe("getThirdPartyMessageDetails", () => {
       "x-pagopa-cx-taxid": aFiscalCode,
       signature:
         "sig1=:hNojB+wWw4A7SYF3qK1S01Y4UP5i2JZFYa2WOlMB4Np5iWmJSO0bDe2hrYRbcIWqVAFjuuCBRsB7lYQJkzbb6g==:",
-      "signature-input":
-        'sig1=("x-pagopa-lollipop-original-method" "x-pagopa-lollipop-original-url"); created=1618884475; keyid="test-key-rsa-pss"',
-      "x-pagopa-lollipop-assertion-ref":
-        "sha256-6LvipIvFuhyorHpUqK3HjySC5Y6gshXHFBhU9EJ4DoM=",
+      "signature-input": aSignatureInput,
+      "x-pagopa-lollipop-assertion-ref": anAssertionRef,
       "x-pagopa-lollipop-assertion-type": "SAML",
       "x-pagopa-lollipop-auth-jwt": "a bearer token",
       "x-pagopa-lollipop-original-method": "POST",
@@ -352,10 +352,8 @@ describe("getThirdPartyAttachments", () => {
       "x-pagopa-cx-taxid": aFiscalCode,
       signature:
         "sig1=:hNojB+wWw4A7SYF3qK1S01Y4UP5i2JZFYa2WOlMB4Np5iWmJSO0bDe2hrYRbcIWqVAFjuuCBRsB7lYQJkzbb6g==:",
-      "signature-input":
-        'sig1=("x-pagopa-lollipop-original-method" "x-pagopa-lollipop-original-url"); created=1618884475; keyid="test-key-rsa-pss"',
-      "x-pagopa-lollipop-assertion-ref":
-        "sha256-6LvipIvFuhyorHpUqK3HjySC5Y6gshXHFBhU9EJ4DoM=",
+      "signature-input": aSignatureInput,
+      "x-pagopa-lollipop-assertion-ref": anAssertionRef,
       "x-pagopa-lollipop-assertion-type": "SAML",
       "x-pagopa-lollipop-auth-jwt": "a bearer token",
       "x-pagopa-lollipop-original-method": "POST",
@@ -411,10 +409,8 @@ describe("getThirdPartyAttachments", () => {
       "x-pagopa-cx-taxid": aFiscalCode,
       signature:
         "sig1=:hNojB+wWw4A7SYF3qK1S01Y4UP5i2JZFYa2WOlMB4Np5iWmJSO0bDe2hrYRbcIWqVAFjuuCBRsB7lYQJkzbb6g==:",
-      "signature-input":
-        'sig1=("x-pagopa-lollipop-original-method" "x-pagopa-lollipop-original-url"); created=1618884475; keyid="test-key-rsa-pss"',
-      "x-pagopa-lollipop-assertion-ref":
-        "sha256-6LvipIvFuhyorHpUqK3HjySC5Y6gshXHFBhU9EJ4DoM=",
+      "signature-input": aSignatureInput,
+      "x-pagopa-lollipop-assertion-ref": anAssertionRef,
       "x-pagopa-lollipop-assertion-type": "SAML",
       "x-pagopa-lollipop-auth-jwt": "a bearer token",
       "x-pagopa-lollipop-original-method": "POST",
@@ -472,10 +468,8 @@ describe("getThirdPartyAttachments", () => {
       "x-pagopa-cx-taxid": aFiscalCode,
       signature:
         "sig1=:hNojB+wWw4A7SYF3qK1S01Y4UP5i2JZFYa2WOlMB4Np5iWmJSO0bDe2hrYRbcIWqVAFjuuCBRsB7lYQJkzbb6g==:",
-      "signature-input":
-        'sig1=("x-pagopa-lollipop-original-method" "x-pagopa-lollipop-original-url"); created=1618884475; keyid="test-key-rsa-pss"',
-      "x-pagopa-lollipop-assertion-ref":
-        "sha256-6LvipIvFuhyorHpUqK3HjySC5Y6gshXHFBhU9EJ4DoM=",
+      "signature-input": aSignatureInput,
+      "x-pagopa-lollipop-assertion-ref": anAssertionRef,
       "x-pagopa-lollipop-assertion-type": "SAML",
       "x-pagopa-lollipop-auth-jwt": "a bearer token",
       "x-pagopa-lollipop-original-method": "POST",
@@ -594,10 +588,8 @@ describe("getThirdPartyMessagePrecondition", () => {
       "x-pagopa-cx-taxid": aFiscalCode,
       signature:
         "sig1=:hNojB+wWw4A7SYF3qK1S01Y4UP5i2JZFYa2WOlMB4Np5iWmJSO0bDe2hrYRbcIWqVAFjuuCBRsB7lYQJkzbb6g==:",
-      "signature-input":
-        'sig1=("x-pagopa-lollipop-original-method" "x-pagopa-lollipop-original-url"); created=1618884475; keyid="test-key-rsa-pss"',
-      "x-pagopa-lollipop-assertion-ref":
-        "sha256-6LvipIvFuhyorHpUqK3HjySC5Y6gshXHFBhU9EJ4DoM=",
+      "signature-input": aSignatureInput,
+      "x-pagopa-lollipop-assertion-ref": anAssertionRef,
       "x-pagopa-lollipop-assertion-type": "SAML",
       "x-pagopa-lollipop-auth-jwt": "a bearer token",
       "x-pagopa-lollipop-original-method": "POST",
@@ -648,10 +640,8 @@ describe("getThirdPartyMessagePrecondition", () => {
       "x-pagopa-cx-taxid": aFiscalCode,
       signature:
         "sig1=:hNojB+wWw4A7SYF3qK1S01Y4UP5i2JZFYa2WOlMB4Np5iWmJSO0bDe2hrYRbcIWqVAFjuuCBRsB7lYQJkzbb6g==:",
-      "signature-input":
-        'sig1=("x-pagopa-lollipop-original-method" "x-pagopa-lollipop-original-url"); created=1618884475; keyid="test-key-rsa-pss"',
-      "x-pagopa-lollipop-assertion-ref":
-        "sha256-6LvipIvFuhyorHpUqK3HjySC5Y6gshXHFBhU9EJ4DoM=",
+      "signature-input": aSignatureInput,
+      "x-pagopa-lollipop-assertion-ref": anAssertionRef,
       "x-pagopa-lollipop-assertion-type": "SAML",
       "x-pagopa-lollipop-auth-jwt": "a bearer token",
       "x-pagopa-lollipop-original-method": "POST",

--- a/src/adapters/__tests__/pnFetch.test.ts
+++ b/src/adapters/__tests__/pnFetch.test.ts
@@ -20,16 +20,13 @@ import {
   aPnUrl,
   aThirdPartyAttachmentForPnRelativeUrl,
   documentBody,
+  lollipopPNHeaders,
 } from "../../__mocks__/pn";
 import {
   notificationDetailResponseExample,
   notificationDetailResponseExampleAsObject,
 } from "../../__mocks__/pn-response";
-import {
-  anAssertionRef,
-  aSignatureInput,
-  lollipopParams,
-} from "../../__mocks__/lollipop";
+import { lollipopParams } from "../../__mocks__/lollipop";
 import { aThirdPartyPrecondition } from "../../__mocks__/third-party";
 
 const dummyGetReceivedNotification = jest.fn();
@@ -145,19 +142,7 @@ describe("getThirdPartyMessageDetails", () => {
 
     expect(dummyGetReceivedNotification).toHaveBeenCalledTimes(1);
     expect(dummyGetReceivedNotification).toHaveBeenCalledWith({
-      ApiKeyAuth: aPnKey,
-      iun: aPnNotificationId,
-      "x-pagopa-cx-taxid": aFiscalCode,
-      signature:
-        "sig1=:hNojB+wWw4A7SYF3qK1S01Y4UP5i2JZFYa2WOlMB4Np5iWmJSO0bDe2hrYRbcIWqVAFjuuCBRsB7lYQJkzbb6g==:",
-      "signature-input": aSignatureInput,
-      "x-pagopa-lollipop-assertion-ref": anAssertionRef,
-      "x-pagopa-lollipop-assertion-type": "SAML",
-      "x-pagopa-lollipop-auth-jwt": "a bearer token",
-      "x-pagopa-lollipop-original-method": "POST",
-      "x-pagopa-lollipop-original-url": "https://api.pagopa.it",
-      "x-pagopa-lollipop-public-key": "a pub key",
-      "x-pagopa-lollipop-user-id": "GRBGPP87L04L741X",
+      ...lollipopPNHeaders,
     });
 
     expect(dummyGetSentNotificationDocument).toHaveBeenCalledTimes(0);
@@ -243,19 +228,7 @@ describe("getThirdPartyMessageDetails", () => {
 
     expect(dummyGetReceivedNotification).toHaveBeenCalledTimes(1);
     expect(dummyGetReceivedNotification).toHaveBeenCalledWith({
-      ApiKeyAuth: aPnKey,
-      iun: aPnNotificationId,
-      "x-pagopa-cx-taxid": aFiscalCode,
-      signature:
-        "sig1=:hNojB+wWw4A7SYF3qK1S01Y4UP5i2JZFYa2WOlMB4Np5iWmJSO0bDe2hrYRbcIWqVAFjuuCBRsB7lYQJkzbb6g==:",
-      "signature-input": aSignatureInput,
-      "x-pagopa-lollipop-assertion-ref": anAssertionRef,
-      "x-pagopa-lollipop-assertion-type": "SAML",
-      "x-pagopa-lollipop-auth-jwt": "a bearer token",
-      "x-pagopa-lollipop-original-method": "POST",
-      "x-pagopa-lollipop-original-url": "https://api.pagopa.it",
-      "x-pagopa-lollipop-public-key": "a pub key",
-      "x-pagopa-lollipop-user-id": "GRBGPP87L04L741X",
+      ...lollipopPNHeaders,
     });
 
     expect(dummyGetSentNotificationDocument).toHaveBeenCalledTimes(0);
@@ -347,19 +320,7 @@ describe("getThirdPartyAttachments", () => {
 
     expect(dummyGetSentNotificationDocument).toHaveBeenCalledTimes(1);
     expect(dummyGetSentNotificationDocument).toHaveBeenCalledWith({
-      ApiKeyAuth: aPnKey,
-      iun: aPnNotificationId,
-      "x-pagopa-cx-taxid": aFiscalCode,
-      signature:
-        "sig1=:hNojB+wWw4A7SYF3qK1S01Y4UP5i2JZFYa2WOlMB4Np5iWmJSO0bDe2hrYRbcIWqVAFjuuCBRsB7lYQJkzbb6g==:",
-      "signature-input": aSignatureInput,
-      "x-pagopa-lollipop-assertion-ref": anAssertionRef,
-      "x-pagopa-lollipop-assertion-type": "SAML",
-      "x-pagopa-lollipop-auth-jwt": "a bearer token",
-      "x-pagopa-lollipop-original-method": "POST",
-      "x-pagopa-lollipop-original-url": "https://api.pagopa.it",
-      "x-pagopa-lollipop-public-key": "a pub key",
-      "x-pagopa-lollipop-user-id": "GRBGPP87L04L741X",
+      ...lollipopPNHeaders,
       docIdx: Number(aDocIdx),
     });
     expect(dummyFetch).toHaveBeenCalledTimes(1);
@@ -404,19 +365,7 @@ describe("getThirdPartyAttachments", () => {
 
     expect(dummyGetSentNotificationDocument).toHaveBeenCalledTimes(1);
     expect(dummyGetSentNotificationDocument).toHaveBeenCalledWith({
-      ApiKeyAuth: aPnKey,
-      iun: aPnNotificationId,
-      "x-pagopa-cx-taxid": aFiscalCode,
-      signature:
-        "sig1=:hNojB+wWw4A7SYF3qK1S01Y4UP5i2JZFYa2WOlMB4Np5iWmJSO0bDe2hrYRbcIWqVAFjuuCBRsB7lYQJkzbb6g==:",
-      "signature-input": aSignatureInput,
-      "x-pagopa-lollipop-assertion-ref": anAssertionRef,
-      "x-pagopa-lollipop-assertion-type": "SAML",
-      "x-pagopa-lollipop-auth-jwt": "a bearer token",
-      "x-pagopa-lollipop-original-method": "POST",
-      "x-pagopa-lollipop-original-url": "https://api.pagopa.it",
-      "x-pagopa-lollipop-public-key": "a pub key",
-      "x-pagopa-lollipop-user-id": "GRBGPP87L04L741X",
+      ...lollipopPNHeaders,
       docIdx: Number(aDocIdx),
     });
     expect(dummyFetch).toHaveBeenCalledTimes(0);
@@ -463,19 +412,7 @@ describe("getThirdPartyAttachments", () => {
 
     expect(dummyGetSentNotificationDocument).toHaveBeenCalledTimes(1);
     expect(dummyGetSentNotificationDocument).toHaveBeenCalledWith({
-      ApiKeyAuth: aPnKey,
-      iun: aPnNotificationId,
-      "x-pagopa-cx-taxid": aFiscalCode,
-      signature:
-        "sig1=:hNojB+wWw4A7SYF3qK1S01Y4UP5i2JZFYa2WOlMB4Np5iWmJSO0bDe2hrYRbcIWqVAFjuuCBRsB7lYQJkzbb6g==:",
-      "signature-input": aSignatureInput,
-      "x-pagopa-lollipop-assertion-ref": anAssertionRef,
-      "x-pagopa-lollipop-assertion-type": "SAML",
-      "x-pagopa-lollipop-auth-jwt": "a bearer token",
-      "x-pagopa-lollipop-original-method": "POST",
-      "x-pagopa-lollipop-original-url": "https://api.pagopa.it",
-      "x-pagopa-lollipop-public-key": "a pub key",
-      "x-pagopa-lollipop-user-id": "GRBGPP87L04L741X",
+      ...lollipopPNHeaders,
       docIdx: Number(aDocIdx),
     });
     expect(dummyFetch).toHaveBeenCalledTimes(1);
@@ -583,19 +520,7 @@ describe("getThirdPartyMessagePrecondition", () => {
 
     expect(dummyGetReceivedNotificationPrecondition).toHaveBeenCalledTimes(1);
     expect(dummyGetReceivedNotificationPrecondition).toHaveBeenCalledWith({
-      ApiKeyAuth: aPnKey,
-      iun: aPnNotificationId,
-      "x-pagopa-cx-taxid": aFiscalCode,
-      signature:
-        "sig1=:hNojB+wWw4A7SYF3qK1S01Y4UP5i2JZFYa2WOlMB4Np5iWmJSO0bDe2hrYRbcIWqVAFjuuCBRsB7lYQJkzbb6g==:",
-      "signature-input": aSignatureInput,
-      "x-pagopa-lollipop-assertion-ref": anAssertionRef,
-      "x-pagopa-lollipop-assertion-type": "SAML",
-      "x-pagopa-lollipop-auth-jwt": "a bearer token",
-      "x-pagopa-lollipop-original-method": "POST",
-      "x-pagopa-lollipop-original-url": "https://api.pagopa.it",
-      "x-pagopa-lollipop-public-key": "a pub key",
-      "x-pagopa-lollipop-user-id": "GRBGPP87L04L741X",
+      ...lollipopPNHeaders,
     });
 
     expect(E.isRight(result)).toBeTruthy();
@@ -635,19 +560,7 @@ describe("getThirdPartyMessagePrecondition", () => {
 
     expect(dummyGetReceivedNotificationPrecondition).toHaveBeenCalledTimes(1);
     expect(dummyGetReceivedNotificationPrecondition).toHaveBeenCalledWith({
-      ApiKeyAuth: aPnKey,
-      iun: aPnNotificationId,
-      "x-pagopa-cx-taxid": aFiscalCode,
-      signature:
-        "sig1=:hNojB+wWw4A7SYF3qK1S01Y4UP5i2JZFYa2WOlMB4Np5iWmJSO0bDe2hrYRbcIWqVAFjuuCBRsB7lYQJkzbb6g==:",
-      "signature-input": aSignatureInput,
-      "x-pagopa-lollipop-assertion-ref": anAssertionRef,
-      "x-pagopa-lollipop-assertion-type": "SAML",
-      "x-pagopa-lollipop-auth-jwt": "a bearer token",
-      "x-pagopa-lollipop-original-method": "POST",
-      "x-pagopa-lollipop-original-url": "https://api.pagopa.it",
-      "x-pagopa-lollipop-public-key": "a pub key",
-      "x-pagopa-lollipop-user-id": "GRBGPP87L04L741X",
+      ...lollipopPNHeaders,
     });
 
     expect(E.isRight(result)).toBeTruthy();

--- a/src/controllers/messagesController.ts
+++ b/src/controllers/messagesController.ts
@@ -248,8 +248,8 @@ export default class MessagesController {
                       extractLollipopLocalsFromLollipopHeaders(
                         this.lollipopClient,
                         this.sessionStorage,
-                        user.fiscal_code,
-                        lollipopHeaders
+                        lollipopHeaders,
+                        user.fiscal_code
                       ),
                       TE.mapLeft((_) =>
                         ResponseErrorInternal(

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -288,6 +288,15 @@ export const withUserFromRequest = async <T>(
 ): Promise<IResponseErrorValidation | T> =>
   withValidatedOrValidationError(User.decode(req.user), f);
 
+export const withOptionalUserFromRequest = async <T>(
+  req: express.Request,
+  f: (user: O.Option<User>) => Promise<T>
+): Promise<IResponseErrorValidation | T> =>
+  withValidatedOrValidationError(
+    req.user ? pipe(User.decode(req.user), E.map(O.some)) : E.right(O.none),
+    f
+  );
+
 /**
  * Extracts a user from a json string.
  */

--- a/src/utils/lollipop.ts
+++ b/src/utils/lollipop.ts
@@ -110,7 +110,7 @@ const validateAssertionRefForUser = (
     TE.chainW(TE.fromOption(() => ResponseErrorForbiddenNotAuthorized)),
     TE.chainW(
       TE.fromPredicate(
-        (_) => _ === requestAssertionRef,
+        (storageAssertionRef) => storageAssertionRef === requestAssertionRef,
         () => ResponseErrorForbiddenNotAuthorized
       )
     ),

--- a/src/utils/lollipop.ts
+++ b/src/utils/lollipop.ts
@@ -250,8 +250,8 @@ export const extractLollipopLocalsFromLollipopHeaders = (
           ["x-pagopa-lollipop-assertion-type"]: lcParams.assertion_type,
           ["x-pagopa-lollipop-auth-jwt"]: lcParams.lc_authentication_bearer,
           ["x-pagopa-lollipop-public-key"]: lcParams.pub_key,
-          // It's possible to improve security by verify that the fiscal code from
-          // the authorization is the same of the value given from the lollipop function
+          // It's possible to improve security by verifying that the fiscal code from
+          // the authorization is equal to the one from the lollipop function
           ["x-pagopa-lollipop-user-id"]: fiscalCode || lcParams.fiscal_code,
           ...lollipopHeaders,
         } as LollipopLocalsType)

--- a/src/utils/middleware/__tests__/lollipop.test.ts
+++ b/src/utils/middleware/__tests__/lollipop.test.ts
@@ -7,8 +7,10 @@ import {
   aLollipopOriginalMethod,
   aLollipopOriginalUrl,
   anAssertionRef,
+  anInvalidSignatureInput,
+  anotherAssertionRef,
   aSignature,
-  aSignatureInput
+  aSignatureInput,
 } from "../../../__mocks__/lollipop";
 import mockRes from "../../../__mocks__/response";
 import * as E from "fp-ts/Either";
@@ -17,29 +19,44 @@ import * as O from "fp-ts/Option";
 import { PubKeyStatusEnum } from "../../../../generated/lollipop-api/PubKeyStatus";
 import { NonEmptyString } from "@pagopa/ts-commons/lib/strings";
 
-const mockGenerateLCParams = jest.fn();
+const aBearerToken = "a bearer token";
+const aPubKey = "a pub key";
+const mockGenerateLCParams = jest.fn().mockResolvedValue(
+  E.right({
+    status: 200,
+    value: {
+      fiscal_code: aFiscalCode,
+      assertion_file_name: `${aFiscalCode}-${anAssertionRef}`,
+      assertion_type: AssertionTypeEnum.SAML,
+      expired_at: Date.now(),
+      lc_authentication_bearer: aBearerToken,
+      assertion_ref: anAssertionRef,
+      pub_key: aPubKey,
+      version: 1,
+      status: PubKeyStatusEnum.VALID,
+      ttl: 900,
+    },
+  })
+);
 const mockClient = {
   generateLCParams: mockGenerateLCParams,
   activatePubKey: jest.fn(),
   ping: jest.fn(),
-  reservePubKey: jest.fn()
+  reservePubKey: jest.fn(),
 } as ReturnType<typeof LollipopApiClient>;
 
 const mockGetlollipopAssertionRefForUser = jest
   .fn()
   .mockResolvedValue(E.right(O.some(anAssertionRef)));
-const mockSessionStorage = ({
-  getLollipopAssertionRefForUser: mockGetlollipopAssertionRefForUser
-} as unknown) as ISessionStorage;
-
-const aBearerToken = "a bearer token";
-const aPubKey = "a pub key";
+const mockSessionStorage = {
+  getLollipopAssertionRefForUser: mockGetlollipopAssertionRefForUser,
+} as unknown as ISessionStorage;
 
 const aValidLollipopRequestHeaders = {
   signature: aSignature,
   ["signature-input"]: aSignatureInput,
   ["x-pagopa-lollipop-original-method"]: aLollipopOriginalMethod,
-  ["x-pagopa-lollipop-original-url"]: aLollipopOriginalUrl
+  ["x-pagopa-lollipop-original-url"]: aLollipopOriginalUrl,
 };
 
 const mockNext = jest.fn();
@@ -54,26 +71,9 @@ describe("lollipopMiddleware", () => {
   `, async () => {
     const req = mockReq({
       headers: aValidLollipopRequestHeaders,
-      user: mockedUser
+      user: mockedUser,
     });
     const res = mockRes();
-    mockGenerateLCParams.mockResolvedValueOnce(
-      E.right({
-        status: 200,
-        value: {
-          fiscal_code: aFiscalCode,
-          assertion_file_name: `${aFiscalCode}-${anAssertionRef}`,
-          assertion_type: AssertionTypeEnum.SAML,
-          expired_at: Date.now(),
-          lc_authentication_bearer: aBearerToken,
-          assertion_ref: anAssertionRef,
-          pub_key: aPubKey,
-          version: 1,
-          status: PubKeyStatusEnum.VALID,
-          ttl: 900
-        }
-      })
-    );
     const middleware = expressLollipopMiddleware(
       mockClient,
       mockSessionStorage
@@ -83,10 +83,10 @@ describe("lollipopMiddleware", () => {
     expect(mockGenerateLCParams).toBeCalledWith({
       assertion_ref: anAssertionRef,
       body: {
-        operation_id: expect.any(String)
-      }
+        operation_id: expect.any(String),
+      },
     });
-    expect(res.json).not.toBeCalledWith();
+    expect(res.json).not.toBeCalled();
     expect(res.status).not.toBeCalled();
     expect(res.locals).toEqual({
       ["x-pagopa-lollipop-assertion-ref"]: anAssertionRef,
@@ -94,7 +94,7 @@ describe("lollipopMiddleware", () => {
       ["x-pagopa-lollipop-auth-jwt"]: aBearerToken,
       ["x-pagopa-lollipop-public-key"]: aPubKey,
       ["x-pagopa-lollipop-user-id"]: aFiscalCode,
-      ...aValidLollipopRequestHeaders
+      ...aValidLollipopRequestHeaders,
     });
     expect(mockNext).toBeCalledTimes(1);
     expect(mockNext).toBeCalledWith();
@@ -107,11 +107,11 @@ describe("lollipopMiddleware", () => {
   `, async () => {
     const lollipopRequestHeaders = {
       ...aValidLollipopRequestHeaders,
-      ["x-pagopa-lollipop-original-url"]: undefined
+      ["x-pagopa-lollipop-original-url"]: undefined,
     };
     const req = mockReq({
       headers: lollipopRequestHeaders,
-      user: mockedUser
+      user: mockedUser,
     });
     const res = mockRes();
     const middleware = expressLollipopMiddleware(
@@ -126,13 +126,38 @@ describe("lollipopMiddleware", () => {
   });
 
   it(`
+  GIVEN a valid user and Lollipop Headers
+  WHEN the keyid in signature-input is invalid
+  THEN returns a an internal server error
+  `, async () => {
+    const lollipopRequestHeaders = {
+      ...aValidLollipopRequestHeaders,
+      ["signature-input"]: anInvalidSignatureInput,
+    };
+    const req = mockReq({
+      headers: lollipopRequestHeaders,
+      user: mockedUser,
+    });
+    const res = mockRes();
+    const middleware = expressLollipopMiddleware(
+      mockClient,
+      mockSessionStorage
+    );
+    await middleware(req, res, mockNext);
+    expect(mockGetlollipopAssertionRefForUser).not.toBeCalled();
+    expect(mockGenerateLCParams).not.toBeCalled();
+    expect(res.status).toBeCalledWith(500);
+    expect(mockNext).not.toBeCalled();
+  });
+
+  it(`
   GIVEN a user and valid Lollipop Headers
   WHEN the user is invalid
   THEN returns a validation error
   `, async () => {
     const req = mockReq({
       headers: aValidLollipopRequestHeaders,
-      user: { ...mockedUser, fiscal_code: "invalidFiscalCode" }
+      user: { ...mockedUser, fiscal_code: "invalidFiscalCode" },
     });
     const res = mockRes();
     const middleware = expressLollipopMiddleware(
@@ -146,11 +171,44 @@ describe("lollipopMiddleware", () => {
     expect(mockNext).not.toBeCalled();
   });
 
+  it(`
+  GIVEN valid Lollipop Headers without a User
+  WHEN the API is not authenticated
+  THEN returns success
+  `, async () => {
+    const req = mockReq({
+      headers: aValidLollipopRequestHeaders,
+    });
+    const res = mockRes();
+    // Delete the default user value
+    req.user = undefined;
+    const middleware = expressLollipopMiddleware(
+      mockClient,
+      mockSessionStorage
+    );
+    await middleware(req, res, mockNext);
+    expect(mockGenerateLCParams).toBeCalled();
+    expect(mockGetlollipopAssertionRefForUser).toBeCalled();
+    expect(res.json).not.toBeCalled();
+    expect(res.status).not.toBeCalled();
+    expect(res.locals).toEqual({
+      ["x-pagopa-lollipop-assertion-ref"]: anAssertionRef,
+      ["x-pagopa-lollipop-assertion-type"]: AssertionTypeEnum.SAML,
+      ["x-pagopa-lollipop-auth-jwt"]: aBearerToken,
+      ["x-pagopa-lollipop-public-key"]: aPubKey,
+      ["x-pagopa-lollipop-user-id"]: aFiscalCode,
+      ...aValidLollipopRequestHeaders,
+    });
+    expect(mockNext).toBeCalledTimes(1);
+    expect(mockNext).toBeCalledWith();
+  });
+
   it.each`
-    title                                                    | lollipopAssertionRefForUser                                          | expectedResponseStatus
-    ${"the lollipopAssertionRefForUser rejects"}             | ${Promise.reject(new Error("promise reject"))}                       | ${500}
-    ${"the lollipopAssertionRefForUser returns an error"}    | ${Promise.resolve(E.left(new Error("Error executing the request")))} | ${500}
-    ${"the lollipopAssertionRefForUser not found the value"} | ${Promise.resolve(E.right(O.none))}                                  | ${403}
+    title                                                                              | lollipopAssertionRefForUser                                          | expectedResponseStatus
+    ${"the lollipopAssertionRefForUser returns a different assertionRef from request"} | ${Promise.resolve(E.right(O.some(anotherAssertionRef)))}             | ${403}
+    ${"the lollipopAssertionRefForUser rejects"}                                       | ${Promise.reject(new Error("promise reject"))}                       | ${500}
+    ${"the lollipopAssertionRefForUser returns an error"}                              | ${Promise.resolve(E.left(new Error("Error executing the request")))} | ${500}
+    ${"the lollipopAssertionRefForUser not found the value"}                           | ${Promise.resolve(E.right(O.none))}                                  | ${403}
   `(
     `
   GIVEN a valid user and Lollipop Headers
@@ -160,7 +218,7 @@ describe("lollipopMiddleware", () => {
     async ({ lollipopAssertionRefForUser, expectedResponseStatus }) => {
       const req = mockReq({
         headers: aValidLollipopRequestHeaders,
-        user: mockedUser
+        user: mockedUser,
       });
       const res = mockRes();
       mockGetlollipopAssertionRefForUser.mockImplementationOnce(
@@ -194,7 +252,7 @@ describe("lollipopMiddleware", () => {
     async ({ generateLCParams, expectedResponseStatus }) => {
       const req = mockReq({
         headers: aValidLollipopRequestHeaders,
-        user: mockedUser
+        user: mockedUser,
       });
       const res = mockRes();
       mockGenerateLCParams.mockImplementationOnce(() => generateLCParams);


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->
New `withOptionalUserFromRequest` to retrieve the User if present
The Lollipop middleware verify the CF and AssertionRef from the request and the LCParams if the session is missing
add some validation on edge case

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
LV needs to use LolliPoP without an active user session. The Lollipop middleware now can be used even if the session token is not provided.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
unit test

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
