### PR TITLE
[#IOPID-1645] Fix ReDOS vulnerability on SignatureInput params

### DIFF
--- a/api_io_sign.yaml
+++ b/api_io_sign.yaml
@@ -699,7 +699,7 @@ components:
 
     LollipopSignatureInput:
       type: string
-      pattern: "^(((sig[0-9]+)=[^,]*?)(, ?)?)+$"
+      pattern: "^(?:sig\\d+=[^,]*)(?:,\\s*(?:sig\\d+=[^,]*))*$"
     LollipopSignature:
       type: string
       pattern: "^((sig[0-9]+)=:[A-Za-z0-9+/=]*:(, ?)?)+$"

--- a/api_lollipop_first_consumer.yaml
+++ b/api_lollipop_first_consumer.yaml
@@ -102,7 +102,7 @@ components:
 
     LollipopSignatureInput:
       type: string
-      pattern: "^(((sig[0-9]+)=[^,]*?)(, ?)?)+$"
+      pattern: "^(?:sig\\d+=[^,]*)(?:,\\s*(?:sig\\d+=[^,]*))*$"
     LollipopSignature:
       type: string
       pattern: "^((sig[0-9]+)=:[A-Za-z0-9+/=]*:(, ?)?)+$"

--- a/openapi/consumed/api-piattaforma-notifiche.yaml
+++ b/openapi/consumed/api-piattaforma-notifiche.yaml
@@ -721,7 +721,7 @@ components:
       pattern: "^https:\/\/"
     LollipopSignatureInput:
       type: string
-      pattern: "^(((sig[0-9]+)=[^,]*?)(, ?)?)+$"
+      pattern: "^(?:sig\\d+=[^,]*)(?:,\\s*(?:sig\\d+=[^,]*))*$"
     LollipopSignature:
       type: string
       pattern: "^((sig[0-9]+)=:[A-Za-z0-9+/=]*:(, ?)?)+$"

--- a/openapi/consumed/api-third-party.yaml
+++ b/openapi/consumed/api-third-party.yaml
@@ -431,7 +431,7 @@ components:
       pattern: "^https:\/\/"
     LollipopSignatureInput:
       type: string
-      pattern: "^(((sig[0-9]+)=[^,]*?)(, ?)?)+$"
+      pattern: "^(?:sig\\d+=[^,]*)(?:,\\s*(?:sig\\d+=[^,]*))*$"
     LollipopSignature:
       type: string
       pattern: "^((sig[0-9]+)=:[A-Za-z0-9+/=]*:(, ?)?)+$"

--- a/openapi/consumed/api_remote_content.yaml
+++ b/openapi/consumed/api_remote_content.yaml
@@ -458,7 +458,7 @@ components:
       pattern: "^https:\/\/"
     LollipopSignatureInput:
       type: string
-      pattern: "^(((sig[0-9]+)=[^,]*?)(, ?)?)+$"
+      pattern: "^(?:sig\\d+=[^,]*)(?:,\\s*(?:sig\\d+=[^,]*))*$"
     LollipopSignature:
       type: string
       pattern: "^((sig[0-9]+)=:[A-Za-z0-9+/=]*:(, ?)?)+$"

--- a/openapi/consumed/lollipop_first_consumer.yaml
+++ b/openapi/consumed/lollipop_first_consumer.yaml
@@ -206,7 +206,7 @@ components:
 
     LollipopSignatureInput:
       type: string
-      pattern: "^(((sig[0-9]+)=[^,]*?)(, ?)?)+$"
+      pattern: "^(?:sig\\d+=[^,]*)(?:,\\s*(?:sig\\d+=[^,]*))*$"
     LollipopSignature:
       type: string
       pattern: "^((sig[0-9]+)=:[A-Za-z0-9+/=]*:(, ?)?)+$"

--- a/openapi/generated/api_fast_login.yaml
+++ b/openapi/generated/api_fast_login.yaml
@@ -91,7 +91,7 @@ components:
       pattern: ^https://
     LollipopSignatureInput:
       type: string
-      pattern: ^(((sig[0-9]+)=[^,]*?)(, ?)?)+$
+      pattern: "^(?:sig\\d+=[^,]*)(?:,\\s*(?:sig\\d+=[^,]*))*$"
     LollipopSignature:
       type: string
       pattern: ^((sig[0-9]+)=:[A-Za-z0-9+/=]*:(, ?)?)+$

--- a/openapi/lollipop_definitions.yaml
+++ b/openapi/lollipop_definitions.yaml
@@ -91,7 +91,7 @@ components:
 
     LollipopSignatureInput:
       type: string
-      pattern: "^(((sig[0-9]+)=[^,]*?)(, ?)?)+$"
+      pattern: "^(?:sig\\d+=[^,]*)(?:,\\s*(?:sig\\d+=[^,]*))*$"
     LollipopSignature:
       type: string
       pattern: "^((sig[0-9]+)=:[A-Za-z0-9+/=]*:(, ?)?)+$"


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
Depends on:
- https://github.com/pagopa/io-functions-fast-login/pull/28
- https://github.com/pagopa/io-sign/pull/268

#### List of Changes
<!--- Describe your changes in detail -->
Update all the LolliPoP signature input parameters regex

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The previous regex is vulnerable to ReDOS attacks

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
