### PR TITLE
[#IOPID-387] user creation utility fails retrieving optional data

### DIFF
--- a/src/controllers/__tests__/fastLoginController.test.ts
+++ b/src/controllers/__tests__/fastLoginController.test.ts
@@ -1,6 +1,5 @@
 import RedisSessionStorage from "../../services/redisSessionStorage";
 import * as E from "fp-ts/lib/Either";
-import * as O from "fp-ts/lib/Option";
 import * as RNEA from "fp-ts/lib/ReadonlyNonEmptyArray";
 import * as redis from "redis";
 import { aFiscalCode } from "../../__mocks__/user_mock";
@@ -21,12 +20,21 @@ import mockRes from "../../__mocks__/response";
 import { LollipopLocalsType } from "../../types/lollipop";
 import { LollipopJWTAuthorization } from "../../../generated/fast-login-api/LollipopJWTAuthorization";
 import { LollipopPublicKey } from "../../../generated/fast-login-api/LollipopPublicKey";
-import { SessionToken } from "../../types/token";
+import {
+  BPDToken,
+  FIMSToken,
+  MyPortalToken,
+  SessionToken,
+  WalletToken,
+  ZendeskToken,
+} from "../../types/token";
 import { aSAMLResponse } from "../../utils/__mocks__/spid";
 import { FastLoginResponse as LCFastLoginResponse } from "../../../generated/fast-login-api/FastLoginResponse";
 import { BadRequest } from "../../../generated/fast-login-api/BadRequest";
 import * as spidUtils from "../../utils/spid";
 import { pipe } from "fp-ts/lib/function";
+import { UserWithoutTokens } from "../../types/user";
+import { SpidLevelEnum } from "../../../generated/backend/SpidLevel";
 
 const mockSet = jest.fn();
 const mockDel = jest.fn();
@@ -112,12 +120,12 @@ describe("fastLoginController", () => {
 
   it("should create a valid session of 15 minutes given a valid payload", async () => {
     const validUserSetPayload = {
-      session_token: aRandomToken,
-      bpd_token: aRandomToken,
-      fims_token: aRandomToken,
-      wallet_token: aRandomToken,
-      zendesk_token: aRandomToken,
-      myportal_token: aRandomToken,
+      session_token: aRandomToken as SessionToken,
+      bpd_token: aRandomToken as BPDToken,
+      fims_token: aRandomToken as FIMSToken,
+      wallet_token: aRandomToken as WalletToken,
+      zendesk_token: aRandomToken as ZendeskToken,
+      myportal_token: aRandomToken as MyPortalToken,
       created_at: expect.any(Number),
       date_of_birth: "1970-01-01",
       family_name: "AgID",
@@ -126,7 +134,7 @@ describe("fastLoginController", () => {
       session_tracking_id: aRandomToken,
       spid_email: "spid.tech@agid.gov.it",
       spid_idp: "http://localhost:8080",
-      spid_level: "https://www.spid.gov.it/SpidL2",
+      spid_level: SpidLevelEnum["https://www.spid.gov.it/SpidL2"],
     };
     mockIsBlockedUser.mockResolvedValueOnce(E.right(false));
     mockSet.mockResolvedValueOnce(E.right(true));
@@ -301,7 +309,7 @@ describe("fastLoginController", () => {
     );
 
     mockIsBlockedUser.mockResolvedValueOnce(E.right(false));
-    makeProxyUser.mockReturnValueOnce(O.none);
+    makeProxyUser.mockReturnValueOnce(UserWithoutTokens.decode({}));
 
     const response = await controller(mockReq(), fastLoginLollipopLocals);
     const res = mockRes();

--- a/src/controllers/fastLoginController.ts
+++ b/src/controllers/fastLoginController.ts
@@ -244,9 +244,8 @@ export const fastLoginEndpoint =
         pipe(
           parsed_saml_response,
           makeProxyUserFromSAMLResponse,
-          TE.fromOption(() =>
-            ResponseErrorInternal("Could not create proxy user")
-          )
+          TE.fromEither,
+          TE.mapLeft(() => ResponseErrorInternal("Could not create proxy user"))
         )
       ),
       TE.chainFirstW(({ userWithoutTokens, tokens }) =>


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->
* see commit history

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
for example, the previous implementation was failing if the email was not found, but the field in the type `UserWithoutTokens` was partial from the start. With this logic, if the field is partial, the user is correctly returned. 

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
unit tests

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
