### PR TITLE
[#IOCOM-682] Included eventual query params in attachment url

### DIFF
--- a/src/controllers/messagesController.ts
+++ b/src/controllers/messagesController.ts
@@ -48,6 +48,7 @@ import { LollipopApiClient } from "../clients/lollipop";
 import { ISessionStorage } from "../services/ISessionStorage";
 import { extractLollipopLocalsFromLollipopHeadersLegacy } from "../utils/lollipop";
 import { checkIfLollipopIsEnabled } from "../utils/lollipop";
+import QueryString = require("qs");
 
 export const withGetThirdPartyAttachmentParams = async <T>(
   req: express.Request,
@@ -55,7 +56,11 @@ export const withGetThirdPartyAttachmentParams = async <T>(
 ) =>
   withValidatedOrValidationError(Ulid.decode(req.params.id), (id) =>
     withValidatedOrValidationError(
-      NonEmptyString.decode(req.params.attachment_url),
+      pipe(
+        QueryString.stringify(req.query, { addQueryPrefix: true }),
+        (queryString) => `${req.params.attachment_url}${queryString}`,
+        NonEmptyString.decode
+      ),
       (attachment_url) => f(id, attachment_url)
     )
   );

--- a/src/controllers/messagesController.ts
+++ b/src/controllers/messagesController.ts
@@ -28,6 +28,7 @@ import { NonEmptyString, Ulid } from "@pagopa/ts-commons/lib/strings";
 import NewMessagesService from "src/services/newMessagesService";
 import { errorsToReadableMessages } from "@pagopa/ts-commons/lib/reporters";
 import { ThirdPartyConfigList } from "src/utils/thirdPartyConfig";
+import QueryString = require("qs");
 import { User, withUserFromRequest } from "../types/user";
 
 import { MessageStatusChange } from "../../generated/io-messages-api/MessageStatusChange";
@@ -48,7 +49,6 @@ import { LollipopApiClient } from "../clients/lollipop";
 import { ISessionStorage } from "../services/ISessionStorage";
 import { extractLollipopLocalsFromLollipopHeadersLegacy } from "../utils/lollipop";
 import { checkIfLollipopIsEnabled } from "../utils/lollipop";
-import QueryString = require("qs");
 
 export const withGetThirdPartyAttachmentParams = async <T>(
   req: express.Request,

--- a/src/controllers/messagesController.ts
+++ b/src/controllers/messagesController.ts
@@ -28,7 +28,7 @@ import { NonEmptyString, Ulid } from "@pagopa/ts-commons/lib/strings";
 import NewMessagesService from "src/services/newMessagesService";
 import { errorsToReadableMessages } from "@pagopa/ts-commons/lib/reporters";
 import { ThirdPartyConfigList } from "src/utils/thirdPartyConfig";
-import QueryString = require("qs");
+import * as QueryString from "qs";
 import { User, withUserFromRequest } from "../types/user";
 
 import { MessageStatusChange } from "../../generated/io-messages-api/MessageStatusChange";


### PR DESCRIPTION
#### List of Changes
Transferred query params from request to the attachment url.

#### Motivation and Context
Attachment url could have some query params so we must add them to the attachment url.

#### How Has This Been Tested?
unit test

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

