### PR TITLE
[#IOPID-1407] Avoid storing Spid email on first onboarding, based on `IS_SPID_EMAIL_PERSISTENCE_ENABLED`

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1116,3 +1116,11 @@ export const FF_UNIQUE_EMAIL_ENFORCEMENT_ENABLED =
     () => false,
     FF_UNIQUE_EMAIL_ENFORCEMENT
   );
+
+// SPID Email Persistence FF
+
+export const IS_SPID_EMAIL_PERSISTENCE_ENABLED = pipe(
+  O.fromNullable(process.env.IS_SPID_EMAIL_PERSISTENCE_ENABLED),
+  O.map((val) => val.toLowerCase() === "true"),
+  O.getOrElse(() => true)
+);

--- a/src/controllers/authenticationController.ts
+++ b/src/controllers/authenticationController.ts
@@ -69,6 +69,7 @@ import {
   IOLOGIN_USERS_LIST,
   isUserElegibleForFastLogin,
   FF_UNIQUE_EMAIL_ENFORCEMENT_ENABLED,
+  IS_SPID_EMAIL_PERSISTENCE_ENABLED,
   TEST_LOGIN_FISCAL_CODES,
 } from "../config";
 import { ISessionStorage } from "../services/ISessionStorage";
@@ -530,7 +531,7 @@ export default class AuthenticationController {
       // one
       const newProfile: NewProfile = createNewProfile(
         user.fiscal_code,
-        spidUser.email
+        IS_SPID_EMAIL_PERSISTENCE_ENABLED ? spidUser.email : undefined
       )({
         FF_UNIQUE_EMAIL_ENFORCEMENT_ENABLED,
         testLoginFiscalCodes: TEST_LOGIN_FISCAL_CODES,


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->

- Add new env variable `IS_SPID_EMAIL_PERSISTENCE_ENABLED` (default `true`)
- when creating a new profile, store SPID email based on `IS_SPID_EMAIL_PERSISTENCE_ENABLED`

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Avoid storing Spid email on first onboarding

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Unit test

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
