### PR TITLE
[#IOPID-756] Internal Logout endpoint for LV

### DIFF
--- a/api_session.yaml
+++ b/api_session.yaml
@@ -85,32 +85,6 @@ paths:
           description: Bad request
         "401":
           description: Token null or invalid.
-        "404":
-          description: User not found.
-        "500":
-          description: There was an error
-          schema:
-            $ref: "#/definitions/ProblemJson"
-    delete:
-      operationId: unlockUserSession
-      summary: Remove a lock to a user session
-      description: |-
-        Use this operation if you want to unblock a user and re-allow to login. The operation succeed if the user wasn't blocked
-      parameters:
-        - $ref: "#/parameters/FiscalCode"
-        - $ref: "#/parameters/Token"
-      responses:
-        "200":
-          description: Success.
-          schema:
-            $ref: "#/definitions/SuccessResponse"
-          examples:
-            application/json:
-              "message": "ok"
-        "400":
-          description: Bad request
-        "401":
-          description: Token null or invalid.
         "500":
           description: There was an error
           schema:

--- a/api_session.yaml
+++ b/api_session.yaml
@@ -64,6 +64,30 @@ paths:
           description: There was an error
           schema:
             $ref: "#/definitions/ProblemJson"
+    delete:
+      operationId: unlockUserSession
+      summary: Remove a lock to a user session
+      description: |-
+        Use this operation if you want to unblock a user and re-allow to login. The operation succeed if the user wasn't blocked
+      parameters:
+        - $ref: "#/parameters/FiscalCode"
+        - $ref: "#/parameters/Token"
+      responses:
+        "200":
+          description: Success.
+          schema:
+            $ref: "#/definitions/SuccessResponse"
+          examples:
+            application/json:
+              "message": "ok"
+        "400":
+          description: Bad request
+        "401":
+          description: Token null or invalid.
+        "500":
+          description: There was an error
+          schema:
+            $ref: "#/definitions/ProblemJson"
   "/sessions/{fiscalcode}/logout":
     post:
       operationId: deleteUserSession

--- a/api_session.yaml
+++ b/api_session.yaml
@@ -64,6 +64,33 @@ paths:
           description: There was an error
           schema:
             $ref: "#/definitions/ProblemJson"
+  "/sessions/{fiscalcode}/logout":
+    post:
+      operationId: deleteUserSession
+      summary: Delete user session and invalidate lollipop data
+      description: |-
+        Use this operation to invalidate the user session and disable the lollipop params to prevent Fast Login token refresh
+      parameters:
+        - $ref: "#/parameters/FiscalCode"
+        - $ref: "#/parameters/Token"
+      responses:
+        "200":
+          description: Success.
+          schema:
+            $ref: "#/definitions/SuccessResponse"
+          examples:
+            application/json:
+              "message": "ok"
+        "400":
+          description: Bad request
+        "401":
+          description: Token null or invalid.
+        "404":
+          description: User not found.
+        "500":
+          description: There was an error
+          schema:
+            $ref: "#/definitions/ProblemJson"
     delete:
       operationId: unlockUserSession
       summary: Remove a lock to a user session

--- a/openapi/api_session.template.yaml
+++ b/openapi/api_session.template.yaml
@@ -88,6 +88,31 @@ paths:
           description: There was an error
           schema:
             $ref: "#/definitions/ProblemJson"
+  "/sessions/{fiscalcode}/logout":
+    post:
+      operationId: deleteUserSession
+      summary: Delete user session and invalidate lollipop data
+      description: |-
+        Use this operation to invalidate the user session and disable the lollipop params to prevent Fast Login token refresh
+      parameters:
+        - $ref: "#/parameters/FiscalCode"
+        - $ref: "#/parameters/Token"
+      responses:
+        "200":
+          description: Success.
+          schema:
+            $ref: "#/definitions/SuccessResponse"
+          examples:
+            application/json:
+              "message": "ok"
+        "400":
+          description: Bad request
+        "401":
+          description: Token null or invalid.
+        "500":
+          description: There was an error
+          schema:
+            $ref: "#/definitions/ProblemJson"
 parameters:
   FiscalCode:
     name: fiscalcode

--- a/openapi/generated/api_session.yaml
+++ b/openapi/generated/api_session.yaml
@@ -89,6 +89,32 @@ paths:
           description: There was an error
           schema:
             $ref: '#/definitions/ProblemJson'
+  /sessions/{fiscalcode}/logout:
+    post:
+      operationId: deleteUserSession
+      summary: Delete user session and invalidate lollipop data
+      description: >-
+        Use this operation to invalidate the user session and disable the
+        lollipop params to prevent Fast Login token refresh
+      parameters:
+        - $ref: '#/parameters/FiscalCode'
+        - $ref: '#/parameters/Token'
+      responses:
+        '200':
+          description: Success.
+          schema:
+            $ref: '#/definitions/SuccessResponse'
+          examples:
+            application/json:
+              message: ok
+        '400':
+          description: Bad request
+        '401':
+          description: Token null or invalid.
+        '500':
+          description: There was an error
+          schema:
+            $ref: '#/definitions/ProblemJson'
 parameters:
   FiscalCode:
     name: fiscalcode

--- a/src/app.ts
+++ b/src/app.ts
@@ -1281,6 +1281,15 @@ function registerSessionAPIRoutes(
       )
     );
 
+    app.post(
+      `${basePath}/sessions/:fiscal_code/logout`,
+      urlTokenAuth,
+      toExpressHandler(
+        sessionLockController.deleteUserSession,
+        sessionLockController
+      )
+    );
+
     app.delete(
       `${basePath}/sessions/:fiscal_code/lock`,
       urlTokenAuth,

--- a/src/controllers/sessionLockController.ts
+++ b/src/controllers/sessionLockController.ts
@@ -15,11 +15,13 @@ import * as E from "fp-ts/lib/Either";
 import * as AP from "fp-ts/lib/Apply";
 import * as TE from "fp-ts/lib/TaskEither";
 import * as O from "fp-ts/lib/Option";
+import * as ROA from "fp-ts/lib/ReadonlyArray";
 import { readableReport } from "@pagopa/ts-commons/lib/reporters";
 import { FiscalCode } from "@pagopa/ts-commons/lib/strings";
-import { SuccessResponse } from "src/types/commons";
 import { pipe, flow, constVoid } from "fp-ts/lib/function";
-import LollipopService from "src/services/lollipopService";
+import { SuccessResponse } from "../types/commons";
+import LollipopService from "../services/lollipopService";
+import { withFiscalCodeFromRequestParams } from "../types/fiscalCode";
 import RedisSessionStorage from "../services/redisSessionStorage";
 import RedisUserMetadataStorage from "../services/redisUserMetadataStorage";
 import { UserSessionInfo } from "../../generated/session/UserSessionInfo";
@@ -81,86 +83,68 @@ export default class SessionLockController {
     | IResponseErrorValidation
     | IResponseSuccessJson<SuccessResponse>
   > =>
-    pipe(
-      req.params.fiscal_code,
-      FiscalCode.decode,
-      E.mapLeft((err) =>
-        ResponseErrorValidation("Invalid fiscal code", readableReport(err))
-      ),
-      TE.fromEither,
-      TE.chainW((fiscalCode) =>
-        pipe(
-          AP.sequenceT(TE.ApplicativeSeq)(
-            // lock the account
-            pipe(
-              TE.tryCatch(
-                () => this.sessionStorage.setBlockedUser(fiscalCode),
-                E.toError
+    withFiscalCodeFromRequestParams(
+      req,
+      flow(
+        (fiscalCode) =>
+          pipe(
+            AP.sequenceT(TE.ApplicativeSeq)(
+              // lock the account
+              pipe(
+                TE.tryCatch(
+                  () => this.sessionStorage.setBlockedUser(fiscalCode),
+                  E.toError
+                ),
+                TE.chain(TE.fromEither)
               ),
-              TE.chain(TE.fromEither)
-            ),
-            // revoke pubkey
-            pipe(
-              TE.tryCatch(
-                () =>
-                  // retrieve the assertionRef for the user
-                  this.sessionStorage.getLollipopAssertionRefForUser(
-                    fiscalCode
-                  ),
-                E.toError
-              ),
-              TE.chain(TE.fromEither),
-              TE.chain(
-                flow(
-                  O.map((assertionRef) =>
-                    TE.tryCatch(
-                      () =>
-                        // fire and forget the queue message
-                        new Promise<true>((resolve) => {
-                          this.lollipopService
-                            .revokePreviousAssertionRef(assertionRef)
-                            .catch(constVoid);
-                          resolve(true);
-                        }),
-                      E.toError
-                    )
-                  ),
-                  // continue if there's no assertionRef on redis
-                  O.getOrElse(() => TE.of(true))
-                )
+              ...this.buildInvalidateUserSessionTask(fiscalCode),
+              // removes all metadata
+              pipe(
+                TE.tryCatch(
+                  () => this.metadataStorage.del(fiscalCode),
+                  E.toError
+                ),
+                TE.chain(TE.fromEither)
               )
             ),
-            // delete the assertionRef for the user
-            pipe(
-              TE.tryCatch(
-                () => this.sessionStorage.delLollipopDataForUser(fiscalCode),
-                E.toError
-              ),
-              TE.chain(TE.fromEither)
-            ),
-            // removes all sessions
-            pipe(
-              TE.tryCatch(
-                () => this.sessionStorage.delUserAllSessions(fiscalCode),
-                E.toError
-              ),
-              TE.chain(TE.fromEither)
-            ),
-            // removes all metadata
-            pipe(
-              TE.tryCatch(
-                () => this.metadataStorage.del(fiscalCode),
-                E.toError
-              ),
-              TE.chain(TE.fromEither)
-            )
+            TE.mapLeft((err) => ResponseErrorInternal(err.message))
           ),
-          TE.mapLeft((err) => ResponseErrorInternal(err.message))
-        )
-      ),
-      TE.map((_) => ResponseSuccessJson({ message: "ok" })),
-      TE.toUnion
-    )();
+        TE.map((_) => ResponseSuccessJson({ message: "ok" })),
+        TE.toUnion,
+        (taskEither) => taskEither()
+      )
+    );
+
+  /**
+   * Delete all the session related data invalidating the user session and
+   * lollipop key related to the user.
+   *
+   * @param req expects fiscal_code as a path param
+   *
+   * @returns a promise with the encoded response object
+   */
+  public readonly deleteUserSession = (
+    req: express.Request
+  ): Promise<
+    | IResponseErrorInternal
+    | IResponseErrorValidation
+    | IResponseSuccessJson<SuccessResponse>
+  > =>
+    withFiscalCodeFromRequestParams(
+      req,
+      flow(
+        (fiscalCode) =>
+          pipe(
+            ROA.sequence(TE.ApplicativeSeq)(
+              this.buildInvalidateUserSessionTask(fiscalCode)
+            ),
+            TE.mapLeft((err) => ResponseErrorInternal(err.message))
+          ),
+        TE.map((_) => ResponseSuccessJson({ message: "ok" })),
+        TE.toUnion,
+        (taskEither) => taskEither()
+      )
+    );
 
   /**
    * Unlock a user account
@@ -197,4 +181,54 @@ export default class SessionLockController {
       TE.map((_) => ResponseSuccessJson({ message: "ok" })),
       TE.toUnion
     )();
+
+  private readonly buildInvalidateUserSessionTask = (
+    fiscalCode: FiscalCode
+  ) => [
+    // revoke pubkey
+    pipe(
+      TE.tryCatch(
+        () =>
+          // retrieve the assertionRef for the user
+          this.sessionStorage.getLollipopAssertionRefForUser(fiscalCode),
+        E.toError
+      ),
+      TE.chain(TE.fromEither),
+      TE.chain(
+        flow(
+          O.map((assertionRef) =>
+            TE.tryCatch(
+              () =>
+                // fire and forget the queue message
+                new Promise<true>((resolve) => {
+                  this.lollipopService
+                    .revokePreviousAssertionRef(assertionRef)
+                    .catch(constVoid);
+                  resolve(true);
+                }),
+              E.toError
+            )
+          ),
+          // continue if there's no assertionRef on redis
+          O.getOrElse(() => TE.of(true))
+        )
+      )
+    ),
+    // delete the assertionRef for the user
+    pipe(
+      TE.tryCatch(
+        () => this.sessionStorage.delLollipopDataForUser(fiscalCode),
+        E.toError
+      ),
+      TE.chain(TE.fromEither)
+    ),
+    // removes all sessions
+    pipe(
+      TE.tryCatch(
+        () => this.sessionStorage.delUserAllSessions(fiscalCode),
+        E.toError
+      ),
+      TE.chain(TE.fromEither)
+    ),
+  ];
 }

--- a/src/services/ISessionStorage.ts
+++ b/src/services/ISessionStorage.ts
@@ -152,4 +152,8 @@ export interface ISessionStorage {
   readonly getPagoPaNoticeEmail: (
     user: User
   ) => Promise<Either<Error, EmailString>>;
+
+  readonly delUserAllSessions: (
+    fiscalCode: FiscalCode
+  ) => Promise<Either<Error, boolean>>;
 }

--- a/src/types/fiscalCode.ts
+++ b/src/types/fiscalCode.ts
@@ -1,0 +1,10 @@
+import * as express from "express";
+import { IResponseErrorValidation } from "@pagopa/ts-commons/lib/responses";
+import { FiscalCode } from "@pagopa/ts-commons/lib/strings";
+import { withValidatedOrValidationError } from "../utils/responses";
+
+export const withFiscalCodeFromRequestParams = async <T>(
+  req: express.Request,
+  f: (fiscalCode: FiscalCode) => Promise<T>
+): Promise<IResponseErrorValidation | T> =>
+  withValidatedOrValidationError(FiscalCode.decode(req.params.fiscal_code), f);


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->
New `logout` endpoint
New `deleteUserSession` handler in `SessionLockController`
Refactor `lockUserSession` handler to remove duplicated code (`buildInvalidateUserSessionTask`)
Fix missing `delUserAllSessions ` in `ISessionStorage` interface.
New middleware `withFiscalCodeFromRequestParams ` to handle FiscalCode in params.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
To invalidate the user session from IO-Web for the `FastLogin` feature is needed an internal endpoint of `io-backendli` for the Fast Login service. This operation need to invalidate the current session and all the lollipop related param of a specified user.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
unit test

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
