### PR TITLE
[#IOPID-346] Consistent Redis Client

### DIFF
--- a/package.json
+++ b/package.json
@@ -189,7 +189,7 @@
       "**/__tests__/*.ts"
     ],
     "coverageDirectory": "./coverage/",
-    "collectCoverage": false,
+    "collectCoverage": true,
     "collectCoverageFrom": [
       "src/**/*.ts",
       "!src/clients/api/*.ts",

--- a/package.json
+++ b/package.json
@@ -189,7 +189,7 @@
       "**/__tests__/*.ts"
     ],
     "coverageDirectory": "./coverage/",
-    "collectCoverage": true,
+    "collectCoverage": false,
     "collectCoverageFrom": [
       "src/**/*.ts",
       "!src/clients/api/*.ts",

--- a/src/__mocks__/redis.ts
+++ b/src/__mocks__/redis.ts
@@ -1,0 +1,28 @@
+import { RedisClientSelectorType } from "../utils/redis";
+
+export const mockGet = jest.fn();
+export const mockSet = jest.fn();
+export const mockSetEx = jest.fn();
+export const mockMget = jest.fn();
+export const mockSmembers = jest.fn();
+export const mockSismember = jest.fn();
+export const mockSrem = jest.fn();
+export const mockTtl = jest.fn();
+export const mockExists = jest.fn();
+export const mockDel = jest.fn();
+export const mockSadd = jest.fn();
+export const mockRedisClientSelector = {
+  selectOne: () => ({
+    set: mockSet,
+    setEx: mockSetEx,
+    get: mockGet,
+    mGet: mockMget,
+    del: mockDel,
+    sAdd: mockSadd,
+    sRem: mockSrem,
+    sMembers: mockSmembers,
+    sIsMember: mockSismember,
+    ttl: mockTtl,
+    exists: mockExists,
+  }),
+} as unknown as RedisClientSelectorType;

--- a/src/__mocks__/redis.ts
+++ b/src/__mocks__/redis.ts
@@ -11,18 +11,19 @@ export const mockTtl = jest.fn();
 export const mockExists = jest.fn();
 export const mockDel = jest.fn();
 export const mockSadd = jest.fn();
+export const mockSelectOne = jest.fn().mockImplementation(() => ({
+  set: mockSet,
+  setEx: mockSetEx,
+  get: mockGet,
+  mGet: mockMget,
+  del: mockDel,
+  sAdd: mockSadd,
+  sRem: mockSrem,
+  sMembers: mockSmembers,
+  sIsMember: mockSismember,
+  ttl: mockTtl,
+  exists: mockExists,
+}));
 export const mockRedisClientSelector = {
-  selectOne: () => ({
-    set: mockSet,
-    setEx: mockSetEx,
-    get: mockGet,
-    mGet: mockMget,
-    del: mockDel,
-    sAdd: mockSadd,
-    sRem: mockSrem,
-    sMembers: mockSmembers,
-    sIsMember: mockSismember,
-    ttl: mockTtl,
-    exists: mockExists,
-  }),
+  selectOne: mockSelectOne,
 } as unknown as RedisClientSelectorType;

--- a/src/__mocks__/redis.ts
+++ b/src/__mocks__/redis.ts
@@ -1,4 +1,5 @@
 import { RedisClientSelectorType } from "../utils/redis";
+import * as redis from "redis";
 
 export const mockGet = jest.fn();
 export const mockSet = jest.fn();
@@ -11,7 +12,8 @@ export const mockTtl = jest.fn();
 export const mockExists = jest.fn();
 export const mockDel = jest.fn();
 export const mockSadd = jest.fn();
-export const mockSelectOne = jest.fn().mockImplementation(() => ({
+export const mockQuit = jest.fn().mockResolvedValue(void 0);
+export const mockRedisClusterType = {
   set: mockSet,
   setEx: mockSetEx,
   get: mockGet,
@@ -23,7 +25,15 @@ export const mockSelectOne = jest.fn().mockImplementation(() => ({
   sIsMember: mockSismember,
   ttl: mockTtl,
   exists: mockExists,
-}));
+  quit: mockQuit,
+} as unknown as redis.RedisClusterType;
+export const mockSelect = jest
+  .fn()
+  .mockImplementation(() => [mockRedisClusterType, mockRedisClusterType]);
+export const mockSelectOne = jest
+  .fn()
+  .mockImplementation(() => mockRedisClusterType);
 export const mockRedisClientSelector = {
+  select: mockSelect,
   selectOne: mockSelectOne,
 } as unknown as RedisClientSelectorType;

--- a/src/app.ts
+++ b/src/app.ts
@@ -803,7 +803,7 @@ export async function newApp({
       );
       _.app.on("server:stop", () => {
         clearInterval(startIdpMetadataRefreshTimer);
-        // Graceful redis connection shoutdown.
+        // Graceful redis connection shutdown.
         for (const client of REDIS_CLIENT.select(RedisClientSelectorEnum.ALL)) {
           log.info(`Graceful closing redis connection`);
           pipe(

--- a/src/app.ts
+++ b/src/app.ts
@@ -157,7 +157,7 @@ import {
   getCurrentBackendVersion,
   getObjectFromPackageJson,
 } from "./utils/package";
-import { RedisClientSelector, RedisClientSelectorEnum } from "./utils/redis";
+import { RedisClientSelector, RedisClientMode } from "./utils/redis";
 import { ResponseErrorDismissed } from "./utils/responses";
 import { makeSpidLogCallback } from "./utils/spid";
 import { TimeTracer } from "./utils/timer";
@@ -583,7 +583,7 @@ export async function newApp({
         const PAGOPA_PROXY_SERVICE = new PagoPAProxyService(PAGOPA_CLIENT);
         // Register the user metadata storage service.
         const USER_METADATA_STORAGE = new RedisUserMetadataStorage(
-          REDIS_CLIENT.selectOne(RedisClientSelectorEnum.FAST)
+          REDIS_CLIENT.selectOne(RedisClientMode.FAST)
         );
         // eslint-disable-next-line @typescript-eslint/no-use-before-define
         registerAPIRoutes(
@@ -772,7 +772,7 @@ export async function newApp({
                   appInsightsClient
                 )
               ),
-              redisClient: REDIS_CLIENT.selectOne(RedisClientSelectorEnum.FAST),
+              redisClient: REDIS_CLIENT.selectOne(RedisClientMode.FAST),
               samlConfig,
               serviceProviderConfig,
             })(),
@@ -804,7 +804,7 @@ export async function newApp({
       _.app.on("server:stop", () => {
         clearInterval(startIdpMetadataRefreshTimer);
         // Graceful redis connection shutdown.
-        for (const client of REDIS_CLIENT.select(RedisClientSelectorEnum.ALL)) {
+        for (const client of REDIS_CLIENT.select(RedisClientMode.ALL)) {
           log.info(`Graceful closing redis connection`);
           pipe(
             O.fromNullable(client.quit),

--- a/src/app.ts
+++ b/src/app.ts
@@ -157,7 +157,7 @@ import {
   getCurrentBackendVersion,
   getObjectFromPackageJson,
 } from "./utils/package";
-import { createClusterRedisClient } from "./utils/redis";
+import { RedisClientSelector, RedisClientSelectorEnum } from "./utils/redis";
 import { ResponseErrorDismissed } from "./utils/responses";
 import { makeSpidLogCallback } from "./utils/spid";
 import { TimeTracer } from "./utils/timer";
@@ -245,7 +245,7 @@ export async function newApp({
   ZendeskBasePath,
 }: IAppFactoryParameters): Promise<Express> {
   const isDevEnvironment = ENV === NodeEnvironmentEnum.DEVELOPMENT;
-  const REDIS_CLIENT = await createClusterRedisClient(
+  const REDIS_CLIENT = await RedisClientSelector(
     !isDevEnvironment,
     appInsightsClient
   )(
@@ -253,6 +253,7 @@ export async function newApp({
     process.env.REDIS_PASSWORD,
     process.env.REDIS_PORT
   );
+
   // Create the Session Storage service
   const SESSION_STORAGE = new RedisSessionStorage(
     REDIS_CLIENT,
@@ -582,7 +583,7 @@ export async function newApp({
         const PAGOPA_PROXY_SERVICE = new PagoPAProxyService(PAGOPA_CLIENT);
         // Register the user metadata storage service.
         const USER_METADATA_STORAGE = new RedisUserMetadataStorage(
-          REDIS_CLIENT
+          REDIS_CLIENT.selectOne(RedisClientSelectorEnum.FAST)
         );
         // eslint-disable-next-line @typescript-eslint/no-use-before-define
         registerAPIRoutes(
@@ -771,7 +772,7 @@ export async function newApp({
                   appInsightsClient
                 )
               ),
-              redisClient: REDIS_CLIENT,
+              redisClient: REDIS_CLIENT.selectOne(RedisClientSelectorEnum.FAST),
               samlConfig,
               serviceProviderConfig,
             })(),
@@ -800,9 +801,25 @@ export async function newApp({
           }),
         IDP_METADATA_REFRESH_INTERVAL_SECONDS * 1000
       );
-      _.app.on("server:stop", () =>
-        clearInterval(startIdpMetadataRefreshTimer)
-      );
+      _.app.on("server:stop", () => {
+        clearInterval(startIdpMetadataRefreshTimer);
+        // Graceful redis connection shoutdown.
+        for (const client of REDIS_CLIENT.select(RedisClientSelectorEnum.ALL)) {
+          log.info(`Graceful closing redis connection`);
+          pipe(
+            O.fromNullable(client.quit),
+            O.map((redisQuitFn) =>
+              redisQuitFn().catch((err) =>
+                log.error(
+                  `An Error occurred closing the redis connection: [${
+                    E.toError(err).message
+                  }]`
+                )
+              )
+            )
+          );
+        }
+      });
       return _.app;
     }),
     TE.chain((_) => {

--- a/src/controllers/__tests__/authenticationController.test.ts
+++ b/src/controllers/__tests__/authenticationController.test.ts
@@ -3,7 +3,6 @@ import * as TE from "fp-ts/lib/TaskEither";
 import * as O from "fp-ts/lib/Option";
 import { UrlFromString, ValidUrl } from "@pagopa/ts-commons/lib/url";
 import * as lolex from "lolex";
-import * as redis from "redis";
 import { NewProfile } from "@pagopa/io-functions-app-sdk/NewProfile";
 import {
   ResponseErrorInternal,
@@ -79,6 +78,7 @@ import {
   AuthenticationLockServiceMock,
   isUserAuthenticationLockedMock,
 } from "../../__mocks__/services.mock";
+import { mockRedisClientSelector } from "../../__mocks__/redis";
 
 const req = mockReq();
 req.ip = "127.0.0.2";
@@ -256,8 +256,6 @@ const mockTelemetryClient = {
   trackEvent: jest.fn(),
 } as unknown as appInsights.TelemetryClient;
 
-const redisClient = {} as redis.RedisClientType;
-
 const tokenService = new TokenService();
 
 const tokenDurationSecs = 3600 * 24 * 30;
@@ -266,7 +264,7 @@ const lvLongSessionDurationSecs = 3600 * 24 * 365;
 
 const aDefaultLollipopAssertionRefDurationSec = (3600 * 24 * 365 * 2) as Second;
 const redisSessionStorage = new RedisSessionStorage(
-  redisClient,
+  mockRedisClientSelector,
   tokenDurationSecs,
   aDefaultLollipopAssertionRefDurationSec
 );

--- a/src/controllers/__tests__/fastLoginController.test.ts
+++ b/src/controllers/__tests__/fastLoginController.test.ts
@@ -1,7 +1,6 @@
 import RedisSessionStorage from "../../services/redisSessionStorage";
 import * as E from "fp-ts/lib/Either";
 import * as RNEA from "fp-ts/lib/ReadonlyNonEmptyArray";
-import * as redis from "redis";
 import { aFiscalCode } from "../../__mocks__/user_mock";
 import TokenService from "../../services/tokenService";
 import { AssertionTypeEnum } from "../../../generated/lollipop-api/AssertionType";
@@ -35,6 +34,7 @@ import * as spidUtils from "../../utils/spid";
 import { pipe } from "fp-ts/lib/function";
 import { UserWithoutTokens } from "../../types/user";
 import { SpidLevelEnum } from "../../../generated/backend/SpidLevel";
+import { mockRedisClientSelector } from "../../__mocks__/redis";
 
 const mockSet = jest.fn();
 const mockDel = jest.fn();
@@ -59,15 +59,13 @@ jest.mock("../../services/tokenService", () => {
   };
 });
 
-const redisClient = {} as redis.RedisClientType;
-
 const tokenService = new TokenService();
 const sessionTTL = 60 * 15;
 
 const aDefaultLollipopAssertionRefDurationSec = (3600 * 24 * 365 * 2) as Second;
 
 const redisSessionStorage = new RedisSessionStorage(
-  redisClient,
+  mockRedisClientSelector,
   sessionTTL,
   aDefaultLollipopAssertionRefDurationSec
 );

--- a/src/controllers/__tests__/notificationController.test.ts
+++ b/src/controllers/__tests__/notificationController.test.ts
@@ -20,8 +20,8 @@ import {
   mockWalletToken,
 } from "../../__mocks__/user_mock";
 import { MessageSubject } from "../../../generated/notifications/MessageSubject";
-import * as redis from "redis";
 import { Second } from "@pagopa/ts-commons/lib/units";
+import { mockRedisClientSelector } from "../../__mocks__/redis";
 
 const aTimestamp = 1518010929530;
 const aFiscalNumber = "GRBGPP87L04L741X" as FiscalCode;
@@ -108,12 +108,10 @@ const badRequestErrorResponse = {
 jest.mock("../../services/notificationService");
 jest.mock("../../services/redisSessionStorage");
 
-const redisClient = {} as redis.RedisClientType;
-
 const tokenDurationSecs = 0;
 const aDefaultLollipopAssertionRefDurationSec = (3600 * 24 * 365 * 2) as Second;
 const redisSessionStorage = new RedisSessionStorage(
-  redisClient,
+  mockRedisClientSelector,
   tokenDurationSecs,
   aDefaultLollipopAssertionRefDurationSec
 );

--- a/src/controllers/__tests__/pagoPAController.test.ts
+++ b/src/controllers/__tests__/pagoPAController.test.ts
@@ -1,5 +1,3 @@
-import * as redis from "redis";
-
 import { PagoPAUser } from "../../../generated/pagopa/PagoPAUser";
 
 import mockReq from "../../__mocks__/request";
@@ -14,16 +12,17 @@ import PagoPAController from "../pagoPAController";
 import {
   aCustomEmailAddress,
   mockedInitializedProfile,
-  mockedUser
+  mockedUser,
 } from "../../__mocks__/user_mock";
 import { Second } from "@pagopa/ts-commons/lib/units";
+import { mockRedisClientSelector } from "../../__mocks__/redis";
 
 const proxyUserResponse: PagoPAUser = {
   family_name: mockedUser.family_name,
   fiscal_code: mockedUser.fiscal_code,
   name: mockedUser.name,
   notice_email: aCustomEmailAddress,
-  spid_email: mockedUser.spid_email
+  spid_email: mockedUser.spid_email,
 };
 
 const mockGetPagoPaNoticeEmail = jest
@@ -34,14 +33,14 @@ const mockGetPagoPaNoticeEmail = jest
 
 const mockSetPagoPaNoticeEmail = jest
   .fn()
-  .mockImplementation(_ => Promise.resolve(E.right(true)));
+  .mockImplementation((_) => Promise.resolve(E.right(true)));
 
 jest.mock("../../services/redisSessionStorage", () => {
   return {
     default: jest.fn().mockImplementation(() => ({
       getPagoPaNoticeEmail: mockGetPagoPaNoticeEmail,
-      setPagoPaNoticeEmail: mockSetPagoPaNoticeEmail
-    }))
+      setPagoPaNoticeEmail: mockSetPagoPaNoticeEmail,
+    })),
   };
 });
 
@@ -49,17 +48,15 @@ const mockGetProfile = jest.fn();
 jest.mock("../../services/profileService", () => {
   return {
     default: jest.fn().mockImplementation(() => ({
-      getProfile: mockGetProfile
-    }))
+      getProfile: mockGetProfile,
+    })),
   };
 });
-
-const redisClient = {} as redis.RedisClientType;
 
 const tokenDurationSecs = 0;
 const aDefaultLollipopAssertionRefDurationSec = (3600 * 24 * 365 * 2) as Second;
 const redisSessionStorage = new RedisSessionStorage(
-  redisClient,
+  mockRedisClientSelector,
   tokenDurationSecs,
   aDefaultLollipopAssertionRefDurationSec
 );
@@ -97,7 +94,7 @@ describe("PagoPaController#getUser", () => {
     expect(response).toEqual({
       apply: expect.any(Function),
       kind: "IResponseSuccessJson",
-      value: proxyUserResponse
+      value: proxyUserResponse,
     });
   });
 
@@ -129,7 +126,7 @@ describe("PagoPaController#getUser", () => {
     expect(response).toEqual({
       apply: expect.any(Function),
       kind: "IResponseSuccessJson",
-      value: proxyUserResponse
+      value: proxyUserResponse,
     });
   });
 
@@ -157,7 +154,7 @@ describe("PagoPaController#getUser", () => {
     expect(response).toEqual({
       apply: expect.any(Function),
       kind: "IResponseSuccessJson",
-      value: proxyUserResponse
+      value: proxyUserResponse,
     });
   });
 
@@ -169,7 +166,7 @@ describe("PagoPaController#getUser", () => {
         // Return an InitializedProfile with non validated email
         ResponseSuccessJson({
           ...mockedInitializedProfile,
-          is_email_validated: false
+          is_email_validated: false,
         })
       )
     );
@@ -193,8 +190,8 @@ describe("PagoPaController#getUser", () => {
       // Custom Email is not provided becouse not yet validated
       value: {
         ...proxyUserResponse,
-        notice_email: mockedUser.spid_email
-      }
+        notice_email: mockedUser.spid_email,
+      },
     });
   });
 
@@ -206,7 +203,7 @@ describe("PagoPaController#getUser", () => {
         // Return an InitializedProfile with non validated email
         ResponseSuccessJson({
           ...mockedInitializedProfile,
-          is_email_validated: false
+          is_email_validated: false,
         })
       )
     );
@@ -214,7 +211,7 @@ describe("PagoPaController#getUser", () => {
     // A session user info without spid email available
     const notSpidUserSessionUser: User = {
       ...mockedUser,
-      spid_email: undefined
+      spid_email: undefined,
     };
     // tslint:disable-next-line: no-object-mutation
     req.user = notSpidUserSessionUser;
@@ -232,7 +229,7 @@ describe("PagoPaController#getUser", () => {
     expect(response).toEqual({
       apply: expect.any(Function),
       detail: "Validation Error: Invalid User Data",
-      kind: "IResponseErrorValidation"
+      kind: "IResponseErrorValidation",
     });
   });
 });

--- a/src/controllers/__tests__/profileController.test.ts
+++ b/src/controllers/__tests__/profileController.test.ts
@@ -2,10 +2,9 @@ import { NonNegativeInteger } from "@pagopa/ts-commons/lib/numbers";
 import {
   ResponseErrorNotFound,
   ResponseSuccessAccepted,
-  ResponseSuccessJson
+  ResponseSuccessJson,
 } from "@pagopa/ts-commons/lib/responses";
 import * as E from "fp-ts/lib/Either";
-import * as redis from "redis";
 import { mockedUser } from "../../__mocks__/user_mock";
 import { EmailAddress } from "../../../generated/backend/EmailAddress";
 import { ExtendedProfile } from "../../../generated/backend/ExtendedProfile";
@@ -14,7 +13,7 @@ import { IsInboxEnabled } from "../../../generated/backend/IsInboxEnabled";
 import { IsWebhookEnabled } from "../../../generated/backend/IsWebhookEnabled";
 import {
   PreferredLanguage,
-  PreferredLanguageEnum
+  PreferredLanguageEnum,
 } from "../../../generated/backend/PreferredLanguage";
 import { Profile } from "../../../generated/backend/Profile";
 import mockReq from "../../__mocks__/request";
@@ -30,6 +29,7 @@ import { AppVersion } from "../../../generated/backend/AppVersion";
 import { PushNotificationsContentTypeEnum } from "../../../generated/backend/PushNotificationsContentType";
 import { ReminderStatusEnum } from "../../../generated/backend/ReminderStatus";
 import { Second } from "@pagopa/ts-commons/lib/units";
+import { mockRedisClientSelector } from "../../__mocks__/redis";
 
 const aTimestamp = 1518010929530;
 
@@ -40,10 +40,10 @@ const aValidFamilyname = "Garibaldi";
 const anIsInboxEnabled = true as IsInboxEnabled;
 const anIsWebookEnabled = true as IsWebhookEnabled;
 const aPreferredLanguages: ReadonlyArray<PreferredLanguage> = [
-  PreferredLanguageEnum.it_IT
+  PreferredLanguageEnum.it_IT,
 ];
 const aServicePreferencesSettings: ServicePreferencesSettings = {
-  mode: ServicesPreferencesModeEnum.AUTO
+  mode: ServicesPreferencesModeEnum.AUTO,
 };
 
 const proxyUserResponse = {
@@ -58,7 +58,7 @@ const proxyUserResponse = {
   preferredLanguages: aPreferredLanguages,
   spid_email: anEmailAddress,
   token: "123hexToken",
-  version: 1 as NonNegativeInteger
+  version: 1 as NonNegativeInteger,
 };
 
 const apiUserProfileResponse = {
@@ -67,7 +67,7 @@ const apiUserProfileResponse = {
   is_inbox_enabled: true,
   is_webhook_enabled: true,
   preferred_languages: ["it_IT"],
-  version: 42
+  version: 42,
 };
 
 // mock for upsert user (Extended Profile)
@@ -79,14 +79,14 @@ const mockedUpsertProfile: ExtendedProfile = {
   is_webhook_enabled: anIsWebookEnabled,
   preferred_languages: aPreferredLanguages,
   service_preferences_settings: aServicePreferencesSettings,
-  version: 1 as NonNegativeInteger
+  version: 1 as NonNegativeInteger,
 };
 
 const badRequestErrorResponse = {
   detail: expect.any(String),
   status: 400,
   title: expect.any(String),
-  type: undefined
+  type: undefined,
 };
 
 const mockGetProfile = jest.fn();
@@ -99,29 +99,27 @@ jest.mock("../../services/profileService", () => {
       emailValidationProcess: mockEmailValidationProcess,
       getApiProfile: mockGetApiProfile,
       getProfile: mockGetProfile,
-      updateProfile: mockUpdateProfile
-    }))
+      updateProfile: mockUpdateProfile,
+    })),
   };
 });
 
 const mockDelPagoPaNoticeEmail = jest
   .fn()
-  .mockImplementation(_ => Promise.resolve(E.right(true)));
+  .mockImplementation((_) => Promise.resolve(E.right(true)));
 
 jest.mock("../../services/redisSessionStorage", () => {
   return {
     default: jest.fn().mockImplementation(() => ({
-      delPagoPaNoticeEmail: mockDelPagoPaNoticeEmail
-    }))
+      delPagoPaNoticeEmail: mockDelPagoPaNoticeEmail,
+    })),
   };
 });
-
-const redisClient = {} as redis.RedisClientType;
 
 const tokenDurationSecs = 0;
 const aDefaultLollipopAssertionRefDurationSec = (3600 * 24 * 365 * 2) as Second;
 const redisSessionStorage = new RedisSessionStorage(
-  redisClient,
+  mockRedisClientSelector,
   tokenDurationSecs,
   aDefaultLollipopAssertionRefDurationSec
 );
@@ -153,7 +151,7 @@ describe("ProfileController#getProfile", () => {
     expect(response).toEqual({
       apply: expect.any(Function),
       kind: "IResponseSuccessJson",
-      value: proxyUserResponse
+      value: proxyUserResponse,
     });
   });
 
@@ -173,7 +171,7 @@ describe("ProfileController#getProfile", () => {
         Promise.resolve(
           ResponseSuccessJson({
             ...proxyUserResponse,
-            [additionalProperty]: value
+            [additionalProperty]: value,
           })
         )
       );
@@ -195,8 +193,8 @@ describe("ProfileController#getProfile", () => {
         kind: "IResponseSuccessJson",
         value: {
           ...proxyUserResponse,
-          [additionalProperty]: value
-        }
+          [additionalProperty]: value,
+        },
       });
     }
   );
@@ -249,7 +247,7 @@ describe("ProfileController#getProfile", () => {
     expect(mockGetProfile).toHaveBeenCalledWith(mockedUser);
     expect(response).toEqual({
       ...profileMissingErrorResponse,
-      apply: expect.any(Function)
+      apply: expect.any(Function),
     });
   });
 });
@@ -280,7 +278,7 @@ describe("ProfileController#getApiProfile", () => {
     expect(response).toEqual({
       apply: expect.any(Function),
       kind: "IResponseSuccessJson",
-      value: apiUserProfileResponse
+      value: apiUserProfileResponse,
     });
   });
 
@@ -300,7 +298,7 @@ describe("ProfileController#getApiProfile", () => {
         Promise.resolve(
           ResponseSuccessJson({
             ...apiUserProfileResponse,
-            [additionalProperty]: value
+            [additionalProperty]: value,
           })
         )
       );
@@ -321,8 +319,8 @@ describe("ProfileController#getApiProfile", () => {
         kind: "IResponseSuccessJson",
         value: {
           ...apiUserProfileResponse,
-          [additionalProperty]: value
-        }
+          [additionalProperty]: value,
+        },
       });
     }
   );
@@ -348,7 +346,7 @@ describe("ProfileController#getApiProfile", () => {
     expect(response).toEqual({
       apply: expect.any(Function),
       kind: "IResponseSuccessJson",
-      value: apiUserProfileResponse
+      value: apiUserProfileResponse,
     });
   });
 
@@ -414,7 +412,7 @@ describe("ProfileController#upsertProfile", () => {
     expect(response).toEqual({
       apply: expect.any(Function),
       kind: "IResponseSuccessJson",
-      value: proxyUserResponse
+      value: proxyUserResponse,
     });
   });
 
@@ -434,7 +432,7 @@ describe("ProfileController#upsertProfile", () => {
         Promise.resolve(
           ResponseSuccessJson({
             ...proxyUserResponse,
-            [additionalProperty]: value
+            [additionalProperty]: value,
           })
         )
       );
@@ -442,7 +440,7 @@ describe("ProfileController#upsertProfile", () => {
       req.user = mockedUser;
       req.body = {
         ...mockedUpsertProfile,
-        [additionalProperty]: value
+        [additionalProperty]: value,
       };
 
       const apiClient = new ApiClient("XUZTCT88A51Y311X", "");
@@ -468,8 +466,8 @@ describe("ProfileController#upsertProfile", () => {
         kind: "IResponseSuccessJson",
         value: {
           ...proxyUserResponse,
-          [additionalProperty]: value
-        }
+          [additionalProperty]: value,
+        },
       });
     }
   );
@@ -551,7 +549,7 @@ describe("ProfileController#startEmailValidationProcess", () => {
     expect(mockEmailValidationProcess).toHaveBeenCalledWith(mockedUser);
     expect(response).toEqual({
       apply: expect.any(Function),
-      kind: "IResponseSuccessAccepted"
+      kind: "IResponseSuccessAccepted",
     });
   });
 });

--- a/src/controllers/__tests__/sessionController.test.ts
+++ b/src/controllers/__tests__/sessionController.test.ts
@@ -22,31 +22,21 @@ import { ResponseSuccessJson } from "@pagopa/ts-commons/lib/responses";
 import * as crypto from "crypto";
 import { Second } from "@pagopa/ts-commons/lib/units";
 import { anAssertionRef } from "../../__mocks__/lollipop";
-import { RedisClientType } from "redis";
+import {
+  mockExists,
+  mockGet,
+  mockRedisClientSelector,
+  mockSet,
+  mockSmembers,
+  mockSrem,
+  mockTtl,
+} from "../../__mocks__/redis";
 
 const aTokenDurationSecs = 3600;
 const aDefaultLollipopAssertionRefDurationSec = (3600 * 24 * 365 * 2) as Second;
-const mockGet = jest.fn();
-const mockSet = jest.fn();
-const mockMget = jest.fn();
-const mockSmembers = jest.fn();
-const mockSismember = jest.fn();
-const mockSrem = jest.fn();
-const mockTtl = jest.fn();
-const mockExists = jest.fn();
-const mockRedisClient = {
-  get: mockGet,
-  mGet: mockMget,
-  sMembers: mockSmembers.mockImplementation((_) =>
-    Promise.resolve([`SESSIONINFO-${mockedUser.session_token}`])
-  ),
-  sIsMember: mockSismember,
-  ttl: mockTtl,
-  set: mockSet,
-  sRem: mockSrem,
-  setEx: mockSet,
-  exists: mockExists,
-} as unknown as RedisClientType;
+mockSmembers.mockImplementation((_) =>
+  Promise.resolve([`SESSIONINFO-${mockedUser.session_token}`])
+);
 
 const mockGetProfile = jest.fn();
 jest.mock("../../services/profileService", () => {
@@ -74,7 +64,7 @@ const mockGetNewToken = jest.spyOn(tokenService, "getNewToken");
 
 const controller = new SessionController(
   new RedisSessionStorage(
-    mockRedisClient,
+    mockRedisClientSelector,
     aTokenDurationSecs,
     aDefaultLollipopAssertionRefDurationSec
   ),

--- a/src/server.ts
+++ b/src/server.ts
@@ -161,8 +161,6 @@ newApp({
       });
     }
     server.on("close", () => {
-      app.emit("server:stop");
-
       // If an AppInsights Client is initialized, flush all pending data and reset the configuration.
       pipe(
         maybeAppInsightsClient,

--- a/src/services/__tests__/redisSessionStorage.test.ts
+++ b/src/services/__tests__/redisSessionStorage.test.ts
@@ -37,9 +37,19 @@ import {
 } from "../../__mocks__/user_mock";
 import { Second } from "@pagopa/ts-commons/lib/units";
 import { anAssertionRef } from "../../__mocks__/lollipop";
-import { RedisClientType } from "redis";
 import { LoginTypeEnum } from "../../utils/fastLogin";
 import { NullableBackendAssertionRefFromString } from "../../types/assertionRef";
+import {
+  mockDel,
+  mockExists,
+  mockGet,
+  mockRedisClientSelector,
+  mockSadd,
+  mockSetEx,
+  mockSmembers,
+  mockSrem,
+  mockTtl,
+} from "../../__mocks__/redis";
 
 const aTokenDurationSecs = 3600;
 const aDefaultLollipopAssertionRefDurationSec = (3600 * 24 * 365 * 2) as Second;
@@ -81,42 +91,15 @@ jest.mock("../../services/tokenService", () => {
     })),
   };
 });
-
-const mockSet = jest.fn();
-const mockSetEx = jest
-  .fn()
-  .mockImplementation((_, __, ___) => Promise.resolve("OK"));
-const mockGet = jest
-  .fn()
-  .mockImplementation((_) => Promise.resolve(JSON.stringify(aValidUser)));
-const mockMget = jest.fn();
-const mockDel = jest.fn().mockImplementation((_) => Promise.resolve(1));
-
-const mockSadd = jest.fn().mockImplementation((_, __) => Promise.resolve(1));
-const mockSrem = jest.fn().mockImplementation((_, __) => Promise.resolve(1));
-const mockSmembers = jest
-  .fn()
-  .mockImplementation((_) => Promise.resolve([mockSessionToken]));
-const mockExists = jest.fn();
-const mockSismember = jest.fn();
-const mockTtl = jest.fn();
-
-const mockRedisClient = {
-  set: mockSet,
-  setEx: mockSetEx,
-  get: mockGet,
-  mGet: mockMget,
-  del: mockDel,
-  sAdd: mockSadd,
-  sRem: mockSrem,
-  sMembers: mockSmembers,
-  exists: mockExists,
-  sIsMember: mockSismember,
-  ttl: mockTtl,
-} as unknown as RedisClientType;
+mockSetEx.mockImplementation((_, __, ___) => Promise.resolve("OK"));
+mockGet.mockImplementation((_) => Promise.resolve(JSON.stringify(aValidUser)));
+mockDel.mockImplementation((_) => Promise.resolve(1));
+mockSadd.mockImplementation((_, __) => Promise.resolve(1));
+mockSrem.mockImplementation((_, __) => Promise.resolve(1));
+mockSmembers.mockImplementation((_) => Promise.resolve([mockSessionToken]));
 
 const sessionStorage = new RedisSessionStorage(
-  mockRedisClient,
+  mockRedisClientSelector,
   aTokenDurationSecs,
   aDefaultLollipopAssertionRefDurationSec
 );

--- a/src/services/__tests__/redisSessionStorage.test.ts
+++ b/src/services/__tests__/redisSessionStorage.test.ts
@@ -45,11 +45,13 @@ import {
   mockGet,
   mockRedisClientSelector,
   mockSadd,
+  mockSelectOne,
   mockSetEx,
   mockSmembers,
   mockSrem,
   mockTtl,
 } from "../../__mocks__/redis";
+import { RedisClientMode } from "../../utils/redis";
 
 const aTokenDurationSecs = 3600;
 const aDefaultLollipopAssertionRefDurationSec = (3600 * 24 * 365 * 2) as Second;
@@ -1388,6 +1390,8 @@ describe("RedisSessionStorage#userHasActiveSessionsOrLV", () => {
   const expectedRedisError = new Error("Generic Redis Error");
 
   const expectOnlyLollipopDataIsRetrieved = (cf: FiscalCode) => {
+    expect(mockSelectOne).toHaveBeenNthCalledWith(1, RedisClientMode.SAFE);
+    expect(mockSelectOne).toHaveBeenCalledTimes(1);
     expect(mockGet).toHaveBeenNthCalledWith(1, `KEYS-${cf}`);
     expect(mockSmembers).not.toHaveBeenCalled();
     expect(mockGet).toHaveBeenCalledTimes(1);
@@ -1397,6 +1401,7 @@ describe("RedisSessionStorage#userHasActiveSessionsOrLV", () => {
     cf: FiscalCode,
     sessionToken: string
   ) => {
+    expect(mockSelectOne).toHaveBeenNthCalledWith(1, RedisClientMode.SAFE);
     expect(mockGet).toHaveBeenNthCalledWith(1, `KEYS-${cf}`);
     expect(mockSmembers).toHaveBeenCalledWith(`USERSESSIONS-${cf}`);
     expect(mockGet).toHaveBeenNthCalledWith(2, `SESSIONINFO-${sessionToken}`);
@@ -1439,6 +1444,7 @@ describe("RedisSessionStorage#userHasActiveSessionsOrLV", () => {
       aValidUser.fiscal_code,
       aValidUser.session_token
     );
+    expect(mockSelectOne).toHaveBeenCalledTimes(4);
   });
 
   it("should return false if no LollipopData was found", async () => {
@@ -1471,6 +1477,7 @@ describe("RedisSessionStorage#userHasActiveSessionsOrLV", () => {
       aValidUser.fiscal_code,
       aValidUser.session_token
     );
+    expect(mockSelectOne).toHaveBeenCalledTimes(3);
   });
 
   it("should return false if login type is LEGACY and user has no active sessions", async () => {
@@ -1484,6 +1491,7 @@ describe("RedisSessionStorage#userHasActiveSessionsOrLV", () => {
     );
     expect(result).toEqual(E.right(false));
 
+    expect(mockSelectOne).toHaveBeenNthCalledWith(1, RedisClientMode.SAFE);
     expect(mockGet).toHaveBeenNthCalledWith(
       1,
       `KEYS-${aValidUser.fiscal_code}`
@@ -1492,6 +1500,7 @@ describe("RedisSessionStorage#userHasActiveSessionsOrLV", () => {
       `USERSESSIONS-${aValidUser.fiscal_code}`
     );
     expect(mockGet).toHaveBeenCalledTimes(1);
+    expect(mockSelectOne).toHaveBeenCalledTimes(2);
   });
 
   it("should return a left value if a redis call fail in getLollipopDataForUser", async () => {
@@ -1502,6 +1511,8 @@ describe("RedisSessionStorage#userHasActiveSessionsOrLV", () => {
     const result = await sessionStorage.userHasActiveSessionsOrLV(
       aValidUser.fiscal_code
     );
+    expect(mockSelectOne).toHaveBeenNthCalledWith(1, RedisClientMode.SAFE);
+    expect(mockSelectOne).toHaveBeenCalledTimes(1);
     expect(result).toEqual(E.left(expectedRedisError));
   });
 
@@ -1517,6 +1528,8 @@ describe("RedisSessionStorage#userHasActiveSessionsOrLV", () => {
     const result = await sessionStorage.userHasActiveSessionsOrLV(
       aValidUser.fiscal_code
     );
+    expect(mockSelectOne).toHaveBeenNthCalledWith(1, RedisClientMode.SAFE);
+    expect(mockSelectOne).toHaveBeenCalledTimes(3);
     expect(result).toEqual(E.left(expectedRedisError));
   });
 });

--- a/src/services/redisSessionStorage.ts
+++ b/src/services/redisSessionStorage.ts
@@ -13,7 +13,6 @@ import * as T from "fp-ts/lib/Task";
 import * as TE from "fp-ts/lib/TaskEither";
 import { errorsToReadableMessages } from "@pagopa/ts-commons/lib/reporters";
 import { EmailString, FiscalCode } from "@pagopa/ts-commons/lib/strings";
-import * as redis from "redis";
 import { TaskEither } from "fp-ts/lib/TaskEither";
 import { Either } from "fp-ts/lib/Either";
 import { Option } from "fp-ts/lib/Option";
@@ -41,6 +40,10 @@ import { User, UserV1, UserV2, UserV3, UserV4, UserV5 } from "../types/user";
 import { multipleErrorsFormatter } from "../utils/errorsFormatter";
 import { log } from "../utils/logger";
 import { ActiveSessionInfo, LoginTypeEnum } from "../utils/fastLogin";
+import {
+  RedisClientSelectorEnum,
+  RedisClientSelectorType,
+} from "../utils/redis";
 import { ISessionStorage } from "./ISessionStorage";
 import RedisStorageUtils from "./redisStorageUtils";
 
@@ -75,9 +78,7 @@ export default class RedisSessionStorage
   implements ISessionStorage
 {
   constructor(
-    private readonly redisClient:
-      | redis.RedisClientType
-      | redis.RedisClusterType,
+    private readonly redisClient: RedisClientSelectorType,
     private readonly tokenDurationSecs: number,
     private readonly defaultDurationAssertionRefSec: Second
   ) {
@@ -98,11 +99,13 @@ export default class RedisSessionStorage
         () =>
           // Set key to hold the string value. If key already holds a value, it is overwritten, regardless of its type.
           // @see https://redis.io/commands/set
-          this.redisClient.setEx(
-            `${sessionKeyPrefix}${user.session_token}`,
-            expireSec,
-            JSON.stringify(user)
-          ),
+          this.redisClient
+            .selectOne(RedisClientSelectorEnum.FAST)
+            .setEx(
+              `${sessionKeyPrefix}${user.session_token}`,
+              expireSec,
+              JSON.stringify(user)
+            ),
         E.toError
       ),
       this.singleStringReplyAsync,
@@ -112,11 +115,13 @@ export default class RedisSessionStorage
     const setWalletTokenV2 = pipe(
       TE.tryCatch(
         () =>
-          this.redisClient.setEx(
-            `${walletKeyPrefix}${user.wallet_token}`,
-            expireSec,
-            user.session_token
-          ),
+          this.redisClient
+            .selectOne(RedisClientSelectorEnum.FAST)
+            .setEx(
+              `${walletKeyPrefix}${user.wallet_token}`,
+              expireSec,
+              user.session_token
+            ),
         E.toError
       ),
       this.singleStringReplyAsync,
@@ -126,11 +131,13 @@ export default class RedisSessionStorage
     const setMyPortalTokenV2 = pipe(
       TE.tryCatch(
         () =>
-          this.redisClient.setEx(
-            `${myPortalTokenPrefix}${user.myportal_token}`,
-            expireSec,
-            user.session_token
-          ),
+          this.redisClient
+            .selectOne(RedisClientSelectorEnum.FAST)
+            .setEx(
+              `${myPortalTokenPrefix}${user.myportal_token}`,
+              expireSec,
+              user.session_token
+            ),
         E.toError
       ),
       this.singleStringReplyAsync,
@@ -140,11 +147,13 @@ export default class RedisSessionStorage
     const setBPDTokenV2 = pipe(
       TE.tryCatch(
         () =>
-          this.redisClient.setEx(
-            `${bpdTokenPrefix}${user.bpd_token}`,
-            expireSec,
-            user.session_token
-          ),
+          this.redisClient
+            .selectOne(RedisClientSelectorEnum.FAST)
+            .setEx(
+              `${bpdTokenPrefix}${user.bpd_token}`,
+              expireSec,
+              user.session_token
+            ),
         E.toError
       ),
       this.singleStringReplyAsync,
@@ -154,11 +163,13 @@ export default class RedisSessionStorage
     const setZendeskTokenV2 = pipe(
       TE.tryCatch(
         () =>
-          this.redisClient.setEx(
-            `${zendeskTokenPrefix}${user.zendesk_token}`,
-            expireSec,
-            user.session_token
-          ),
+          this.redisClient
+            .selectOne(RedisClientSelectorEnum.FAST)
+            .setEx(
+              `${zendeskTokenPrefix}${user.zendesk_token}`,
+              expireSec,
+              user.session_token
+            ),
         E.toError
       ),
       this.singleStringReplyAsync,
@@ -168,11 +179,13 @@ export default class RedisSessionStorage
     const setFIMSTokenV2 = pipe(
       TE.tryCatch(
         () =>
-          this.redisClient.setEx(
-            `${fimsTokenPrefix}${user.fims_token}`,
-            expireSec,
-            user.session_token
-          ),
+          this.redisClient
+            .selectOne(RedisClientSelectorEnum.FAST)
+            .setEx(
+              `${fimsTokenPrefix}${user.fims_token}`,
+              expireSec,
+              user.session_token
+            ),
         E.toError
       ),
       this.singleStringReplyAsync,
@@ -367,7 +380,13 @@ export default class RedisSessionStorage
     const deleteTokensPromiseV2 = await pipe(
       tokens,
       ROA.map((singleToken) =>
-        TE.tryCatch(() => this.redisClient.del(singleToken), E.toError)
+        TE.tryCatch(
+          () =>
+            this.redisClient
+              .selectOne(RedisClientSelectorEnum.FAST)
+              .del(singleToken),
+          E.toError
+        )
       ),
       ROA.sequence(TE.ApplicativeSeq),
       TE.map(ROA.reduce(0, (current, next) => current + next)),
@@ -391,10 +410,12 @@ export default class RedisSessionStorage
     pipe(
       TE.tryCatch(
         () =>
-          this.redisClient.sRem(
-            `${userSessionsSetKeyPrefix}${user.fiscal_code}`,
-            `${sessionInfoKeyPrefix}${user.session_token}`
-          ),
+          this.redisClient
+            .selectOne(RedisClientSelectorEnum.FAST)
+            .sRem(
+              `${userSessionsSetKeyPrefix}${user.fiscal_code}`,
+              `${sessionInfoKeyPrefix}${user.session_token}`
+            ),
         E.toError
       ),
       TE.mapLeft((_) => {
@@ -437,7 +458,10 @@ export default class RedisSessionStorage
     const userSessionSetKey = `${userSessionsSetKeyPrefix}${fiscalCode}`;
     const keysV2 = await pipe(
       TE.tryCatch(
-        () => this.redisClient.sMembers(userSessionSetKey),
+        () =>
+          this.redisClient
+            .selectOne(RedisClientSelectorEnum.FAST)
+            .sMembers(userSessionSetKey),
         E.toError
       ),
       TE.mapLeft((err) => {
@@ -451,7 +475,13 @@ export default class RedisSessionStorage
     const activeKeys = await Promise.all(
       keysV2.map((key) =>
         pipe(
-          TE.tryCatch(() => this.redisClient.exists(key), E.toError),
+          TE.tryCatch(
+            () =>
+              this.redisClient
+                .selectOne(RedisClientSelectorEnum.FAST)
+                .exists(key),
+            E.toError
+          ),
           TE.chainW(TE.fromPredicate((response) => !!response, identity)),
           TE.bimap(
             () => key,
@@ -465,7 +495,11 @@ export default class RedisSessionStorage
       pipe(
         activeKeys
           .filter(E.isLeft)
-          .map((key) => this.redisClient.sRem(userSessionSetKey, key.left)),
+          .map((key) =>
+            this.redisClient
+              .selectOne(RedisClientSelectorEnum.FAST)
+              .sRem(userSessionSetKey, key.left)
+          ),
         (keysRemPromises) =>
           keysRemPromises.map((promise) =>
             pipe(
@@ -566,7 +600,9 @@ export default class RedisSessionStorage
     return pipe(
       TE.tryCatch(() => {
         log.info(`Adding ${fiscalCode} to ${blockedUserSetKey} set`);
-        return this.redisClient.sAdd(blockedUserSetKey, fiscalCode);
+        return this.redisClient
+          .selectOne(RedisClientSelectorEnum.FAST)
+          .sAdd(blockedUserSetKey, fiscalCode);
       }, E.toError),
       TE.map<number, true>((_) => true)
     )();
@@ -585,7 +621,9 @@ export default class RedisSessionStorage
     return pipe(
       TE.tryCatch(() => {
         log.info(`Removing ${fiscalCode} from ${blockedUserSetKey} set`);
-        return this.redisClient.sRem(blockedUserSetKey, fiscalCode);
+        return this.redisClient
+          .selectOne(RedisClientSelectorEnum.FAST)
+          .sRem(blockedUserSetKey, fiscalCode);
       }, E.toError),
       this.integerReplyAsync(1),
       this.falsyResponseToErrorAsync(
@@ -739,11 +777,13 @@ export default class RedisSessionStorage
     return pipe(
       TE.tryCatch(
         () =>
-          this.redisClient.setEx(
-            `${noticeEmailPrefix}${user.session_token}`,
-            sessionTtl,
-            NoticeEmail
-          ),
+          this.redisClient
+            .selectOne(RedisClientSelectorEnum.FAST)
+            .setEx(
+              `${noticeEmailPrefix}${user.session_token}`,
+              sessionTtl,
+              NoticeEmail
+            ),
         E.toError
       ),
       this.singleStringReplyAsync,
@@ -757,7 +797,10 @@ export default class RedisSessionStorage
   public async delPagoPaNoticeEmail(user: User): Promise<Either<Error, true>> {
     return pipe(
       TE.tryCatch(
-        () => this.redisClient.del(`${noticeEmailPrefix}${user.session_token}`),
+        () =>
+          this.redisClient
+            .selectOne(RedisClientSelectorEnum.FAST)
+            .del(`${noticeEmailPrefix}${user.session_token}`),
         E.toError
       ),
       TE.map<number, true>((_) => true)
@@ -772,7 +815,10 @@ export default class RedisSessionStorage
   ): Promise<Either<Error, EmailString>> {
     return pipe(
       TE.tryCatch(
-        () => this.redisClient.get(`${noticeEmailPrefix}${user.session_token}`),
+        () =>
+          this.redisClient
+            .selectOne(RedisClientSelectorEnum.FAST)
+            .get(`${noticeEmailPrefix}${user.session_token}`),
         E.toError
       ),
       TE.chain((maybeEmail) =>
@@ -816,7 +862,10 @@ export default class RedisSessionStorage
   ): Promise<Either<Error, O.Option<LollipopData>>> {
     return pipe(
       TE.tryCatch(
-        () => this.redisClient.get(`${lollipopDataPrefix}${fiscalCode}`),
+        () =>
+          this.redisClient
+            .selectOne(RedisClientSelectorEnum.FAST)
+            .get(`${lollipopDataPrefix}${fiscalCode}`),
         E.toError
       ),
       TE.chain(
@@ -857,7 +906,10 @@ export default class RedisSessionStorage
         // The `setLollipopDataForUser` has a default value for key `expire`
         // If the assertionRef is saved whidout providing an expire time related
         // with the session validity it will invalidate this implementation.
-        () => this.redisClient.ttl(`${lollipopDataPrefix}${fiscalCode}`),
+        () =>
+          this.redisClient
+            .selectOne(RedisClientSelectorEnum.FAST)
+            .ttl(`${lollipopDataPrefix}${fiscalCode}`),
         E.toError
       ),
       TE.chain(
@@ -901,11 +953,13 @@ export default class RedisSessionStorage
     return pipe(
       TE.tryCatch(
         () =>
-          this.redisClient.setEx(
-            `${lollipopDataPrefix}${user.fiscal_code}`,
-            expireAssertionRefSec,
-            LollipopDataFromString.encode(data)
-          ),
+          this.redisClient
+            .selectOne(RedisClientSelectorEnum.FAST)
+            .setEx(
+              `${lollipopDataPrefix}${user.fiscal_code}`,
+              expireAssertionRefSec,
+              LollipopDataFromString.encode(data)
+            ),
         E.toError
       ),
       this.singleStringReplyAsync,
@@ -925,11 +979,13 @@ export default class RedisSessionStorage
     return pipe(
       TE.tryCatch(
         () =>
-          this.redisClient.setEx(
-            `${lollipopDataPrefix}${user.fiscal_code}`,
-            expireAssertionRefSec,
-            assertionRef
-          ),
+          this.redisClient
+            .selectOne(RedisClientSelectorEnum.FAST)
+            .setEx(
+              `${lollipopDataPrefix}${user.fiscal_code}`,
+              expireAssertionRefSec,
+              assertionRef
+            ),
         E.toError
       ),
       this.singleStringReplyAsync,
@@ -943,7 +999,10 @@ export default class RedisSessionStorage
   public async delLollipopDataForUser(fiscalCode: FiscalCode) {
     return pipe(
       TE.tryCatch(
-        () => this.redisClient.del(`${lollipopDataPrefix}${fiscalCode}`),
+        () =>
+          this.redisClient
+            .selectOne(RedisClientSelectorEnum.FAST)
+            .del(`${lollipopDataPrefix}${fiscalCode}`),
         E.toError
       ),
       this.integerReplyAsync()
@@ -960,21 +1019,29 @@ export default class RedisSessionStorage
     return pipe(
       keys,
       A.map((singleKey) =>
-        TE.tryCatch(
-          () => this.redisClient.get.bind(this.redisClient)(singleKey),
-          E.toError
-        )
+        TE.tryCatch(() => {
+          const redis_client = this.redisClient.selectOne(
+            RedisClientSelectorEnum.FAST
+          );
+          return redis_client.get.bind(redis_client)(singleKey);
+        }, E.toError)
       ),
       A.sequence(TE.ApplicativePar)
     );
   }
 
   private sIsMember(key: string, member: string) {
-    return this.redisClient.sIsMember.bind(this.redisClient)(key, member);
+    const redis_client = this.redisClient.selectOne(
+      RedisClientSelectorEnum.FAST
+    );
+    return redis_client.sIsMember.bind(redis_client)(key, member);
   }
 
   private ttl(key: string) {
-    return this.redisClient.ttl.bind(this.redisClient)(key);
+    const redis_client = this.redisClient.selectOne(
+      RedisClientSelectorEnum.FAST
+    );
+    return redis_client.ttl.bind(redis_client)(key);
   }
 
   /**
@@ -1024,7 +1091,9 @@ export default class RedisSessionStorage
         log.info(
           `Deleting sessions set ${userSessionsSetKeyPrefix}${fiscalCode}`
         );
-        return this.redisClient.del(`${userSessionsSetKeyPrefix}${fiscalCode}`);
+        return this.redisClient
+          .selectOne(RedisClientSelectorEnum.FAST)
+          .del(`${userSessionsSetKeyPrefix}${fiscalCode}`);
       }, E.toError),
       TE.map<number, true>((_) => true)
     )();
@@ -1044,11 +1113,9 @@ export default class RedisSessionStorage
     return pipe(
       TE.tryCatch(
         () =>
-          this.redisClient.setEx(
-            sessionInfoKey,
-            expireSec,
-            JSON.stringify(sessionInfo)
-          ),
+          this.redisClient
+            .selectOne(RedisClientSelectorEnum.FAST)
+            .setEx(sessionInfoKey, expireSec, JSON.stringify(sessionInfo)),
         E.toError
       ),
       this.singleStringReplyAsync,
@@ -1059,10 +1126,12 @@ export default class RedisSessionStorage
         pipe(
           TE.tryCatch(
             () =>
-              this.redisClient.sAdd(
-                `${userSessionsSetKeyPrefix}${fiscalCode}`,
-                sessionInfoKey
-              ),
+              this.redisClient
+                .selectOne(RedisClientSelectorEnum.FAST)
+                .sAdd(
+                  `${userSessionsSetKeyPrefix}${fiscalCode}`,
+                  sessionInfoKey
+                ),
             E.toError
           ),
           this.integerReplyAsync(),
@@ -1082,7 +1151,10 @@ export default class RedisSessionStorage
   ): Promise<Either<Error, User>> {
     return pipe(
       TE.tryCatch(
-        () => this.redisClient.get(`${sessionKeyPrefix}${token}`),
+        () =>
+          this.redisClient
+            .selectOne(RedisClientSelectorEnum.FAST)
+            .get(`${sessionKeyPrefix}${token}`),
         E.toError
       ),
       TE.chain(
@@ -1104,7 +1176,13 @@ export default class RedisSessionStorage
     token: WalletToken | MyPortalToken | BPDToken | ZendeskToken | FIMSToken
   ): Promise<Either<Error, User>> {
     return pipe(
-      TE.tryCatch(() => this.redisClient.get(`${prefix}${token}`), E.toError),
+      TE.tryCatch(
+        () =>
+          this.redisClient
+            .selectOne(RedisClientSelectorEnum.FAST)
+            .get(`${prefix}${token}`),
+        E.toError
+      ),
       TE.chain(
         flow(
           O.fromNullable,
@@ -1149,7 +1227,11 @@ export default class RedisSessionStorage
       const errorOrSerializedUserV2 = await pipe(
         oldSessionInfoKeys,
         ROA.map((key) =>
-          TE.tryCatch(() => this.redisClient.get(key), E.toError)
+          TE.tryCatch(
+            () =>
+              this.redisClient.selectOne(RedisClientSelectorEnum.FAST).get(key),
+            E.toError
+          )
         ),
         ROA.sequence(TE.ApplicativeSeq),
         // It's intended that some value can be null here
@@ -1215,7 +1297,13 @@ export default class RedisSessionStorage
             pipe(
               keys,
               ROA.map((singleKey) =>
-                TE.tryCatch(() => this.redisClient.del(singleKey), E.toError)
+                TE.tryCatch(
+                  () =>
+                    this.redisClient
+                      .selectOne(RedisClientSelectorEnum.FAST)
+                      .del(singleKey),
+                  E.toError
+                )
               ),
               ROA.sequence(TE.ApplicativeSeq),
               this.integerReplyAsync()
@@ -1237,7 +1325,9 @@ export default class RedisSessionStorage
     return pipe(
       TE.tryCatch(
         () =>
-          this.redisClient.sMembers(`${userSessionsSetKeyPrefix}${fiscalCode}`),
+          this.redisClient
+            .selectOne(RedisClientSelectorEnum.FAST)
+            .sMembers(`${userSessionsSetKeyPrefix}${fiscalCode}`),
         E.toError
       ),
       this.arrayStringReplyAsync

--- a/src/services/redisSessionStorage.ts
+++ b/src/services/redisSessionStorage.ts
@@ -40,10 +40,7 @@ import { User, UserV1, UserV2, UserV3, UserV4, UserV5 } from "../types/user";
 import { multipleErrorsFormatter } from "../utils/errorsFormatter";
 import { log } from "../utils/logger";
 import { ActiveSessionInfo, LoginTypeEnum } from "../utils/fastLogin";
-import {
-  RedisClientSelectorEnum,
-  RedisClientSelectorType,
-} from "../utils/redis";
+import { RedisClientMode, RedisClientSelectorType } from "../utils/redis";
 import { ISessionStorage } from "./ISessionStorage";
 import RedisStorageUtils from "./redisStorageUtils";
 
@@ -100,7 +97,7 @@ export default class RedisSessionStorage
           // Set key to hold the string value. If key already holds a value, it is overwritten, regardless of its type.
           // @see https://redis.io/commands/set
           this.redisClient
-            .selectOne(RedisClientSelectorEnum.FAST)
+            .selectOne(RedisClientMode.FAST)
             .setEx(
               `${sessionKeyPrefix}${user.session_token}`,
               expireSec,
@@ -116,7 +113,7 @@ export default class RedisSessionStorage
       TE.tryCatch(
         () =>
           this.redisClient
-            .selectOne(RedisClientSelectorEnum.FAST)
+            .selectOne(RedisClientMode.FAST)
             .setEx(
               `${walletKeyPrefix}${user.wallet_token}`,
               expireSec,
@@ -132,7 +129,7 @@ export default class RedisSessionStorage
       TE.tryCatch(
         () =>
           this.redisClient
-            .selectOne(RedisClientSelectorEnum.FAST)
+            .selectOne(RedisClientMode.FAST)
             .setEx(
               `${myPortalTokenPrefix}${user.myportal_token}`,
               expireSec,
@@ -148,7 +145,7 @@ export default class RedisSessionStorage
       TE.tryCatch(
         () =>
           this.redisClient
-            .selectOne(RedisClientSelectorEnum.FAST)
+            .selectOne(RedisClientMode.FAST)
             .setEx(
               `${bpdTokenPrefix}${user.bpd_token}`,
               expireSec,
@@ -164,7 +161,7 @@ export default class RedisSessionStorage
       TE.tryCatch(
         () =>
           this.redisClient
-            .selectOne(RedisClientSelectorEnum.FAST)
+            .selectOne(RedisClientMode.FAST)
             .setEx(
               `${zendeskTokenPrefix}${user.zendesk_token}`,
               expireSec,
@@ -180,7 +177,7 @@ export default class RedisSessionStorage
       TE.tryCatch(
         () =>
           this.redisClient
-            .selectOne(RedisClientSelectorEnum.FAST)
+            .selectOne(RedisClientMode.FAST)
             .setEx(
               `${fimsTokenPrefix}${user.fims_token}`,
               expireSec,
@@ -382,9 +379,7 @@ export default class RedisSessionStorage
       ROA.map((singleToken) =>
         TE.tryCatch(
           () =>
-            this.redisClient
-              .selectOne(RedisClientSelectorEnum.FAST)
-              .del(singleToken),
+            this.redisClient.selectOne(RedisClientMode.FAST).del(singleToken),
           E.toError
         )
       ),
@@ -411,7 +406,7 @@ export default class RedisSessionStorage
       TE.tryCatch(
         () =>
           this.redisClient
-            .selectOne(RedisClientSelectorEnum.FAST)
+            .selectOne(RedisClientMode.FAST)
             .sRem(
               `${userSessionsSetKeyPrefix}${user.fiscal_code}`,
               `${sessionInfoKeyPrefix}${user.session_token}`
@@ -460,7 +455,7 @@ export default class RedisSessionStorage
       TE.tryCatch(
         () =>
           this.redisClient
-            .selectOne(RedisClientSelectorEnum.FAST)
+            .selectOne(RedisClientMode.FAST)
             .sMembers(userSessionSetKey),
         E.toError
       ),
@@ -476,10 +471,7 @@ export default class RedisSessionStorage
       keysV2.map((key) =>
         pipe(
           TE.tryCatch(
-            () =>
-              this.redisClient
-                .selectOne(RedisClientSelectorEnum.FAST)
-                .exists(key),
+            () => this.redisClient.selectOne(RedisClientMode.FAST).exists(key),
             E.toError
           ),
           TE.chainW(TE.fromPredicate((response) => !!response, identity)),
@@ -497,7 +489,7 @@ export default class RedisSessionStorage
           .filter(E.isLeft)
           .map((key) =>
             this.redisClient
-              .selectOne(RedisClientSelectorEnum.FAST)
+              .selectOne(RedisClientMode.FAST)
               .sRem(userSessionSetKey, key.left)
           ),
         (keysRemPromises) =>
@@ -601,7 +593,7 @@ export default class RedisSessionStorage
       TE.tryCatch(() => {
         log.info(`Adding ${fiscalCode} to ${blockedUserSetKey} set`);
         return this.redisClient
-          .selectOne(RedisClientSelectorEnum.FAST)
+          .selectOne(RedisClientMode.FAST)
           .sAdd(blockedUserSetKey, fiscalCode);
       }, E.toError),
       TE.map<number, true>((_) => true)
@@ -622,7 +614,7 @@ export default class RedisSessionStorage
       TE.tryCatch(() => {
         log.info(`Removing ${fiscalCode} from ${blockedUserSetKey} set`);
         return this.redisClient
-          .selectOne(RedisClientSelectorEnum.FAST)
+          .selectOne(RedisClientMode.FAST)
           .sRem(blockedUserSetKey, fiscalCode);
       }, E.toError),
       this.integerReplyAsync(1),
@@ -778,7 +770,7 @@ export default class RedisSessionStorage
       TE.tryCatch(
         () =>
           this.redisClient
-            .selectOne(RedisClientSelectorEnum.FAST)
+            .selectOne(RedisClientMode.FAST)
             .setEx(
               `${noticeEmailPrefix}${user.session_token}`,
               sessionTtl,
@@ -799,7 +791,7 @@ export default class RedisSessionStorage
       TE.tryCatch(
         () =>
           this.redisClient
-            .selectOne(RedisClientSelectorEnum.FAST)
+            .selectOne(RedisClientMode.FAST)
             .del(`${noticeEmailPrefix}${user.session_token}`),
         E.toError
       ),
@@ -817,7 +809,7 @@ export default class RedisSessionStorage
       TE.tryCatch(
         () =>
           this.redisClient
-            .selectOne(RedisClientSelectorEnum.FAST)
+            .selectOne(RedisClientMode.FAST)
             .get(`${noticeEmailPrefix}${user.session_token}`),
         E.toError
       ),
@@ -864,7 +856,7 @@ export default class RedisSessionStorage
       TE.tryCatch(
         () =>
           this.redisClient
-            .selectOne(RedisClientSelectorEnum.SAFE)
+            .selectOne(RedisClientMode.SAFE)
             .get(`${lollipopDataPrefix}${fiscalCode}`),
         E.toError
       ),
@@ -908,7 +900,7 @@ export default class RedisSessionStorage
         // with the session validity it will invalidate this implementation.
         () =>
           this.redisClient
-            .selectOne(RedisClientSelectorEnum.SAFE)
+            .selectOne(RedisClientMode.SAFE)
             .ttl(`${lollipopDataPrefix}${fiscalCode}`),
         E.toError
       ),
@@ -954,7 +946,7 @@ export default class RedisSessionStorage
       TE.tryCatch(
         () =>
           this.redisClient
-            .selectOne(RedisClientSelectorEnum.FAST)
+            .selectOne(RedisClientMode.FAST)
             .setEx(
               `${lollipopDataPrefix}${user.fiscal_code}`,
               expireAssertionRefSec,
@@ -980,7 +972,7 @@ export default class RedisSessionStorage
       TE.tryCatch(
         () =>
           this.redisClient
-            .selectOne(RedisClientSelectorEnum.FAST)
+            .selectOne(RedisClientMode.FAST)
             .setEx(
               `${lollipopDataPrefix}${user.fiscal_code}`,
               expireAssertionRefSec,
@@ -1001,7 +993,7 @@ export default class RedisSessionStorage
       TE.tryCatch(
         () =>
           this.redisClient
-            .selectOne(RedisClientSelectorEnum.FAST)
+            .selectOne(RedisClientMode.FAST)
             .del(`${lollipopDataPrefix}${fiscalCode}`),
         E.toError
       ),
@@ -1020,9 +1012,7 @@ export default class RedisSessionStorage
       keys,
       A.map((singleKey) =>
         TE.tryCatch(() => {
-          const redis_client = this.redisClient.selectOne(
-            RedisClientSelectorEnum.FAST
-          );
+          const redis_client = this.redisClient.selectOne(RedisClientMode.FAST);
           return redis_client.get.bind(redis_client)(singleKey);
         }, E.toError)
       ),
@@ -1031,16 +1021,12 @@ export default class RedisSessionStorage
   }
 
   private sIsMember(key: string, member: string) {
-    const redis_client = this.redisClient.selectOne(
-      RedisClientSelectorEnum.FAST
-    );
+    const redis_client = this.redisClient.selectOne(RedisClientMode.FAST);
     return redis_client.sIsMember.bind(redis_client)(key, member);
   }
 
   private ttl(key: string) {
-    const redis_client = this.redisClient.selectOne(
-      RedisClientSelectorEnum.FAST
-    );
+    const redis_client = this.redisClient.selectOne(RedisClientMode.FAST);
     return redis_client.ttl.bind(redis_client)(key);
   }
 
@@ -1092,7 +1078,7 @@ export default class RedisSessionStorage
           `Deleting sessions set ${userSessionsSetKeyPrefix}${fiscalCode}`
         );
         return this.redisClient
-          .selectOne(RedisClientSelectorEnum.FAST)
+          .selectOne(RedisClientMode.FAST)
           .del(`${userSessionsSetKeyPrefix}${fiscalCode}`);
       }, E.toError),
       TE.map<number, true>((_) => true)
@@ -1114,7 +1100,7 @@ export default class RedisSessionStorage
       TE.tryCatch(
         () =>
           this.redisClient
-            .selectOne(RedisClientSelectorEnum.FAST)
+            .selectOne(RedisClientMode.FAST)
             .setEx(sessionInfoKey, expireSec, JSON.stringify(sessionInfo)),
         E.toError
       ),
@@ -1127,7 +1113,7 @@ export default class RedisSessionStorage
           TE.tryCatch(
             () =>
               this.redisClient
-                .selectOne(RedisClientSelectorEnum.FAST)
+                .selectOne(RedisClientMode.FAST)
                 .sAdd(
                   `${userSessionsSetKeyPrefix}${fiscalCode}`,
                   sessionInfoKey
@@ -1153,7 +1139,7 @@ export default class RedisSessionStorage
       TE.tryCatch(
         () =>
           this.redisClient
-            .selectOne(RedisClientSelectorEnum.FAST)
+            .selectOne(RedisClientMode.FAST)
             .get(`${sessionKeyPrefix}${token}`),
         E.toError
       ),
@@ -1179,7 +1165,7 @@ export default class RedisSessionStorage
       TE.tryCatch(
         () =>
           this.redisClient
-            .selectOne(RedisClientSelectorEnum.FAST)
+            .selectOne(RedisClientMode.FAST)
             .get(`${prefix}${token}`),
         E.toError
       ),
@@ -1228,8 +1214,7 @@ export default class RedisSessionStorage
         oldSessionInfoKeys,
         ROA.map((key) =>
           TE.tryCatch(
-            () =>
-              this.redisClient.selectOne(RedisClientSelectorEnum.FAST).get(key),
+            () => this.redisClient.selectOne(RedisClientMode.FAST).get(key),
             E.toError
           )
         ),
@@ -1300,7 +1285,7 @@ export default class RedisSessionStorage
                 TE.tryCatch(
                   () =>
                     this.redisClient
-                      .selectOne(RedisClientSelectorEnum.FAST)
+                      .selectOne(RedisClientMode.FAST)
                       .del(singleKey),
                   E.toError
                 )
@@ -1326,7 +1311,7 @@ export default class RedisSessionStorage
       TE.tryCatch(
         () =>
           this.redisClient
-            .selectOne(RedisClientSelectorEnum.FAST)
+            .selectOne(RedisClientMode.FAST)
             .sMembers(`${userSessionsSetKeyPrefix}${fiscalCode}`),
         E.toError
       ),

--- a/src/services/redisSessionStorage.ts
+++ b/src/services/redisSessionStorage.ts
@@ -864,7 +864,7 @@ export default class RedisSessionStorage
       TE.tryCatch(
         () =>
           this.redisClient
-            .selectOne(RedisClientSelectorEnum.FAST)
+            .selectOne(RedisClientSelectorEnum.SAFE)
             .get(`${lollipopDataPrefix}${fiscalCode}`),
         E.toError
       ),
@@ -908,7 +908,7 @@ export default class RedisSessionStorage
         // with the session validity it will invalidate this implementation.
         () =>
           this.redisClient
-            .selectOne(RedisClientSelectorEnum.FAST)
+            .selectOne(RedisClientSelectorEnum.SAFE)
             .ttl(`${lollipopDataPrefix}${fiscalCode}`),
         E.toError
       ),

--- a/src/strategies/__tests__/bearerZendeskTokenStrategy.test.ts
+++ b/src/strategies/__tests__/bearerZendeskTokenStrategy.test.ts
@@ -8,17 +8,16 @@ import mockReq from "../../__mocks__/request";
 import mockRes from "../../__mocks__/response";
 import { ZendeskToken } from "../../types/token";
 import { Second } from "@pagopa/ts-commons/lib/units";
-import { RedisClientType } from "redis";
+import { mockRedisClientSelector } from "../../__mocks__/redis";
 
 const aTokenDurationSecs = 3600;
 const aDefaultLollipopAssertionRefDurationSec = (3600 * 24 * 365 * 2) as Second;
-const mockRedisClient = {} as RedisClientType;
 
 const aValidOldTransitorySessionZendeskToken = mockZendeskToken;
 const aValidZendeskToken = mockZendeskToken + "1234abcd";
 
 const mockedRedisMemory = {
-  [mockZendeskToken]: mockedUser
+  [mockZendeskToken]: mockedUser,
 };
 
 const errorMessage = "User not found";
@@ -32,13 +31,13 @@ jest.mock("../../services/redisSessionStorage", () => {
           mockedRedisMemory[token]
             ? E.right(O.some(mockedRedisMemory[token]))
             : E.left(errorMessage)
-        )
-    }))
+        ),
+    })),
   };
 });
 
 const sessionService = new RedisSessionStorage(
-  mockRedisClient,
+  mockRedisClientSelector,
   aTokenDurationSecs,
   aDefaultLollipopAssertionRefDurationSec
 );
@@ -46,15 +45,15 @@ const sessionService = new RedisSessionStorage(
 const res = mockRes();
 const req = mockReq();
 
-describe("bearerZendeskTokenStrategy", function() {
-  it("should correctly find the user to login with a valid zendeskToken of 48 bytes", done => {
+describe("bearerZendeskTokenStrategy", function () {
+  it("should correctly find the user to login with a valid zendeskToken of 48 bytes", (done) => {
     req.body = { user_token: aValidOldTransitorySessionZendeskToken };
 
     passport.use("bearer.zendesk", bearerZendeskTokenStrategy(sessionService));
     passport.authenticate(
       "bearer.zendesk",
       {
-        session: false
+        session: false,
       },
       // this is the "done" function of the strategy
       (error: any, user: any, options: any) => {
@@ -66,14 +65,14 @@ describe("bearerZendeskTokenStrategy", function() {
     )(req, res);
   });
 
-  it("should correctly find the user to login with a new valid zendeskToken greater than 48 bytes", done => {
+  it("should correctly find the user to login with a new valid zendeskToken greater than 48 bytes", (done) => {
     req.body = { user_token: aValidZendeskToken };
 
     passport.use("bearer.zendesk", bearerZendeskTokenStrategy(sessionService));
     passport.authenticate(
       "bearer.zendesk",
       {
-        session: false
+        session: false,
       },
       // this is the "done" function of the strategy
       (error: any, user: any, options: any) => {
@@ -85,14 +84,14 @@ describe("bearerZendeskTokenStrategy", function() {
     )(req, res);
   });
 
-  it("should fail to find the user to login with an invalid zendeskToken", done => {
+  it("should fail to find the user to login with an invalid zendeskToken", (done) => {
     req.body = { user_token: "notexists" };
 
     passport.use("bearer.zendesk", bearerZendeskTokenStrategy(sessionService));
     passport.authenticate(
       "bearer.zendesk",
       {
-        session: false
+        session: false,
       },
       // this is the "done" function of the strategy
       (error: any, user: any, options: any) => {

--- a/src/utils/redis.ts
+++ b/src/utils/redis.ts
@@ -106,11 +106,11 @@ export type Selector<T, S> = {
 };
 
 export type RedisClientSelectorType = Selector<
-  RedisClientSelectorEnum,
+  RedisClientMode,
   redis.RedisClusterType
 >;
 
-export enum RedisClientSelectorEnum {
+export enum RedisClientMode {
   "ALL" = "ALL",
   "SAFE" = "SAFE",
   "FAST" = "FAST",
@@ -132,15 +132,15 @@ export const RedisClientSelector =
       appInsightsClient,
       false
     )(redisUrl, password, port);
-    const select = (t: RedisClientSelectorEnum) => {
+    const select = (t: RedisClientMode) => {
       switch (t) {
-        case RedisClientSelectorEnum.ALL: {
+        case RedisClientMode.ALL: {
           return [SAFE_REDIS_CLIENT, FAST_REDIS_CLIENT];
         }
-        case RedisClientSelectorEnum.SAFE: {
+        case RedisClientMode.SAFE: {
           return [SAFE_REDIS_CLIENT];
         }
-        case RedisClientSelectorEnum.FAST: {
+        case RedisClientMode.FAST: {
           return [FAST_REDIS_CLIENT];
         }
         default: {

--- a/src/utils/redis.ts
+++ b/src/utils/redis.ts
@@ -18,7 +18,11 @@ export const obfuscateTokensInfo = (message: string) =>
   );
 
 export const createClusterRedisClient =
-  (enableTls: boolean, appInsightsClient?: appInsights.TelemetryClient) =>
+  (
+    enableTls: boolean,
+    appInsightsClient?: appInsights.TelemetryClient,
+    useReplicas: boolean = true
+  ) =>
   async (
     redisUrl: string,
     password?: string,
@@ -51,7 +55,7 @@ export const createClusterRedisClient =
           url: `${completeRedisUrl}:${redisPort}`,
         },
       ],
-      useReplicas: true,
+      useReplicas,
     });
     redisClient.on("error", (err) => {
       log.error("[REDIS Error] an error occurs on redis client: %s", err);
@@ -93,4 +97,59 @@ export const createClusterRedisClient =
     );
     await redisClient.connect();
     return redisClient;
+  };
+
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
+export type Selector<T, S> = {
+  readonly select: (type: T) => ReadonlyArray<S>;
+  readonly selectOne: (type: T) => S;
+};
+
+export type RedisClientSelectorType = Selector<
+  RedisClientSelectorEnum,
+  redis.RedisClusterType
+>;
+
+export enum RedisClientSelectorEnum {
+  "ALL" = "ALL",
+  "SAFE" = "SAFE",
+  "FAST" = "FAST",
+}
+
+export const RedisClientSelector =
+  (enableTls: boolean, appInsightsClient?: appInsights.TelemetryClient) =>
+  async (
+    redisUrl: string,
+    password?: string,
+    port?: string
+  ): Promise<RedisClientSelectorType> => {
+    const FAST_REDIS_CLIENT = await createClusterRedisClient(
+      enableTls,
+      appInsightsClient
+    )(redisUrl, password, port);
+    const SAFE_REDIS_CLIENT = await createClusterRedisClient(
+      enableTls,
+      appInsightsClient,
+      false
+    )(redisUrl, password, port);
+    const select = (t: RedisClientSelectorEnum) => {
+      switch (t) {
+        case RedisClientSelectorEnum.ALL: {
+          return [SAFE_REDIS_CLIENT, FAST_REDIS_CLIENT];
+        }
+        case RedisClientSelectorEnum.SAFE: {
+          return [SAFE_REDIS_CLIENT];
+        }
+        case RedisClientSelectorEnum.FAST: {
+          return [FAST_REDIS_CLIENT];
+        }
+        default: {
+          throw new Error("Unexpected selector for redis client");
+        }
+      }
+    };
+    return {
+      select,
+      selectOne: (t) => select(t)[0],
+    };
   };


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->
New `RedisClientSelector` to select `SAFE` and `FAST` redis client.
Graceful shutdown for all the Redis clients.
Refactor `RedisSessionStorage` with the new selector, use SAFE mode for critical operations.
Refactor unit test (shared redis client mock).



#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The key that stores the `CF-AssertionRef` relationship on redis is used to validate the correct initialization of the lollipop protocol. When the validity of the stored value expires, the private key cannot be used to perform a lollipop operation. The read operation on Redis can return an expired key if the operation occurs on a slave instance. The `RedisClientSelector` creates 2 different Redis clients, the SAFE selector will return a client with `useReplicas=false` forcing the operation to be performed on the master node.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
not yet

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
