### PR TITLE
fix(io-sign): [SFEQS-2089] Fix x-io-sign-environment header decode

### DIFF
--- a/src/services/__tests__/ioSignService.test.ts
+++ b/src/services/__tests__/ioSignService.test.ts
@@ -28,6 +28,8 @@ import { IssuerEnvironmentEnum } from "../../../generated/io-sign-api/IssuerEnvi
 import { SignatureRequestList } from "../../../generated/io-sign-api/SignatureRequestList";
 import mockRes from "../../__mocks__/response";
 
+import { Headers as NodeFetchHeaders } from "node-fetch";
+
 const mockCreateFilledDocument = jest.fn();
 const mockGetSignerByFiscalCode = jest.fn();
 const mockGetInfo = jest.fn();
@@ -687,23 +689,23 @@ describe("IoSignService#getSignatureRequest", () => {
   });
 
   it("should use prod as default environment if x-io-sign-environment is not defined", () => {
-    const headers = {};
+    const headers = new NodeFetchHeaders({});
     expect(getEnvironmentFromHeaders(headers)).toBe("prod");
   });
 
   it("should use prod as default environment if x-io-sign-environment is not valid", () => {
-    const headers = {
+    const headers = new NodeFetchHeaders({
       "x-io-sign-environment": "uat",
-    };
+    });
     expect(getEnvironmentFromHeaders(headers)).toBe("prod");
   });
 
   it.each(["test", "prod"])(
     "should use the valid value of x-io-sign-environment if it's defined",
     (environment) => {
-      const headers = {
+      const headers = new NodeFetchHeaders({
         "x-io-sign-environment": environment,
-      };
+      });
       expect(getEnvironmentFromHeaders(headers)).toBe(environment);
     }
   );

--- a/src/services/ioSignService.ts
+++ b/src/services/ioSignService.ts
@@ -58,7 +58,8 @@ const userNotFound =
 
 export const getEnvironmentFromHeaders = flow(
   O.fromPredicate(
-    (u: unknown): u is NodeFetchHeaders => u instanceof NodeFetchHeaders
+    (headers: unknown): headers is NodeFetchHeaders =>
+      headers instanceof NodeFetchHeaders
   ),
   O.map((headers) => headers.get("x-io-sign-environment")),
   O.chain(O.fromNullable),

--- a/src/services/ioSignService.ts
+++ b/src/services/ioSignService.ts
@@ -28,7 +28,7 @@ import {
   NonEmptyString,
 } from "@pagopa/ts-commons/lib/strings";
 import * as E from "fp-ts/Either";
-import { lookup } from "fp-ts/lib/ReadonlyRecord";
+import { Headers as NodeFetchHeaders } from "node-fetch";
 import { CreateSignatureBody as CreateSignatureBodyApiModel } from "../../generated/io-sign-api/CreateSignatureBody";
 import { IssuerEnvironment } from "../../generated/io-sign/IssuerEnvironment";
 import { SignerDetailView } from "../../generated/io-sign-api/SignerDetailView";
@@ -57,7 +57,11 @@ const userNotFound =
   "The user associated with this profile could not be found.";
 
 export const getEnvironmentFromHeaders = flow(
-  lookup("x-io-sign-environment"),
+  O.fromPredicate(
+    (u: unknown): u is NodeFetchHeaders => u instanceof NodeFetchHeaders
+  ),
+  O.map((headers) => headers.get("x-io-sign-environment")),
+  O.chain(O.fromNullable),
   O.chainEitherK(t.keyof({ prod: true, test: true }).decode),
   O.getOrElse(() => "prod")
 );


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->
Add a type guard to work with `req.headers` with the right runtime type (`Map` instead of `Record<string, string>`)

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Due to a type annotation error on the generated api client, `getEnvironmentFromHeaders` wrongly assumed that `req.headers` was a `Record` instead of an `Headers` map, so the decode step has always failed.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
