### PR TITLE
[#IOPID-382] Legacy LolliPoP middleware without assertionRef validation

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -173,7 +173,10 @@ import {
 import { lollipopLoginHandler } from "./handlers/lollipop";
 import LollipopService from "./services/lollipopService";
 import { firstLollipopSign } from "./controllers/firstLollipopConsumerController";
-import { expressLollipopMiddleware } from "./utils/middleware/lollipop";
+import {
+  expressLollipopMiddleware,
+  expressLollipopMiddlewareLegacy,
+} from "./utils/middleware/lollipop";
 import { LollipopApiClient } from "./clients/lollipop";
 import { ISessionStorage } from "./services/ISessionStorage";
 import { FirstLollipopConsumerClient } from "./clients/firstLollipopConsumer";
@@ -1386,7 +1389,7 @@ function registerIoSignAPIRoutes(
   app.post(
     `${basePath}/signatures`,
     bearerSessionTokenAuth,
-    expressLollipopMiddleware(lollipopClient, sessionStorage),
+    expressLollipopMiddlewareLegacy(lollipopClient, sessionStorage),
     toExpressHandler(ioSignController.createSignature, ioSignController)
   );
 

--- a/src/utils/lollipop.ts
+++ b/src/utils/lollipop.ts
@@ -117,6 +117,141 @@ const validateAssertionRefForUser = (
     TE.map(() => true)
   );
 
+/**
+ * @deprecated
+ */
+export const extractLollipopLocalsFromLollipopHeadersLegacy = (
+  lollipopClient: ReturnType<typeof LollipopApiClient>,
+  sessionStorage: ISessionStorage,
+  fiscalCode: FiscalCode,
+  lollipopHeaders: LollipopRequiredHeaders
+) =>
+  pipe(
+    // eslint-disable-next-line sonarjs/no-duplicate-string
+    TE.of(getNonceOrUlid(lollipopHeaders["signature-input"])),
+    TE.bindTo("operationId"),
+    TE.bind("assertionRef", ({ operationId }) =>
+      pipe(
+        TE.tryCatch(
+          () => sessionStorage.getLollipopAssertionRefForUser(fiscalCode),
+          E.toError
+        ),
+        TE.chainEitherK(identity),
+        // eslint-disable-next-line sonarjs/no-identical-functions
+        eventLog.taskEither.errorLeft((err) => [
+          `An error occurs retrieving the assertion ref from Redis | ${err.message}`,
+          {
+            fiscal_code: sha256(fiscalCode),
+            name: LOLLIPOP_SIGN_ERROR_EVENT_NAME,
+            operation_id: operationId,
+          },
+        ]),
+        // eslint-disable-next-line sonarjs/no-identical-functions
+        TE.mapLeft((err) => {
+          log.error(
+            "lollipopMiddleware|error reading the assertionRef from redis [%s]",
+            err.message
+          );
+          return ResponseErrorInternal("Error retrieving the assertionRef");
+        }),
+        TE.chainW(TE.fromOption(() => ResponseErrorForbiddenNotAuthorized))
+      )
+    ),
+    TE.bindW("generateLCParamsResponse", ({ assertionRef, operationId }) =>
+      pipe(
+        TE.tryCatch(
+          () =>
+            lollipopClient.generateLCParams({
+              assertion_ref: assertionRef,
+              body: {
+                operation_id: operationId,
+              },
+            }),
+          E.toError
+        ),
+        eventLog.taskEither.errorLeft((error) => [
+          `Error trying to call the Lollipop function service | ${error.message}`,
+          {
+            assertion_ref: assertionRef,
+            fiscal_code: sha256(fiscalCode),
+            name: LOLLIPOP_SIGN_ERROR_EVENT_NAME,
+            operation_id: operationId,
+          },
+        ]),
+        TE.mapLeft((err) => {
+          log.error(
+            "lollipopMiddleware|error trying to call the Lollipop function service [%s]",
+            err.message
+          );
+          return ResponseErrorInternal(
+            "Error calling the Lollipop function service"
+          );
+        })
+      )
+    ),
+    TE.chain(({ generateLCParamsResponse, assertionRef, operationId }) =>
+      pipe(
+        generateLCParamsResponse,
+        TE.fromEither,
+        eventLog.taskEither.errorLeft((err) => [
+          `Unexpected response from the lollipop function service | ${readableReportSimplified(
+            err
+          )}`,
+          {
+            assertion_ref: assertionRef,
+            fiscal_code: sha256(fiscalCode),
+            name: LOLLIPOP_SIGN_ERROR_EVENT_NAME,
+            operation_id: operationId,
+          },
+        ]),
+        TE.mapLeft((err) => {
+          log.error(
+            "lollipopMiddleware|error calling the Lollipop function service [%s]",
+            readableReportSimplified(err)
+          );
+          return ResponseErrorInternal(
+            "Unexpected response from lollipop service"
+          );
+        }),
+        TE.chainW((lollipopRes) =>
+          pipe(
+            lollipopRes.status === 200
+              ? TE.of<ErrorsResponses, LcParams>(lollipopRes.value)
+              : lollipopRes.status === 403
+              ? TE.left(ResponseErrorForbiddenNotAuthorized)
+              : TE.left(
+                  ResponseErrorInternal("The lollipop service returns an error")
+                ),
+            eventLog.taskEither.errorLeft((errorResponse) => [
+              `The lollipop function service returns an error | ${errorResponse.kind}`,
+              {
+                assertion_ref: assertionRef,
+                fiscal_code: sha256(fiscalCode),
+                name: LOLLIPOP_SIGN_ERROR_EVENT_NAME,
+                operation_id: operationId,
+              },
+            ])
+          )
+        )
+      )
+    ),
+    TE.map(
+      (lcParams) =>
+        ({
+          ["x-pagopa-lollipop-assertion-ref"]: lcParams.assertion_ref,
+          ["x-pagopa-lollipop-assertion-type"]: lcParams.assertion_type,
+          ["x-pagopa-lollipop-auth-jwt"]: lcParams.lc_authentication_bearer,
+          ["x-pagopa-lollipop-public-key"]: lcParams.pub_key,
+          ["x-pagopa-lollipop-user-id"]: fiscalCode,
+          ...lollipopHeaders,
+        } as LollipopLocalsType)
+    ),
+    eventLog.taskEither.info((lcLocals) => [
+      "Lollipop locals to be sent to third party api",
+      { ...Object.keys(lcLocals), name: "lollipop.locals.info" },
+    ])
+  );
+
 export const extractLollipopLocalsFromLollipopHeaders = (
   lollipopClient: ReturnType<typeof LollipopApiClient>,
   sessionStorage: ISessionStorage,
@@ -155,6 +290,7 @@ export const extractLollipopLocalsFromLollipopHeaders = (
     TE.bindW("lcParams", ({ assertionRef, operationId }) =>
       pipe(
         TE.tryCatch(
+          // eslint-disable-next-line sonarjs/no-identical-functions
           () =>
             lollipopClient.generateLCParams({
               assertion_ref: assertionRef,
@@ -173,6 +309,7 @@ export const extractLollipopLocalsFromLollipopHeaders = (
             operation_id: operationId,
           }),
         ]),
+        // eslint-disable-next-line sonarjs/no-identical-functions
         TE.mapLeft((err) => {
           log.error(
             "lollipopMiddleware|error trying to call the Lollipop function service [%s]",
@@ -196,6 +333,7 @@ export const extractLollipopLocalsFromLollipopHeaders = (
                 operation_id: operationId,
               }),
             ]),
+            // eslint-disable-next-line sonarjs/no-identical-functions
             TE.mapLeft((err) => {
               log.error(
                 "lollipopMiddleware|error calling the Lollipop function service [%s]",
@@ -256,6 +394,7 @@ export const extractLollipopLocalsFromLollipopHeaders = (
           ...lollipopHeaders,
         } as LollipopLocalsType)
     ),
+    // eslint-disable-next-line sonarjs/no-identical-functions
     eventLog.taskEither.info((lcLocals) => [
       "Lollipop locals to be sent to third party api",
       { ...Object.keys(lcLocals), name: "lollipop.locals.info" },

--- a/src/utils/lollipop.ts
+++ b/src/utils/lollipop.ts
@@ -277,7 +277,7 @@ export const extractLollipopLocalsFromLollipopHeaders = (
       pipe(
         getAssertionRefFromSignature(lollipopHeaders["signature-input"]),
         eventLog.either.errorLeft(() => [
-          `AssertionRef is different from stored one`,
+          `AssertionRef in signature-input is missing or invalid`,
           {
             fiscal_code: fiscalCode ? sha256(fiscalCode) : undefined,
             name: LOLLIPOP_SIGN_ERROR_EVENT_NAME,

--- a/src/utils/lollipop.ts
+++ b/src/utils/lollipop.ts
@@ -127,6 +127,7 @@ const validateAssertionRefForUser = (
     TE.map(() => true)
   );
 
+/* eslint-disable sonarjs/no-identical-functions */
 /**
  * @deprecated
  */
@@ -147,7 +148,6 @@ export const extractLollipopLocalsFromLollipopHeadersLegacy = (
           E.toError
         ),
         TE.chainEitherK(identity),
-        // eslint-disable-next-line sonarjs/no-identical-functions
         eventLog.taskEither.errorLeft((err) => [
           `An error occurs retrieving the assertion ref from Redis | ${err.message}`,
           {
@@ -156,7 +156,6 @@ export const extractLollipopLocalsFromLollipopHeadersLegacy = (
             operation_id: operationId,
           },
         ]),
-        // eslint-disable-next-line sonarjs/no-identical-functions
         TE.mapLeft((err) => {
           log.error(
             "lollipopMiddleware|error reading the assertionRef from redis [%s]",
@@ -308,7 +307,6 @@ export const extractLollipopLocalsFromLollipopHeaders = (
     TE.bindW("lcParams", ({ assertionRef, operationId }) =>
       pipe(
         TE.tryCatch(
-          // eslint-disable-next-line sonarjs/no-identical-functions
           () =>
             lollipopClient.generateLCParams({
               assertion_ref: assertionRef,
@@ -327,7 +325,6 @@ export const extractLollipopLocalsFromLollipopHeaders = (
             operation_id: operationId,
           }),
         ]),
-        // eslint-disable-next-line sonarjs/no-identical-functions
         TE.mapLeft((err) => {
           log.error(
             "lollipopMiddleware|error trying to call the Lollipop function service [%s]",
@@ -351,7 +348,6 @@ export const extractLollipopLocalsFromLollipopHeaders = (
                 operation_id: operationId,
               }),
             ]),
-            // eslint-disable-next-line sonarjs/no-identical-functions
             TE.mapLeft((err) => {
               log.error(
                 "lollipopMiddleware|error calling the Lollipop function service [%s]",
@@ -412,9 +408,9 @@ export const extractLollipopLocalsFromLollipopHeaders = (
           ...lollipopHeaders,
         } as LollipopLocalsType)
     ),
-    // eslint-disable-next-line sonarjs/no-identical-functions
     eventLog.taskEither.info((lcLocals) => [
       "Lollipop locals to be sent to third party api",
       { ...Object.keys(lcLocals), name: "lollipop.locals.info" },
     ])
   );
+/* eslint-enable sonarjs/no-identical-functions */

--- a/src/utils/middleware/lollipop.ts
+++ b/src/utils/middleware/lollipop.ts
@@ -4,12 +4,64 @@ import { pipe } from "fp-ts/lib/function";
 import { ResponseErrorInternal } from "@pagopa/ts-commons/lib/responses";
 import * as E from "fp-ts/Either";
 import * as O from "fp-ts/Option";
-import { withOptionalUserFromRequest } from "../../types/user";
+import {
+  withOptionalUserFromRequest,
+  withUserFromRequest,
+} from "../../types/user";
 import { LollipopApiClient } from "../../clients/lollipop";
 import { withLollipopHeadersFromRequest } from "../../types/lollipop";
 import { log } from "../logger";
-import { extractLollipopLocalsFromLollipopHeaders } from "../lollipop";
+import {
+  extractLollipopLocalsFromLollipopHeaders,
+  extractLollipopLocalsFromLollipopHeadersLegacy,
+} from "../lollipop";
 import { ISessionStorage } from "../../services/ISessionStorage";
+
+/**
+ * @deprecated
+ */
+export const expressLollipopMiddlewareLegacy: (
+  lollipopClient: ReturnType<typeof LollipopApiClient>,
+  sessionStorage: ISessionStorage
+) => (req: Request, res: Response, next: NextFunction) => Promise<void> =
+  (lollipopClient, sessionStorage) => (req, res, next) =>
+    pipe(
+      TE.tryCatch(
+        () =>
+          withUserFromRequest(req, async (user) =>
+            withLollipopHeadersFromRequest(req, async (lollipopHeaders) =>
+              pipe(
+                extractLollipopLocalsFromLollipopHeadersLegacy(
+                  lollipopClient,
+                  sessionStorage,
+                  user.fiscal_code,
+                  lollipopHeaders
+                ),
+                TE.map((lollipopLocals) => {
+                  // eslint-disable-next-line functional/immutable-data
+                  res.locals = { ...res.locals, ...lollipopLocals };
+                }),
+                TE.toUnion
+              )()
+            )
+          ),
+        (err) => {
+          log.error(
+            "lollipopMiddleware|error executing the middleware [%s]",
+            E.toError(err).message
+          );
+          return ResponseErrorInternal("Error executing middleware");
+        }
+      ),
+      TE.chain((maybeErrorResponse) =>
+        maybeErrorResponse === undefined
+          ? TE.of(void 0)
+          : TE.left(maybeErrorResponse)
+      ),
+      TE.mapLeft((response) => response.apply(res)),
+      TE.map(() => next()),
+      TE.toUnion
+    )();
 
 export const expressLollipopMiddleware: (
   lollipopClient: ReturnType<typeof LollipopApiClient>,
@@ -36,6 +88,7 @@ export const expressLollipopMiddleware: (
               )()
             )
           ),
+        // eslint-disable-next-line sonarjs/no-identical-functions
         (err) => {
           log.error(
             "lollipopMiddleware|error executing the middleware [%s]",
@@ -44,6 +97,7 @@ export const expressLollipopMiddleware: (
           return ResponseErrorInternal("Error executing middleware");
         }
       ),
+      // eslint-disable-next-line sonarjs/no-identical-functions
       TE.chain((maybeErrorResponse) =>
         maybeErrorResponse === undefined
           ? TE.of(void 0)

--- a/src/utils/middleware/lollipop.ts
+++ b/src/utils/middleware/lollipop.ts
@@ -63,6 +63,7 @@ export const expressLollipopMiddlewareLegacy: (
       TE.toUnion
     )();
 
+/* eslint-disable sonarjs/no-identical-functions */
 export const expressLollipopMiddleware: (
   lollipopClient: ReturnType<typeof LollipopApiClient>,
   sessionStorage: ISessionStorage
@@ -88,7 +89,6 @@ export const expressLollipopMiddleware: (
               )()
             )
           ),
-        // eslint-disable-next-line sonarjs/no-identical-functions
         (err) => {
           log.error(
             "lollipopMiddleware|error executing the middleware [%s]",
@@ -97,7 +97,6 @@ export const expressLollipopMiddleware: (
           return ResponseErrorInternal("Error executing middleware");
         }
       ),
-      // eslint-disable-next-line sonarjs/no-identical-functions
       TE.chain((maybeErrorResponse) =>
         maybeErrorResponse === undefined
           ? TE.of(void 0)
@@ -107,3 +106,4 @@ export const expressLollipopMiddleware: (
       TE.map(() => next()),
       TE.toUnion
     )();
+/* eslint-enable sonarjs/no-identical-functions */


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->
Restore the old lollipop middleware with legacy suffix used only for Firma con IO

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Firma con IO send as keyid the assertionRef without the prefix, the new middleware fail the new validation step on the keyid format.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
not tested

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

