### PR TITLE
[#IOPID-1105] Add Lollipop capabilities on test login

### DIFF
--- a/src/strategies/localStrategy.ts
+++ b/src/strategies/localStrategy.ts
@@ -78,29 +78,38 @@ export const localStrategy = (
           TE.orElse((_) => TE.of("_aTestValueRequestId" as NonEmptyString))
         )
       ),
-      TE.map(
-        (inResponseTo) =>
-          ({
-            authnContextClassRef:
-              SpidLevelEnum["https://www.spid.gov.it/SpidL2"],
-            dateOfBirth: "2000-06-02",
-            familyName: "Rossi",
-            fiscalNumber: username as FiscalCode, // Verified in line 31
-            getAcsOriginalRequest: () => req,
-            getAssertionXml: () =>
-              getASAMLAssertion_saml2Namespace(
-                username as FiscalCode,
-                inResponseTo
-              ),
-            getSamlResponseXml: () =>
-              getASAMLResponse_saml2Namespace(
-                username as FiscalCode,
-                inResponseTo
-              ),
-            issuer: Object.keys(SPID_IDP_IDENTIFIERS)[0] as Issuer,
-            name: "Mario",
-          } as SpidUser)
-      ),
+      TE.map((inResponseTo) => {
+        const spidUserData = {
+          authnContextClassRef: SpidLevelEnum["https://www.spid.gov.it/SpidL2"],
+          dateOfBirth: "2000-06-02",
+          familyName: "Rossi",
+          fiscalNumber: username as FiscalCode, // Verified in line 31
+          issuer: Object.keys(SPID_IDP_IDENTIFIERS)[0] as Issuer,
+          name: "Mario",
+        };
+        return {
+          ...spidUserData,
+          getAcsOriginalRequest: () => req,
+          getAssertionXml: () =>
+            getASAMLAssertion_saml2Namespace(
+              username as FiscalCode,
+              inResponseTo,
+              spidUserData.authnContextClassRef,
+              spidUserData.name,
+              spidUserData.familyName,
+              spidUserData.dateOfBirth
+            ),
+          getSamlResponseXml: () =>
+            getASAMLResponse_saml2Namespace(
+              username as FiscalCode,
+              inResponseTo,
+              spidUserData.authnContextClassRef,
+              spidUserData.name,
+              spidUserData.familyName,
+              spidUserData.dateOfBirth
+            ),
+        } as SpidUser;
+      }),
       TE.bimap(
         () => done(null, false),
         (user) => done(null, user)

--- a/src/strategies/localStrategy.ts
+++ b/src/strategies/localStrategy.ts
@@ -9,6 +9,7 @@ import {
 import { flow, pipe } from "fp-ts/lib/function";
 import * as TE from "fp-ts/TaskEither";
 import * as E from "fp-ts/Either";
+import * as jose from "jose";
 import { SpidLevelEnum } from "../../generated/backend/SpidLevel";
 import {
   LollipopLoginParams,
@@ -62,7 +63,10 @@ export const localStrategy = (
       ),
       TE.map((_) => {
         const inResponseTo: NonEmptyString = _
-          ? (_.algo as NonEmptyString) // TODO: Build algo-thumbprint
+          ? (`${_.algo}-${jose.calculateJwkThumbprint(
+              _.jwk,
+              _.algo
+            )}` as NonEmptyString)
           : ("_aTestValueRequestId" as NonEmptyString);
         return {
           authnContextClassRef: SpidLevelEnum["https://www.spid.gov.it/SpidL2"],

--- a/src/utils/__mocks__/spid.ts
+++ b/src/utils/__mocks__/spid.ts
@@ -146,7 +146,10 @@ export const getASAMLResponse = (
 export const getASAMLAssertion_saml2Namespace = (
   fiscalCode: FiscalCode,
   inResponseTo: NonEmptyString,
-  spidLevel: SpidLevel = SpidLevelEnum["https://www.spid.gov.it/SpidL2"]
+  spidLevel: SpidLevel = SpidLevelEnum["https://www.spid.gov.it/SpidL2"],
+  name?: string,
+  familyName?: string,
+  dateOfBirth?: string
 ) => `<saml2:Assertion
     ID="_43568006-96d4-4dcc-84da-d98e01ea3a28"
     IssueInstant="2020-02-26T07:32:05Z"
@@ -234,7 +237,7 @@ export const getASAMLAssertion_saml2Namespace = (
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:type="xs:string"
         >
-          SpidValidator
+          ${name || "SpidValidator"}
         </saml2:AttributeValue>
       </saml2:Attribute>
       <saml2:Attribute
@@ -246,7 +249,7 @@ export const getASAMLAssertion_saml2Namespace = (
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:type="xs:string"
         >
-          AgID
+          ${familyName || "AgID"}
         </saml2:AttributeValue>
       </saml2:Attribute>
       <saml2:Attribute
@@ -262,42 +265,6 @@ export const getASAMLAssertion_saml2Namespace = (
         </saml2:AttributeValue>
       </saml2:Attribute>
       <saml2:Attribute
-        Name="mobilePhone"
-        NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:basic"
-      >
-        <saml2:AttributeValue
-          xmlns:xs="http://www.w3.org/2001/XMLSchema"
-          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:type="xs:string"
-        >
-          +393331234567
-        </saml2:AttributeValue>
-      </saml2:Attribute>
-      <saml2:Attribute
-        Name="email"
-        NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:basic"
-      >
-        <saml2:AttributeValue
-          xmlns:xs="http://www.w3.org/2001/XMLSchema"
-          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:type="xs:string"
-        >
-          spid.tech@agid.gov.it
-        </saml2:AttributeValue>
-      </saml2:Attribute>
-      <saml2:Attribute
-        Name="address"
-        NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:basic"
-      >
-        <saml2:AttributeValue
-          xmlns:xs="http://www.w3.org/2001/XMLSchema"
-          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:type="xs:string"
-        >
-          Via Listz 21 00144 Roma
-        </saml2:AttributeValue>
-      </saml2:Attribute>
-      <saml2:Attribute
         Name="dateOfBirth"
         NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:basic"
       >
@@ -306,7 +273,7 @@ export const getASAMLAssertion_saml2Namespace = (
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:type="xs:date"
         >
-          1970-01-01
+          ${dateOfBirth || "1970-01-01"}
         </saml2:AttributeValue>
       </saml2:Attribute>
     </saml2:AttributeStatement>
@@ -315,7 +282,10 @@ export const getASAMLAssertion_saml2Namespace = (
 export const getASAMLResponse_saml2Namespace = (
   fiscalCode: FiscalCode,
   inResponseTo: NonEmptyString,
-  spidLevel: SpidLevel = SpidLevelEnum["https://www.spid.gov.it/SpidL2"]
+  spidLevel: SpidLevel = SpidLevelEnum["https://www.spid.gov.it/SpidL2"],
+  name?: string,
+  familyName?: string,
+  dateOfBirth?: string
 ) => `<saml2p:Response
   Destination="https://app-backend.dev.io.italia.it/assertionConsumerService"
   ID="_7080f453-78cb-4f57-9692-62dc8a5c23e8"
@@ -363,7 +333,14 @@ export const getASAMLResponse_saml2Namespace = (
   <saml2p:Status>
     <saml2p:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success" />
   </saml2p:Status>
-  ${getASAMLAssertion_saml2Namespace(fiscalCode, inResponseTo, spidLevel)}
+  ${getASAMLAssertion_saml2Namespace(
+    fiscalCode,
+    inResponseTo,
+    spidLevel,
+    name,
+    familyName,
+    dateOfBirth
+  )}
 </saml2p:Response>
 `;
 

--- a/src/utils/__mocks__/spid.ts
+++ b/src/utils/__mocks__/spid.ts
@@ -1,5 +1,4 @@
-import { FiscalCode } from "@pagopa/io-functions-app-sdk/FiscalCode";
-import { NonEmptyString } from "io-ts-types";
+import { FiscalCode, NonEmptyString } from "@pagopa/ts-commons/lib/strings";
 import { SpidLevel, SpidLevelEnum } from "../../../generated/backend/SpidLevel";
 
 export const aSAMLRequest = `<?xml version="1.0"?>
@@ -144,58 +143,11 @@ export const getASAMLResponse = (
 </saml:Assertion>
 </samlp:Response>`;
 
-export const getASAMLResponse_saml2Namespace = (
+export const getASAMLAssertion_saml2Namespace = (
   fiscalCode: FiscalCode,
   inResponseTo: NonEmptyString,
   spidLevel: SpidLevel = SpidLevelEnum["https://www.spid.gov.it/SpidL2"]
-) => `<saml2p:Response
-  Destination="https://app-backend.dev.io.italia.it/assertionConsumerService"
-  ID="_7080f453-78cb-4f57-9692-62dc8a5c23e8"
-   InResponseTo="${inResponseTo}"
-  IssueInstant="2020-02-26T07:32:05Z"
-  Version="2.0"
-  xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion"
-  xmlns:saml2p="urn:oasis:names:tc:SAML:2.0:protocol"
->
-  <saml2:Issuer Format="urn:oasis:names:tc:SAML:2.0:nameid-format:entity">
-    http://localhost:8080
-  </saml2:Issuer>
-  <ds:Signature xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
-    <ds:SignedInfo>
-      <ds:CanonicalizationMethod
-        Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"
-      />
-      <ds:SignatureMethod
-        Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"
-      />
-      <ds:Reference URI="#_7080f453-78cb-4f57-9692-62dc8a5c23e8">
-        <ds:Transforms>
-          <ds:Transform
-            Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"
-          />
-          <ds:Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#" />
-        </ds:Transforms>
-        <ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256" />
-        <ds:DigestValue>
-          TF1ulWGxyd1WLVdSAqBIamJFuM2asyon8TiXFA5MKRk=
-        </ds:DigestValue>
-      </ds:Reference>
-    </ds:SignedInfo>
-    <ds:SignatureValue>
-      riM6BMi4m5VSG26SrSJ7oB5Sk2TYWAUWcQOeE0oeKEDvBbDSXYfMCed5RD8ZCaD340OdmYBNylW8WsegTR0Ejxlusjg/KbLfDFlTpFA6kQEI02A7LFjlWL1XR+t/jE2101zEcZQHp01R8oALxrMzicW591h12l8Y0HtoMCYTOoAThsyk7D+ce/+Jh4Ogn5xUtAm7NpXGuMRChIhVuhfvQ3l7rDxFU+N+CHc7mfLxRZFooQn1zmHS3Ccd/O8N1Tnx+ivCIzozDa9n35S5bzSqiVHBgoa3kEUsQB+ZEn38Y8gOWJgRpPi6txorjWj2+NAmzGH2DJ0tNQAuGc2B4Eu5uQ==
-    </ds:SignatureValue>
-    <ds:KeyInfo>
-      <ds:X509Data>
-        <ds:X509Certificate>
-          MIIEGDCCAwCgAwIBAgIJAOrYj9oLEJCwMA0GCSqGSIb3DQEBCwUAMGUxCzAJBgNVBAYTAklUMQ4wDAYDVQQIEwVJdGFseTENMAsGA1UEBxMEUm9tZTENMAsGA1UEChMEQWdJRDESMBAGA1UECxMJQWdJRCBURVNUMRQwEgYDVQQDEwthZ2lkLmdvdi5pdDAeFw0xOTA0MTExMDAyMDhaFw0yNTAzMDgxMDAyMDhaMGUxCzAJBgNVBAYTAklUMQ4wDAYDVQQIEwVJdGFseTENMAsGA1UEBxMEUm9tZTENMAsGA1UEChMEQWdJRDESMBAGA1UECxMJQWdJRCBURVNUMRQwEgYDVQQDEwthZ2lkLmdvdi5pdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAK8kJVo+ugRrbbv9xhXCuVrqi4B7/MQzQc62ocwlFFujJNd4m1mXkUHFbgvwhRkQqo2DAmFeHiwCkJT3K1eeXIFhNFFroEzGPzONyekLpjNvmYIs1CFvirGOj0bkEiGaKEs+/umzGjxIhy5JQlqXE96y1+Izp2QhJimDK0/KNij8I1bzxseP0Ygc4SFveKS+7QO+PrLzWklEWGMs4DM5Zc3VRK7g4LWPWZhKdImC1rnS+/lEmHSvHisdVp/DJtbSrZwSYTRvTTz5IZDSq4kAzrDfpj16h7b3t3nFGc8UoY2Ro4tRZ3ahJ2r3b79yK6C5phY7CAANuW3gDdhVjiBNYs0CAwEAAaOByjCBxzAdBgNVHQ4EFgQU3/7kV2tbdFtphbSA4LH7+w8SkcwwgZcGA1UdIwSBjzCBjIAU3/7kV2tbdFtphbSA4LH7+w8SkcyhaaRnMGUxCzAJBgNVBAYTAklUMQ4wDAYDVQQIEwVJdGFseTENMAsGA1UEBxMEUm9tZTENMAsGA1UEChMEQWdJRDESMBAGA1UECxMJQWdJRCBURVNUMRQwEgYDVQQDEwthZ2lkLmdvdi5pdIIJAOrYj9oLEJCwMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQELBQADggEBAJNFqXg/V3aimJKUmUaqmQEEoSc3qvXFITvT5f5bKw9yk/NVhR6wndL+z/24h1OdRqs76blgH8k116qWNkkDtt0AlSjQOx5qvFYh1UviOjNdRI4WkYONSw+vuavcx+fB6O5JDHNmMhMySKTnmRqTkyhjrch7zaFIWUSV7hsBuxpqmrWDoLWdXbV3eFH3mINA5AoIY/m0bZtzZ7YNgiFWzxQgekpxd0vcTseMnCcXnsAlctdir0FoCZztxMuZjlBjwLTtM6Ry3/48LMM8Z+lw7NMciKLLTGQyU8XmKKSSOh0dGh5Lrlt5GxIIJkH81C0YimWebz8464QPL3RbLnTKg+c=
-        </ds:X509Certificate>
-      </ds:X509Data>
-    </ds:KeyInfo>
-  </ds:Signature>
-  <saml2p:Status>
-    <saml2p:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success" />
-  </saml2p:Status>
-  <saml2:Assertion
+) => `<saml2:Assertion
     ID="_43568006-96d4-4dcc-84da-d98e01ea3a28"
     IssueInstant="2020-02-26T07:32:05Z"
     Version="2.0"
@@ -358,7 +310,60 @@ export const getASAMLResponse_saml2Namespace = (
         </saml2:AttributeValue>
       </saml2:Attribute>
     </saml2:AttributeStatement>
-  </saml2:Assertion>
+  </saml2:Assertion>`;
+
+export const getASAMLResponse_saml2Namespace = (
+  fiscalCode: FiscalCode,
+  inResponseTo: NonEmptyString,
+  spidLevel: SpidLevel = SpidLevelEnum["https://www.spid.gov.it/SpidL2"]
+) => `<saml2p:Response
+  Destination="https://app-backend.dev.io.italia.it/assertionConsumerService"
+  ID="_7080f453-78cb-4f57-9692-62dc8a5c23e8"
+   InResponseTo="${inResponseTo}"
+  IssueInstant="2020-02-26T07:32:05Z"
+  Version="2.0"
+  xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion"
+  xmlns:saml2p="urn:oasis:names:tc:SAML:2.0:protocol"
+>
+  <saml2:Issuer Format="urn:oasis:names:tc:SAML:2.0:nameid-format:entity">
+    http://localhost:8080
+  </saml2:Issuer>
+  <ds:Signature xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+    <ds:SignedInfo>
+      <ds:CanonicalizationMethod
+        Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"
+      />
+      <ds:SignatureMethod
+        Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"
+      />
+      <ds:Reference URI="#_7080f453-78cb-4f57-9692-62dc8a5c23e8">
+        <ds:Transforms>
+          <ds:Transform
+            Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"
+          />
+          <ds:Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#" />
+        </ds:Transforms>
+        <ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256" />
+        <ds:DigestValue>
+          TF1ulWGxyd1WLVdSAqBIamJFuM2asyon8TiXFA5MKRk=
+        </ds:DigestValue>
+      </ds:Reference>
+    </ds:SignedInfo>
+    <ds:SignatureValue>
+      riM6BMi4m5VSG26SrSJ7oB5Sk2TYWAUWcQOeE0oeKEDvBbDSXYfMCed5RD8ZCaD340OdmYBNylW8WsegTR0Ejxlusjg/KbLfDFlTpFA6kQEI02A7LFjlWL1XR+t/jE2101zEcZQHp01R8oALxrMzicW591h12l8Y0HtoMCYTOoAThsyk7D+ce/+Jh4Ogn5xUtAm7NpXGuMRChIhVuhfvQ3l7rDxFU+N+CHc7mfLxRZFooQn1zmHS3Ccd/O8N1Tnx+ivCIzozDa9n35S5bzSqiVHBgoa3kEUsQB+ZEn38Y8gOWJgRpPi6txorjWj2+NAmzGH2DJ0tNQAuGc2B4Eu5uQ==
+    </ds:SignatureValue>
+    <ds:KeyInfo>
+      <ds:X509Data>
+        <ds:X509Certificate>
+          MIIEGDCCAwCgAwIBAgIJAOrYj9oLEJCwMA0GCSqGSIb3DQEBCwUAMGUxCzAJBgNVBAYTAklUMQ4wDAYDVQQIEwVJdGFseTENMAsGA1UEBxMEUm9tZTENMAsGA1UEChMEQWdJRDESMBAGA1UECxMJQWdJRCBURVNUMRQwEgYDVQQDEwthZ2lkLmdvdi5pdDAeFw0xOTA0MTExMDAyMDhaFw0yNTAzMDgxMDAyMDhaMGUxCzAJBgNVBAYTAklUMQ4wDAYDVQQIEwVJdGFseTENMAsGA1UEBxMEUm9tZTENMAsGA1UEChMEQWdJRDESMBAGA1UECxMJQWdJRCBURVNUMRQwEgYDVQQDEwthZ2lkLmdvdi5pdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAK8kJVo+ugRrbbv9xhXCuVrqi4B7/MQzQc62ocwlFFujJNd4m1mXkUHFbgvwhRkQqo2DAmFeHiwCkJT3K1eeXIFhNFFroEzGPzONyekLpjNvmYIs1CFvirGOj0bkEiGaKEs+/umzGjxIhy5JQlqXE96y1+Izp2QhJimDK0/KNij8I1bzxseP0Ygc4SFveKS+7QO+PrLzWklEWGMs4DM5Zc3VRK7g4LWPWZhKdImC1rnS+/lEmHSvHisdVp/DJtbSrZwSYTRvTTz5IZDSq4kAzrDfpj16h7b3t3nFGc8UoY2Ro4tRZ3ahJ2r3b79yK6C5phY7CAANuW3gDdhVjiBNYs0CAwEAAaOByjCBxzAdBgNVHQ4EFgQU3/7kV2tbdFtphbSA4LH7+w8SkcwwgZcGA1UdIwSBjzCBjIAU3/7kV2tbdFtphbSA4LH7+w8SkcyhaaRnMGUxCzAJBgNVBAYTAklUMQ4wDAYDVQQIEwVJdGFseTENMAsGA1UEBxMEUm9tZTENMAsGA1UEChMEQWdJRDESMBAGA1UECxMJQWdJRCBURVNUMRQwEgYDVQQDEwthZ2lkLmdvdi5pdIIJAOrYj9oLEJCwMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQELBQADggEBAJNFqXg/V3aimJKUmUaqmQEEoSc3qvXFITvT5f5bKw9yk/NVhR6wndL+z/24h1OdRqs76blgH8k116qWNkkDtt0AlSjQOx5qvFYh1UviOjNdRI4WkYONSw+vuavcx+fB6O5JDHNmMhMySKTnmRqTkyhjrch7zaFIWUSV7hsBuxpqmrWDoLWdXbV3eFH3mINA5AoIY/m0bZtzZ7YNgiFWzxQgekpxd0vcTseMnCcXnsAlctdir0FoCZztxMuZjlBjwLTtM6Ry3/48LMM8Z+lw7NMciKLLTGQyU8XmKKSSOh0dGh5Lrlt5GxIIJkH81C0YimWebz8464QPL3RbLnTKg+c=
+        </ds:X509Certificate>
+      </ds:X509Data>
+    </ds:KeyInfo>
+  </ds:Signature>
+  <saml2p:Status>
+    <saml2p:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success" />
+  </saml2p:Status>
+  ${getASAMLAssertion_saml2Namespace(fiscalCode, inResponseTo, spidLevel)}
 </saml2p:Response>
 `;
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->
Test login support lollipop headers.
Test login reserve the provided key.
Test login generate a fake assertion with ResponseID and CF linked to the credential.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
To executes load test for fast login capability is needed use lollipop with test login.
Test login can be used for lollipop functions in App for testing purposes.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
local execution with `io-mock`

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
