### PR TITLE
[#IOPID-394] Refactory LolliPoP Middleware with thumbprint instead assertionRef as keyId

### DIFF
--- a/src/__mocks__/lollipop.ts
+++ b/src/__mocks__/lollipop.ts
@@ -7,7 +7,7 @@ import { LollipopSignature } from "../../generated/lollipop/LollipopSignature";
 import { LollipopSignatureInput } from "../../generated/lollipop/LollipopSignatureInput";
 import { LollipopMethod } from "../../generated/lollipop/LollipopMethod";
 import { LollipopOriginalURL } from "../../generated/lollipop/LollipopOriginalURL";
-import { LollipopLocalsType } from "../types/lollipop";
+import { LollipopLocalsType, Thumbprint } from "../types/lollipop";
 import { AssertionTypeEnum } from "../../generated/io-sign-api/AssertionType";
 import { LollipopJWTAuthorization } from "../../generated/io-sign-api/LollipopJWTAuthorization";
 import { LollipopPublicKey } from "../../generated/io-sign-api/LollipopPublicKey";
@@ -20,6 +20,8 @@ import * as O from "fp-ts/lib/Option";
 
 export const anAssertionRef =
   "sha256-6LvipIvFuhyorHpUqK3HjySC5Y6gshXHFBhU9EJ4DoM=" as AssertionRefSha256;
+export const aThumbprint =
+  "6LvipIvFuhyorHpUqK3HjySC5Y6gshXHFBhU9EJ4DoM=" as Thumbprint;
 export const anotherAssertionRef =
   "sha512-6LvipIvFuhyorHpUqK3HjySC5Y6gshXHFBhU9EJ4DoM=" as AssertionRefSha512;
 
@@ -44,7 +46,7 @@ export const aLollipopAssertion =
 export const aSignature =
   `sig1=:hNojB+wWw4A7SYF3qK1S01Y4UP5i2JZFYa2WOlMB4Np5iWmJSO0bDe2hrYRbcIWqVAFjuuCBRsB7lYQJkzbb6g==:` as LollipopSignature;
 export const aSignatureInput =
-  `sig1=("x-pagopa-lollipop-original-method" "x-pagopa-lollipop-original-url"); created=1618884475; keyid="${anAssertionRef}"` as LollipopSignatureInput;
+  `sig1=("x-pagopa-lollipop-original-method" "x-pagopa-lollipop-original-url"); created=1618884475; keyid="${aThumbprint}"` as LollipopSignatureInput;
 export const aLollipopOriginalMethod = "POST" as LollipopMethod;
 export const aLollipopOriginalUrl =
   "https://api.pagopa.it" as LollipopOriginalURL;
@@ -74,8 +76,7 @@ export const mockSessionStorage = {
 export const lollipopRequiredHeaders = {
   signature:
     "sig1=:hNojB+wWw4A7SYF3qK1S01Y4UP5i2JZFYa2WOlMB4Np5iWmJSO0bDe2hrYRbcIWqVAFjuuCBRsB7lYQJkzbb6g==:",
-  "signature-input":
-    'sig1=("x-pagopa-lollipop-original-method" "x-pagopa-lollipop-original-url"); created=1618884475; keyid="test-key-rsa-pss"',
+  "signature-input": `sig1=("x-pagopa-lollipop-original-method" "x-pagopa-lollipop-original-url"); created=1618884475; keyid="${aThumbprint}"`,
   "x-pagopa-lollipop-original-method": "POST",
   "x-pagopa-lollipop-original-url": "https://api.pagopa.it",
 };

--- a/src/__mocks__/lollipop.ts
+++ b/src/__mocks__/lollipop.ts
@@ -23,7 +23,7 @@ export const anAssertionRef =
 export const aThumbprint =
   "6LvipIvFuhyorHpUqK3HjySC5Y6gshXHFBhU9EJ4DoM=" as Thumbprint;
 export const anotherAssertionRef =
-  "sha512-6LvipIvFuhyorHpUqK3HjySC5Y6gshXHFBhU9EJ4DoM=" as AssertionRefSha512;
+  "sha512-Dj51I0q8aPQ3ioaz9LMqGYujAYRbDNblAQbodDRXAMxmY6hsHqEl3F6SvhfJj5oPhcqdX1ldsgEvfMNXGUXBIw==" as AssertionRefSha512;
 
 export const aJwkPubKey: JwkPublicKey = {
   kty: "EC",
@@ -52,7 +52,7 @@ export const aLollipopOriginalUrl =
   "https://api.pagopa.it" as LollipopOriginalURL;
 
 export const anInvalidSignatureInput =
-  `sig1=("x-pagopa-lollipop-original-method" "x-pagopa-lollipop-original-url"); created=1618884475; keyid="an-invalid-assertion-ref"` as LollipopSignatureInput;
+  `sig1=("x-pagopa-lollipop-original-method" "x-pagopa-lollipop-original-url"); created=1618884475; keyid="#an-invalid-thumbprint#"` as LollipopSignatureInput;
 
 export const mockActivatePubKey = jest.fn();
 

--- a/src/__tests__/lollipop-consumer.test.ts
+++ b/src/__tests__/lollipop-consumer.test.ts
@@ -9,7 +9,7 @@ import {
   aLollipopOriginalUrl,
   anAssertionRef,
   aSignature,
-  aSignatureInput
+  aSignatureInput,
 } from "../__mocks__/lollipop";
 import * as E from "fp-ts/Either";
 import * as O from "fp-ts/Option";
@@ -29,7 +29,7 @@ const mockClient = {
   generateLCParams: mockGenerateLCParams,
   activatePubKey: jest.fn(),
   ping: jest.fn(),
-  reservePubKey: jest.fn()
+  reservePubKey: jest.fn(),
 } as ReturnType<typeof LollipopApiClient>;
 
 const mockGetlollipopAssertionRefForUser = jest
@@ -38,9 +38,9 @@ const mockGetlollipopAssertionRefForUser = jest
     console.log("ho chiamato mockGetlollipopAssertionRefForUser");
     return E.right(O.some(anAssertionRef));
   });
-const mockSessionStorage = ({
-  getLollipopAssertionRefForUser: mockGetlollipopAssertionRefForUser
-} as unknown) as ISessionStorage;
+const mockSessionStorage = {
+  getLollipopAssertionRefForUser: mockGetlollipopAssertionRefForUser,
+} as unknown as ISessionStorage;
 
 const aBearerToken = "aBearerTokenJWT";
 const aPubKey = "aPubKey";
@@ -62,14 +62,14 @@ lollipopConsumerApp.use(
     verify: (_req, res: express.Response, buf, _encoding: BufferEncoding) => {
       // eslint-disable-next-line functional/immutable-data
       res.locals.body = buf;
-    }
+    },
   })
 );
 const mockLCMiddleware = jest
   .fn()
   .mockImplementation((req: express.Request, res) => {
     res.status(200).json({
-      response: req.body["message"]
+      response: req.body["message"],
     });
   });
 const expectedLollipopLCPath = "/api/v1/first-lollipop-consumer/signed-message";
@@ -81,7 +81,7 @@ const server = http.createServer(lollipopConsumerApp);
 
 describe("lollipopSign", () => {
   beforeAll(async () => {
-    await new Promise(resolve => {
+    await new Promise((resolve) => {
       server.listen(port, () => {
         resolve(void 0);
       });
@@ -89,7 +89,7 @@ describe("lollipopSign", () => {
   });
   afterAll(async () => {
     jest.clearAllMocks();
-    await new Promise(resolve => server.close(() => resolve(void 0)));
+    await new Promise((resolve) => server.close(() => resolve(void 0)));
   });
   it("should returns a status 200 response on lollipop consumer mocked impl", async () => {
     mockGenerateLCParams.mockResolvedValueOnce(
@@ -99,14 +99,14 @@ describe("lollipopSign", () => {
           fiscal_code: aFiscalCode,
           assertion_file_name: `${aFiscalCode}-${anAssertionRef}`,
           assertion_type: AssertionTypeEnum.SAML,
-          expired_at: Date.now(),
+          expired_at: new Date(),
           lc_authentication_bearer: aBearerToken,
           assertion_ref: anAssertionRef,
           pub_key: aPubKey,
           version: 1,
           status: PubKeyStatusEnum.VALID,
-          ttl: 900
-        }
+          ttl: 900,
+        },
       })
     );
     mockGetlollipopAssertionRefForUser.mockResolvedValue(
@@ -125,7 +125,7 @@ describe("lollipopSign", () => {
         ) => {
           // eslint-disable-next-line functional/immutable-data
           res.locals.body = buf;
-        }
+        },
       })
     );
     // Mock the Api call for signing whithout the auth middleware
@@ -144,7 +144,8 @@ describe("lollipopSign", () => {
       ["signature-input"]: aSignatureInput,
       ["x-pagopa-lollipop-original-method"]: aLollipopOriginalMethod,
       ["x-pagopa-lollipop-original-url"]: aLollipopOriginalUrl,
-      "content-digest": "sha-256=:cpyRqJ1VhoVC+MSs9fq4/4wXs4c46EyEFriskys43Zw=:"
+      "content-digest":
+        "sha-256=:cpyRqJ1VhoVC+MSs9fq4/4wXs4c46EyEFriskys43Zw=:",
     };
 
     const expectedRequestBody = { message: "aMessage" };
@@ -159,7 +160,7 @@ describe("lollipopSign", () => {
     expect(mockFetch).toBeCalledWith(
       `http://localhost:${port}${expectedLollipopLCPath}`,
       expect.objectContaining({
-        body: expect.any(Buffer)
+        body: expect.any(Buffer),
       })
     );
   });

--- a/src/app.ts
+++ b/src/app.ts
@@ -1616,7 +1616,7 @@ function registerFirstLollipopConsumer(
   app.post(
     `${basePath}/sign`,
     bearerSessionTokenAuth,
-    expressLollipopMiddleware(lollipopClient, sessionStorage),
+    expressLollipopMiddlewareLegacy(lollipopClient, sessionStorage),
     toExpressHandler(firstLollipopSign(firstLollipopConsumerClient))
   );
 }

--- a/src/types/lollipop.ts
+++ b/src/types/lollipop.ts
@@ -8,11 +8,11 @@ import {
 } from "@pagopa/ts-commons/lib/responses";
 import * as E from "fp-ts/Either";
 import { pipe } from "fp-ts/lib/function";
+import * as O from "fp-ts/Option";
 import {
   JwkPubKeyHashAlgorithm,
   JwkPubKeyHashAlgorithmEnum,
-} from "generated/lollipop-api/JwkPubKeyHashAlgorithm";
-import * as O from "fp-ts/Option";
+} from "../../generated/lollipop-api/JwkPubKeyHashAlgorithm";
 import { AssertionRefSha256 } from "../../generated/backend/AssertionRefSha256";
 import { AssertionRefSha384 } from "../../generated/backend/AssertionRefSha384";
 import { AssertionRefSha512 } from "../../generated/backend/AssertionRefSha512";

--- a/src/utils/__tests__/lollipop.test.ts
+++ b/src/utils/__tests__/lollipop.test.ts
@@ -1,9 +1,23 @@
 import { ServiceId } from "@pagopa/io-functions-app-sdk/ServiceId";
 import { aFiscalCode } from "../../__mocks__/user_mock";
-import { checkIfLollipopIsEnabled } from "../lollipop";
+import {
+  checkIfLollipopIsEnabled,
+  extractLollipopLocalsFromLollipopHeaders,
+} from "../lollipop";
 import * as E from "fp-ts/lib/Either";
 import { FiscalCode } from "@pagopa/io-functions-app-sdk/FiscalCode";
 import { ThirdPartyConfigList } from "../thirdPartyConfig";
+import { LollipopApiClient } from "../../clients/lollipop";
+import { AssertionTypeEnum } from "../../../generated/lollipop-api/AssertionType";
+import {
+  anAssertionRef,
+  lollipopRequiredHeaders,
+  mockSessionStorage,
+} from "../../__mocks__/lollipop";
+import { PubKeyStatusEnum } from "../../../generated/lollipop-api/PubKeyStatus";
+import { LollipopRequiredHeaders } from "../../types/lollipop";
+import { pipe } from "fp-ts/lib/function";
+import * as RA from "fp-ts/ReadonlyArray";
 
 const aServiceId = "aServiceId" as ServiceId;
 const aLollipopEnabledFiscalCode = "ABCABC00A00B000C" as FiscalCode;
@@ -99,5 +113,103 @@ describe("checkIfLollipopIsEnabled", () => {
     if (E.isRight(res)) {
       expect(res.right).toBe(false);
     }
+  });
+});
+
+describe("extractLollipopLocalsFromLollipopHeaders|>missing fiscal code", () => {
+  const aBearerToken = "aBearerTokenJWT";
+  const aPubKey = "aPubKey";
+
+  const mockGenerateLCParams = jest.fn().mockImplementation(async () =>
+    E.right({
+      status: 200,
+      value: {
+        fiscal_code: aFiscalCode,
+        assertion_file_name: `${aFiscalCode}-${anAssertionRef}`,
+        assertion_type: AssertionTypeEnum.SAML,
+        expired_at: new Date(),
+        lc_authentication_bearer: aBearerToken,
+        assertion_ref: anAssertionRef,
+        pub_key: aPubKey,
+        version: 1,
+        status: PubKeyStatusEnum.VALID,
+        ttl: 900,
+      },
+    })
+  );
+  const mockLollipopClient: ReturnType<typeof LollipopApiClient> = {
+    generateLCParams: mockGenerateLCParams,
+    activatePubKey: jest.fn(),
+    ping: jest.fn(),
+    reservePubKey: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it.each`
+    generateLCParamsCalls
+    ${1}
+    ${2}
+    ${3}
+  `(
+    "should return the lollipop header when the assertion ref was found for the keyId",
+    async ({ generateLCParamsCalls }) => {
+      pipe(
+        RA.replicate(generateLCParamsCalls - 1, undefined),
+        RA.map(() =>
+          mockGenerateLCParams.mockImplementationOnce(async () =>
+            E.right({ status: 404 })
+          )
+        )
+      );
+
+      const res = await extractLollipopLocalsFromLollipopHeaders(
+        mockLollipopClient,
+        mockSessionStorage,
+        lollipopRequiredHeaders as LollipopRequiredHeaders,
+        undefined
+      )();
+
+      expect(mockGenerateLCParams).toHaveBeenCalledTimes(generateLCParamsCalls);
+      expect(res).toMatchObject(
+        E.right({
+          ...lollipopRequiredHeaders,
+          "x-pagopa-lollipop-assertion-ref":
+            "sha256-6LvipIvFuhyorHpUqK3HjySC5Y6gshXHFBhU9EJ4DoM=",
+          "x-pagopa-lollipop-assertion-type": "SAML",
+          "x-pagopa-lollipop-auth-jwt": "aBearerTokenJWT",
+          "x-pagopa-lollipop-public-key": "aPubKey",
+          "x-pagopa-lollipop-user-id": "GRBGPP87L04L741X",
+        })
+      );
+    }
+  );
+
+  it("should return Internal Server Error when no assertion ref was found for the keyId", async () => {
+    pipe(
+      RA.replicate(3, undefined),
+      RA.map(() =>
+        mockGenerateLCParams.mockImplementationOnce(async () =>
+          E.right({ status: 404 })
+        )
+      )
+    );
+
+    const res = await extractLollipopLocalsFromLollipopHeaders(
+      mockLollipopClient,
+      mockSessionStorage,
+      lollipopRequiredHeaders as LollipopRequiredHeaders,
+      undefined
+    )();
+
+    expect(mockGenerateLCParams).toHaveBeenCalledTimes(3);
+    expect(res).toMatchObject(
+      E.left({
+        detail: "Internal server error: Missing assertion ref",
+        kind: "IResponseErrorInternal",
+      })
+    );
   });
 });

--- a/src/utils/lollipop.ts
+++ b/src/utils/lollipop.ts
@@ -123,7 +123,7 @@ const getAndValidateAssertionRefForUser = (
         TE.fromPredicate(
           (assertionRef) =>
             assertionRef ===
-            `${getAlgoFromAssertionRef(assertionRef)}${keyThumbprint}`,
+            `${getAlgoFromAssertionRef(assertionRef)}-${keyThumbprint}`,
           () => ResponseErrorForbiddenNotAuthorized
         ),
         eventLog.taskEither.errorLeft(() => [
@@ -430,7 +430,17 @@ export const extractLollipopLocalsFromLollipopHeaders = (
           )
         ),
         TE.fold(
-          (_) => (LcParams.is(_) ? TE.right(_) : TE.left(_)),
+          (_) =>
+            LcParams.is(_)
+              ? TE.right(_)
+              : _.kind === "IResponseErrorInternal" ||
+                _.kind === "IResponseErrorForbiddenNotAuthorized"
+              ? TE.left(_)
+              : TE.left(
+                  ResponseErrorInternal(
+                    "Unexpected result given from retrieveLCParams"
+                  )
+                ),
           () =>
             TE.left<
               IResponseErrorForbiddenNotAuthorized | IResponseErrorInternal

--- a/src/utils/middleware/__tests__/lollipop.test.ts
+++ b/src/utils/middleware/__tests__/lollipop.test.ts
@@ -28,7 +28,7 @@ const mockGenerateLCParams = jest.fn().mockResolvedValue(
       fiscal_code: aFiscalCode,
       assertion_file_name: `${aFiscalCode}-${anAssertionRef}`,
       assertion_type: AssertionTypeEnum.SAML,
-      expired_at: Date.now(),
+      expired_at: new Date(),
       lc_authentication_bearer: aBearerToken,
       assertion_ref: anAssertionRef,
       pub_key: aPubKey,
@@ -204,11 +204,11 @@ describe("lollipopMiddleware", () => {
   });
 
   it.each`
-    title                                                                              | lollipopAssertionRefForUser                                          | expectedResponseStatus
-    ${"the lollipopAssertionRefForUser returns a different assertionRef from request"} | ${Promise.resolve(E.right(O.some(anotherAssertionRef)))}             | ${403}
-    ${"the lollipopAssertionRefForUser rejects"}                                       | ${Promise.reject(new Error("promise reject"))}                       | ${500}
-    ${"the lollipopAssertionRefForUser returns an error"}                              | ${Promise.resolve(E.left(new Error("Error executing the request")))} | ${500}
-    ${"the lollipopAssertionRefForUser not found the value"}                           | ${Promise.resolve(E.right(O.none))}                                  | ${403}
+    title                                                                              | lollipopAssertionRefForUser                                                | expectedResponseStatus
+    ${"the lollipopAssertionRefForUser returns a different assertionRef from request"} | ${() => Promise.resolve(E.right(O.some(anotherAssertionRef)))}             | ${403}
+    ${"the lollipopAssertionRefForUser rejects"}                                       | ${() => Promise.reject(new Error("promise reject"))}                       | ${500}
+    ${"the lollipopAssertionRefForUser returns an error"}                              | ${() => Promise.resolve(E.left(new Error("Error executing the request")))} | ${500}
+    ${"the lollipopAssertionRefForUser not found the value"}                           | ${() => Promise.resolve(E.right(O.none))}                                  | ${403}
   `(
     `
   GIVEN a valid user and Lollipop Headers
@@ -222,7 +222,7 @@ describe("lollipopMiddleware", () => {
       });
       const res = mockRes();
       mockGetlollipopAssertionRefForUser.mockImplementationOnce(
-        () => lollipopAssertionRefForUser
+        lollipopAssertionRefForUser
       );
       const middleware = expressLollipopMiddleware(
         mockClient,
@@ -236,13 +236,13 @@ describe("lollipopMiddleware", () => {
   );
 
   it.each`
-    title                                            | generateLCParams                               | expectedResponseStatus
-    ${"the generateLCParams rejects"}                | ${Promise.reject(new Error("promise reject"))} | ${500}
-    ${"the generateLCParams returns an error"}       | ${Promise.resolve(NonEmptyString.decode(""))}  | ${500}
-    ${"the generateLCParams returns bad request"}    | ${Promise.resolve(E.right({ status: 400 }))}   | ${500}
-    ${"the generateLCParams returns forbidden"}      | ${Promise.resolve(E.right({ status: 403 }))}   | ${403}
-    ${"the generateLCParams returns not found"}      | ${Promise.resolve(E.right({ status: 404 }))}   | ${500}
-    ${"the generateLCParams returns error internal"} | ${Promise.resolve(E.right({ status: 500 }))}   | ${500}
+    title                                            | generateLCParams                                     | expectedResponseStatus
+    ${"the generateLCParams rejects"}                | ${() => Promise.reject(new Error("promise reject"))} | ${500}
+    ${"the generateLCParams returns an error"}       | ${() => Promise.resolve(NonEmptyString.decode(""))}  | ${500}
+    ${"the generateLCParams returns bad request"}    | ${() => Promise.resolve(E.right({ status: 400 }))}   | ${500}
+    ${"the generateLCParams returns forbidden"}      | ${() => Promise.resolve(E.right({ status: 403 }))}   | ${403}
+    ${"the generateLCParams returns not found"}      | ${() => Promise.resolve(E.right({ status: 404 }))}   | ${500}
+    ${"the generateLCParams returns error internal"} | ${() => Promise.resolve(E.right({ status: 500 }))}   | ${500}
   `(
     `
   GIVEN a valid user and Lollipop Headers
@@ -255,7 +255,7 @@ describe("lollipopMiddleware", () => {
         user: mockedUser,
       });
       const res = mockRes();
-      mockGenerateLCParams.mockImplementationOnce(() => generateLCParams);
+      mockGenerateLCParams.mockImplementationOnce(generateLCParams);
       const middleware = expressLollipopMiddleware(
         mockClient,
         mockSessionStorage


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
Refactory of the LolliPoP middleware to handle LV flow without an active session.
<!--- Describe your changes in detail -->

#### Motivation and Context
The LV feature need to retrieve the assertionRef directly from the request. The keyId field into the `signature-inputs` header on other services (IO sign and PN) is evaluated with the thumbprint of the key (an assertionRef without the prefix). This refactory retrieve the assertionRef from the thumbprint.
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
unit test

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
