### PR TITLE
[#IOPID-1201] Disable notifications when the user locks the session from ioapp.it

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -624,7 +624,8 @@ export async function newApp({
           SESSION_STORAGE,
           USER_METADATA_STORAGE,
           LOLLIPOP_SERVICE,
-          AUTHENTICATION_LOCK_SERVICE
+          AUTHENTICATION_LOCK_SERVICE,
+          notificationServiceFactory
         );
         if (FF_BONUS_ENABLED) {
           // eslint-disable-next-line @typescript-eslint/no-use-before-define
@@ -1290,7 +1291,8 @@ function registerSessionAPIRoutes(
   sessionStorage: RedisSessionStorage,
   userMetadataStorage: RedisUserMetadataStorage,
   lollipopService: LollipopService,
-  authenticationLockService: AuthenticationLockService
+  authenticationLockService: AuthenticationLockService,
+  notificationServiceFactory: NotificationServiceFactory
 ): void {
   if (FF_ENABLE_SESSION_ENDPOINTS) {
     const sessionLockController: SessionLockController =
@@ -1298,7 +1300,8 @@ function registerSessionAPIRoutes(
         sessionStorage,
         userMetadataStorage,
         lollipopService,
-        authenticationLockService
+        authenticationLockService,
+        notificationServiceFactory
       );
 
     app.get(

--- a/src/controllers/sessionLockController.ts
+++ b/src/controllers/sessionLockController.ts
@@ -242,11 +242,13 @@ export default class SessionLockController {
                 "Another user authentication lock has already been applied"
               )
           ),
-          // clear session data
           TE.chainW((_) =>
             pipe(
               AP.sequenceT(TE.ApplicativeSeq)(
+                // clear session data
                 ...this.buildInvalidateUserSessionTask(fiscalCode),
+                // clear installation before locking the user account
+                // for allowing allow the FE to retry the call in case of failure.
                 this.clearInstallation(fiscalCode),
                 // if clean up went well, lock user session
                 this.authenticationLockService.lockUserAuthentication(
@@ -418,7 +420,6 @@ export default class SessionLockController {
     ] as const;
 
   private readonly clearInstallation = (fiscalCode: FiscalCode) =>
-    // async fire & forget
     pipe(
       TE.tryCatch(
         () =>

--- a/src/controllers/sessionLockController.ts
+++ b/src/controllers/sessionLockController.ts
@@ -430,7 +430,7 @@ export default class SessionLockController {
             `Cannot delete Notification Installation: ${JSON.stringify(err)}`
           )
       ),
-      TE.chainW(
+      TE.chain(
         flow(
           TE.fromPredicate(
             (response) => response.kind === "IResponseSuccessJson",


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->

- add deleteInstallation to lockUserAuthentiction flow](https://github.com/pagopa/io-backend/commit/fa4308d5be855b9917a2d8e98dbf0ea2f680c01b)
- add tests](https://github.com/pagopa/io-backend/commit/d6eacbdc6a825b6e7ee8926f977906650596a434)

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Avoid to sent notifications to the user's device when a session lock occurred

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Unit tests

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
