### PR TITLE
[#IOCOM-152] Restrict message id type to be an Ulid for messages endpoints

### DIFF
--- a/api_backend.yaml
+++ b/api_backend.yaml
@@ -218,11 +218,7 @@ paths:
   "/messages/{id}":
     x-swagger-router-controller: MessagesController
     parameters:
-      - name: id
-        in: path
-        type: string
-        required: true
-        description: The ID of the message.
+      - $ref: "#/parameters/MessageId"
       - $ref: "#/parameters/PublicMessage"
     get:
       operationId: getUserMessage
@@ -271,11 +267,7 @@ paths:
       summary: UpsertMessageStatusAttributes
       description: Updates the status of a message with attributes
       parameters:
-        - name: id
-          in: path
-          type: string
-          required: true
-          description: The ID of the message.
+        - $ref: "#/parameters/MessageId"
         - name: body
           in: body
           schema:
@@ -323,12 +315,7 @@ paths:
       description: |-
         Returns the Third Party message with the provided message ID.
       parameters:
-        - name: id
-          in: path
-          type: string
-          minLength: 1
-          required: true
-          description: ID of the IO message.
+        - $ref: "#/parameters/MessageId"
       responses:
         "200":
           description: Found.
@@ -384,12 +371,7 @@ paths:
       produces:
         - application/octet-stream
       parameters:
-        - name: id
-          in: path
-          type: string
-          minLength: 1
-          required: true
-          description: ID of the IO message.
+        - $ref: "#/parameters/MessageId"
         - in: path
           name: attachment_url
           type: string
@@ -431,12 +413,7 @@ paths:
       description: |-
         Returns the Third Party message precondition associated to the provided message ID to receive the third party content.
       parameters:
-        - name: id
-          in: path
-          type: string
-          minLength: 1
-          required: true
-          description: ID of the IO message.
+        - $ref: "#/parameters/MessageId"
       responses:
         "200":
           description: Found.
@@ -1195,6 +1172,8 @@ definitions:
     $ref: "https://raw.githubusercontent.com/pagopa/io-functions-commons/v28.5.0/openapi/definitions.yaml#/CreatedMessageWithContentResponse"
   CreatedMessageWithContentAndEnrichedData:
     $ref: "https://raw.githubusercontent.com/pagopa/io-functions-commons/v28.5.0/openapi/definitions.yaml#/CreatedMessageWithContentAndEnrichedData"
+  Ulid:
+    $ref: "https://raw.githubusercontent.com/pagopa/io-functions-commons/v28.5.0/openapi/definitions.yaml#/Ulid"
   # Definitions from pagopa-proxy
   PaymentProblemJson:
     $ref: "https://raw.githubusercontent.com/pagopa/io-pagopa-proxy/v1.6.0/api-spec/api-for-io.yaml#/definitions/PaymentProblemJson"
@@ -1475,6 +1454,17 @@ definitions:
       - expires_in
 responses: {}
 parameters:
+  MessageId:
+    name: id
+    in: path
+    type: string
+    maxLength: 26
+    minLength: 26
+    required: true
+    description: The message id in ulid format
+    pattern: >-
+      [0-9a-hjkmnp-tv-zA-HJKMNP-TV-Z]{26}
+    x-example: 01ARZ3NDEKTSV4RRFFQ69G5FAV
   PublicMessage:
     name: public_message
     in: query
@@ -1505,15 +1495,23 @@ parameters:
     type: string
     in: query
     required: false
-    description: >-
-      The maximum id to get messages until to.
+    maxLength: 26
+    minLength: 26
+    description: The maximum id to get messages until to.
+    pattern: >-
+      [0-9a-hjkmnp-tv-zA-HJKMNP-TV-Z]{26}
+    x-example: 01ARZ3NDEKTSV4RRFFQ69G5FAV
   MinimumId:
     name: minimum_id
     type: string
     in: query
     required: false
-    description: >-
-      The minimum id to get messages from.
+    maxLength: 26
+    minLength: 26
+    description: The minimum id to get messages from.
+    pattern: >-
+      [0-9a-hjkmnp-tv-zA-HJKMNP-TV-Z]{26}
+    x-example: 01ARZ3NDEKTSV4RRFFQ69G5FAV
   PaginationRequest:
     type: string
     name: cursor

--- a/api_parameters.yaml
+++ b/api_parameters.yaml
@@ -21,16 +21,16 @@ definitions:
       getArchivedMessages:
         $ref: "#/definitions/BooleanFromString"
       maximumId:
-        $ref: "#/definitions/NonEmptyString"
+        $ref: "#/definitions/Ulid"
       minimumId:
-        $ref: "#/definitions/NonEmptyString"
+        $ref: "#/definitions/Ulid"
   GetMessageParameters:
     type: object
     title: GetMessageParameters
     description: Describes the GetMessage api parameters
     properties:
       id:
-        $ref: "#/definitions/NonEmptyString"
+        $ref: "#/definitions/Ulid"
       public_message:
         $ref: "#/definitions/BooleanFromString"
     required:
@@ -62,3 +62,5 @@ definitions:
     format: NonEmptyString
     x-import: '@pagopa/ts-commons/lib/strings'
     example: "xxxxxxxx"
+  Ulid:
+    $ref: "https://raw.githubusercontent.com/pagopa/io-functions-commons/v28.5.0/openapi/definitions.yaml#/Ulid"

--- a/openapi/api_backend.template.yaml
+++ b/openapi/api_backend.template.yaml
@@ -218,11 +218,7 @@ paths:
   "/messages/{id}":
     x-swagger-router-controller: MessagesController
     parameters:
-      - name: id
-        in: path
-        type: string
-        required: true
-        description: The ID of the message.
+      - $ref: "#/parameters/MessageId"
       - $ref: "#/parameters/PublicMessage"
     get:
       operationId: getUserMessage
@@ -271,11 +267,7 @@ paths:
       summary: UpsertMessageStatusAttributes
       description: Updates the status of a message with attributes
       parameters:
-        - name: id
-          in: path
-          type: string
-          required: true
-          description: The ID of the message.
+        - $ref: "#/parameters/MessageId"
         - name: body
           in: body
           schema:
@@ -323,12 +315,7 @@ paths:
       description: |-
         Returns the Third Party message with the provided message ID.
       parameters:
-        - name: id
-          in: path
-          type: string
-          minLength: 1
-          required: true
-          description: ID of the IO message.
+        - $ref: "#/parameters/MessageId"
       responses:
         "200":
           description: Found.
@@ -370,12 +357,7 @@ paths:
       produces:
         - application/octet-stream
       parameters:
-        - name: id
-          in: path
-          type: string
-          minLength: 1
-          required: true
-          description: ID of the IO message.
+        - $ref: "#/parameters/MessageId"
         - in: path
           name: attachment_url
           type: string
@@ -1125,6 +1107,8 @@ definitions:
     $ref: "../node_modules/@pagopa/io-functions-commons/openapi/definitions.yaml#/CreatedMessageWithContentResponse"
   CreatedMessageWithContentAndEnrichedData:
     $ref: "../node_modules/@pagopa/io-functions-commons/openapi/definitions.yaml#/CreatedMessageWithContentAndEnrichedData"
+  Ulid:
+    $ref: "../node_modules/@pagopa/io-functions-commons/openapi/definitions.yaml#/Ulid"
   # Definitions from pagopa-proxy
   PaymentProblemJson:
     $ref: "https://raw.githubusercontent.com/pagopa/io-pagopa-proxy/v1.6.0/api-spec/api-for-io.yaml#/definitions/PaymentProblemJson"
@@ -1405,6 +1389,17 @@ definitions:
       - expires_in
 responses: {}
 parameters:
+  MessageId:
+    name: id
+    in: path
+    type: string
+    maxLength: 26
+    minLength: 26
+    required: true
+    description: The message id in ulid format
+    pattern: >-
+      [0-9a-hjkmnp-tv-zA-HJKMNP-TV-Z]{26}
+    x-example: 01ARZ3NDEKTSV4RRFFQ69G5FAV
   PublicMessage:
     name: public_message
     in: query
@@ -1435,15 +1430,23 @@ parameters:
     type: string
     in: query
     required: false
-    description: >-
-      The maximum id to get messages until to.
+    maxLength: 26
+    minLength: 26
+    description: The maximum id to get messages until to.
+    pattern: >-
+      [0-9a-hjkmnp-tv-zA-HJKMNP-TV-Z]{26}
+    x-example: 01ARZ3NDEKTSV4RRFFQ69G5FAV
   MinimumId:
     name: minimum_id
     type: string
     in: query
     required: false
-    description: >-
-      The minimum id to get messages from.
+    maxLength: 26
+    minLength: 26
+    description: The minimum id to get messages from.
+    pattern: >-
+      [0-9a-hjkmnp-tv-zA-HJKMNP-TV-Z]{26}
+    x-example: 01ARZ3NDEKTSV4RRFFQ69G5FAV
   PaginationRequest:
     type: string
     name: cursor

--- a/openapi/api_parameters.template.yaml
+++ b/openapi/api_parameters.template.yaml
@@ -21,16 +21,16 @@ definitions:
       getArchivedMessages:
         $ref: "#/definitions/BooleanFromString"
       maximumId:
-        $ref: "#/definitions/NonEmptyString"
+        $ref: "#/definitions/Ulid"
       minimumId:
-        $ref: "#/definitions/NonEmptyString"
+        $ref: "#/definitions/Ulid"
   GetMessageParameters:
     type: object
     title: GetMessageParameters
     description: Describes the GetMessage api parameters
     properties:
       id:
-        $ref: "#/definitions/NonEmptyString"
+        $ref: "#/definitions/Ulid"
       public_message:
         $ref: "#/definitions/BooleanFromString"
     required:
@@ -62,3 +62,5 @@ definitions:
     format: NonEmptyString
     x-import: '@pagopa/ts-commons/lib/strings'
     example: "xxxxxxxx"
+  Ulid:
+    $ref: "https://raw.githubusercontent.com/pagopa/io-functions-commons/v28.5.0/openapi/definitions.yaml#/Ulid"

--- a/openapi/generated/api_backend.yaml
+++ b/openapi/generated/api_backend.yaml
@@ -224,11 +224,7 @@ paths:
   /messages/{id}:
     x-swagger-router-controller: MessagesController
     parameters:
-      - name: id
-        in: path
-        type: string
-        required: true
-        description: The ID of the message.
+      - $ref: '#/parameters/MessageId'
       - $ref: '#/parameters/PublicMessage'
     get:
       operationId: getUserMessage
@@ -276,11 +272,7 @@ paths:
       summary: UpsertMessageStatusAttributes
       description: Updates the status of a message with attributes
       parameters:
-        - name: id
-          in: path
-          type: string
-          required: true
-          description: The ID of the message.
+        - $ref: '#/parameters/MessageId'
         - name: body
           in: body
           schema:
@@ -327,12 +319,7 @@ paths:
       summary: Retrieve Third Party message
       description: Returns the Third Party message with the provided message ID.
       parameters:
-        - name: id
-          in: path
-          type: string
-          minLength: 1
-          required: true
-          description: ID of the IO message.
+        - $ref: '#/parameters/MessageId'
       responses:
         '200':
           description: Found.
@@ -388,12 +375,7 @@ paths:
       produces:
         - application/octet-stream
       parameters:
-        - name: id
-          in: path
-          type: string
-          minLength: 1
-          required: true
-          description: ID of the IO message.
+        - $ref: '#/parameters/MessageId'
         - in: path
           name: attachment_url
           type: string
@@ -2155,6 +2137,12 @@ definitions:
     allOf:
       - $ref: '#/definitions/CreatedMessageWithContent'
       - $ref: '#/definitions/EnrichedMessage'
+  Ulid:
+    type: string
+    description: Ulid string.
+    format: Ulid
+    x-import: '@pagopa/ts-commons/lib/strings'
+    example: 01ARZ3NDEKTSV4RRFFQ69G5FAV
   PaymentProblemJson:
     description: >-
       A ProblemJson-like type specific for the GetPayment and ActivatePayment
@@ -2869,6 +2857,16 @@ definitions:
       - expires_in
 responses: {}
 parameters:
+  MessageId:
+    name: id
+    in: path
+    type: string
+    maxLength: 26
+    minLength: 26
+    required: true
+    description: The message id in ulid format
+    pattern: '[0-9a-hjkmnp-tv-zA-HJKMNP-TV-Z]{26}'
+    x-example: 01ARZ3NDEKTSV4RRFFQ69G5FAV
   PublicMessage:
     name: public_message
     in: query
@@ -2901,13 +2899,21 @@ parameters:
     type: string
     in: query
     required: false
+    maxLength: 26
+    minLength: 26
     description: The maximum id to get messages until to.
+    pattern: '[0-9a-hjkmnp-tv-zA-HJKMNP-TV-Z]{26}'
+    x-example: 01ARZ3NDEKTSV4RRFFQ69G5FAV
   MinimumId:
     name: minimum_id
     type: string
     in: query
     required: false
+    maxLength: 26
+    minLength: 26
     description: The minimum id to get messages from.
+    pattern: '[0-9a-hjkmnp-tv-zA-HJKMNP-TV-Z]{26}'
+    x-example: 01ARZ3NDEKTSV4RRFFQ69G5FAV
   PaginationRequest:
     type: string
     name: cursor

--- a/openapi/generated/api_parameters.yaml
+++ b/openapi/generated/api_parameters.yaml
@@ -21,16 +21,16 @@ definitions:
       getArchivedMessages:
         $ref: '#/definitions/BooleanFromString'
       maximumId:
-        $ref: '#/definitions/NonEmptyString'
+        $ref: '#/definitions/Ulid'
       minimumId:
-        $ref: '#/definitions/NonEmptyString'
+        $ref: '#/definitions/Ulid'
   GetMessageParameters:
     type: object
     title: GetMessageParameters
     description: Describes the GetMessage api parameters
     properties:
       id:
-        $ref: '#/definitions/NonEmptyString'
+        $ref: '#/definitions/Ulid'
       public_message:
         $ref: '#/definitions/BooleanFromString'
     required:
@@ -60,3 +60,9 @@ definitions:
     format: NonEmptyString
     x-import: '@pagopa/ts-commons/lib/strings'
     example: xxxxxxxx
+  Ulid:
+    type: string
+    description: Ulid string.
+    format: Ulid
+    x-import: '@pagopa/ts-commons/lib/strings'
+    example: 01ARZ3NDEKTSV4RRFFQ69G5FAV

--- a/src/controllers/__tests__/messagesController.test.ts
+++ b/src/controllers/__tests__/messagesController.test.ts
@@ -19,6 +19,7 @@ import * as TE from "fp-ts/TaskEither";
 import * as lollipopUtils from "../../utils/lollipop";
 import { ThirdPartyConfigList } from "../../utils/thirdPartyConfig";
 import { aThirdPartyPrecondition } from "../../__mocks__/third-party";
+import { Ulid } from "@pagopa/ts-commons/lib/strings";
 
 const dummyExtractLollipopLocalsFromLollipopHeaders = jest.spyOn(
   lollipopUtils,
@@ -34,6 +35,7 @@ const dummyCheckIfLollipopIsEnabled = jest.spyOn(
 dummyCheckIfLollipopIsEnabled.mockReturnValue(TE.of(false));
 
 const anId: string = "string-id";
+const aValidMessageId = "01C3GDA0GB7GAFX6CCZ3FK3Z5Q" as Ulid;
 
 const proxyMessagesResponse = {
   items: [
@@ -193,8 +195,8 @@ describe("MessagesController#getMessagesByUser", () => {
 
     const pageSize = 2;
     const enrichResultData = false;
-    const maximumId = "AAAA";
-    const minimumId = "BBBB";
+    const maximumId = aValidMessageId;
+    const minimumId = aValidMessageId;
 
     // query params should be strings
     req.query = {
@@ -269,7 +271,7 @@ describe("MessagesController#getMessage", () => {
     );
 
     req.user = mockedUser;
-    req.params = { id: anId };
+    req.params = { id: aValidMessageId };
     req.query = { public_message: "true" };
 
     const controller = new MessagesController(
@@ -282,7 +284,7 @@ describe("MessagesController#getMessage", () => {
     const response = await controller.getMessage(req);
 
     expect(mockFnAppGetMessage).toHaveBeenCalledWith(mockedUser, {
-      id: anId,
+      id: aValidMessageId,
       public_message: true,
     });
     expect(response).toEqual({
@@ -300,7 +302,7 @@ describe("MessagesController#getMessage", () => {
     );
 
     req.user = mockedUser;
-    req.params = { id: anId };
+    req.params = { id: aValidMessageId };
 
     const controller = new MessagesController(
       newMessageService,
@@ -312,7 +314,7 @@ describe("MessagesController#getMessage", () => {
     const response = await controller.getMessage(req);
 
     expect(mockFnAppGetMessage).toHaveBeenCalledWith(mockedUser, {
-      id: anId,
+      id: aValidMessageId,
     });
     expect(response).toEqual({
       apply: expect.any(Function),
@@ -369,7 +371,7 @@ describe("MessagesController#getThirdPartyAttachment", () => {
 
     req.user = mockedUser;
     req.params = {
-      id: anId,
+      id: aValidMessageId,
       attachment_url: anAttachmentUrl,
     };
 
@@ -443,7 +445,7 @@ describe("MessagesController#getThirdPartyMessagePrecondition", () => {
     req.user = mockedUser;
     req.headers = lollipopRequiredHeaders;
     req.params = {
-      id: anId,
+      id: aValidMessageId,
     };
 
     const controller = new MessagesController(
@@ -487,7 +489,7 @@ describe("MessagesController#getThirdPartyMessagePrecondition", () => {
     req.user = mockedUser;
     req.headers = lollipopRequiredHeaders;
     req.params = {
-      id: anId,
+      id: aValidMessageId,
     };
 
     const controller = new MessagesController(
@@ -539,7 +541,7 @@ describe("MessagesController#upsertMessageStatus", () => {
     );
 
     req.user = mockedUser;
-    req.params = { id: anId };
+    req.params = { id: aValidMessageId };
     req.body = aMessageStatusChange;
 
     const controller = new MessagesController(
@@ -551,11 +553,9 @@ describe("MessagesController#upsertMessageStatus", () => {
 
     const response = await controller.upsertMessageStatus(req);
 
-    console.log(response);
-
     expect(mockFnAppUpsertMessageStatus).toHaveBeenCalledWith(
       mockedUser.fiscal_code,
-      anId,
+      aValidMessageId,
       aMessageStatusChange
     );
     expect(response).toEqual({

--- a/src/services/__tests__/newMessagesService.test.ts
+++ b/src/services/__tests__/newMessagesService.test.ts
@@ -14,7 +14,7 @@ import { GetMessagesParameters } from "../../../generated/parameters/GetMessages
 import { MessageStatusChange } from "../../../generated/io-messages-api/MessageStatusChange";
 import { Change_typeEnum as Reading_Change_typeEnum } from "../../../generated/io-messages-api/MessageStatusReadingChange";
 import { MessageStatusValueEnum } from "../../../generated/io-messages-api/MessageStatusValue";
-import { NonEmptyString } from "@pagopa/ts-commons/lib/strings";
+import { NonEmptyString, Ulid } from "@pagopa/ts-commons/lib/strings";
 import { MessageStatusAttributes } from "../../../generated/io-messages-api/MessageStatusAttributes";
 import { MessageStatusWithAttributes } from "../../../generated/io-messages-api/MessageStatusWithAttributes";
 import { AppMessagesAPIClient } from "../../clients/app-messages.client";
@@ -42,9 +42,8 @@ const dummyCheckIfLollipopIsEnabled = jest.spyOn(
 dummyCheckIfLollipopIsEnabled.mockReturnValue(TE.of(false));
 
 const aServiceId = "5a563817fcc896087002ea46c49a";
-const aValidMessageId = "01C3GDA0GB7GAFX6CCZ3FK3Z5Q" as NonEmptyString;
-const aValidMessageIdWithThirdPartyData =
-  "01C3GDA0GB7GAFX6CCZ3FK3XXX" as NonEmptyString;
+const aValidMessageId = "01C3GDA0GB7GAFX6CCZ3FK3Z5Q" as Ulid;
+const aValidMessageIdWithThirdPartyData = "01C3GDA0GB7GAFX6CCZ3FK3XXX" as Ulid;
 const aPublicMessageParam = true;
 const getMessageParamOnlyWithMessageId = {
   id: aValidMessageId,
@@ -522,7 +521,7 @@ describe("MessageService#upsertMessageStatus", () => {
     );
     const res = await service.upsertMessageStatus(
       mockedUser.fiscal_code,
-      aValidMessageId as NonEmptyString,
+      aValidMessageId,
       aMessageStatusChange
     );
 
@@ -573,7 +572,7 @@ describe("MessageService#upsertMessageStatus", () => {
       );
       const res = await service.upsertMessageStatus(
         mockedUser.fiscal_code,
-        aValidMessageId as NonEmptyString,
+        aValidMessageId,
         aMessageStatusChange
       );
 

--- a/src/services/newMessagesService.ts
+++ b/src/services/newMessagesService.ts
@@ -18,7 +18,11 @@ import {
   IResponseSuccessNoContent,
 } from "@pagopa/ts-commons/lib/responses";
 import { AppMessagesAPIClient } from "src/clients/app-messages.client";
-import { FiscalCode, NonEmptyString } from "@pagopa/ts-commons/lib/strings";
+import {
+  FiscalCode,
+  NonEmptyString,
+  Ulid,
+} from "@pagopa/ts-commons/lib/strings";
 import { pipe, flow } from "fp-ts/lib/function";
 import * as TE from "fp-ts/TaskEither";
 import * as E from "fp-ts/Either";
@@ -175,7 +179,7 @@ export default class NewMessagesService {
    */
   public readonly upsertMessageStatus = (
     fiscalCode: FiscalCode,
-    messageId: NonEmptyString,
+    messageId: Ulid,
     messageStatusChange: MessageStatusChange
   ): Promise<
     | IResponseErrorInternal
@@ -306,7 +310,7 @@ export default class NewMessagesService {
 
   public readonly getThirdPartyMessageFnApp = (
     fiscalCode: FiscalCode,
-    messageId: string
+    messageId: Ulid
   ): TE.TaskEither<
     | IResponseErrorInternal
     | IResponseErrorValidation


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->

* [Restrict message id type to be an Ulid for messages endpoints](https://github.com/pagopa/io-backend/commit/cc04ef43535ca3e590289f3ee9d3039b10467f19);

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

We need a strict type check on every path param accepted as a string to address a potential security issue.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
