### PR TITLE
[SIW-1843] Removed the setCurrentWalletInstanceStatus API

### DIFF
--- a/api_io_wallet.yaml
+++ b/api_io_wallet.yaml
@@ -82,29 +82,6 @@ paths:
         "503":
           $ref: "#/components/responses/ServiceUnavailable"
 
-  /wallet-instances/current/status:
-    put:
-      summary: Revoke current Wallet Instance
-      operationId: setCurrentWalletInstanceStatus
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/SetWalletInstanceStatusBody"
-      responses:
-        "204":
-          description: Wallet Instance status successfully set
-        "400":
-          $ref: "#/components/responses/BadRequest"
-        "403":
-          $ref: "#/components/responses/Forbidden"
-        "422":
-          $ref: "#/components/responses/UnprocessableContent"
-        "500":
-          $ref: "#/components/responses/Unexpected"
-        "503":
-          $ref: "#/components/responses/ServiceUnavailable"
-
   /wallet-instances/{id}/status:
     parameters:
     - in: path

--- a/src/app.ts
+++ b/src/app.ts
@@ -1467,16 +1467,6 @@ function registerIoWalletAPIRoutes(
     )
   );
 
-  // TODO SIW-1843
-  app.put(
-    `${basePath}/wallet-instances/current/status`,
-    bearerSessionTokenAuth,
-    toExpressHandler(
-      ioWalletController.setCurrentWalletInstanceStatus,
-      ioWalletController
-    )
-  );
-
   app.get(
     `${basePath}/wallet-instances/:walletInstanceId/status`,
     bearerSessionTokenAuth,

--- a/src/controllers/ioWalletController.ts
+++ b/src/controllers/ioWalletController.ts
@@ -167,40 +167,6 @@ export default class IoWalletController {
     );
 
   /**
-   * Update current Wallet Instance status.
-   */
-  public readonly setCurrentWalletInstanceStatus = (
-    req: express.Request
-  ): Promise<
-    | IResponseErrorInternal
-    | IResponseErrorGeneric
-    | IResponseSuccessNoContent
-    | IResponseErrorServiceUnavailable
-    | IResponseErrorValidation
-    | IResponseErrorForbiddenNotAuthorized
-  > =>
-    withUserFromRequest(req, async (user) =>
-      pipe(
-        this.ensureFiscalCodeIsAllowed(user.fiscal_code),
-        TE.chainW(() =>
-          pipe(
-            req.body,
-            SetWalletInstanceStatusBody.decode,
-            E.mapLeft(toValidationError),
-            TE.fromEither
-          )
-        ),
-        TE.map(({ status }) =>
-          this.ioWalletService.setCurrentWalletInstanceStatus(
-            status,
-            user.fiscal_code
-          )
-        ),
-        TE.toUnion
-      )()
-    );
-
-  /**
    * Get current Wallet Instance status.
    */
   public readonly getWalletInstanceStatus = (

--- a/src/services/__tests__/ioWalletService.test.ts
+++ b/src/services/__tests__/ioWalletService.test.ts
@@ -15,7 +15,6 @@ const mockHealthCheck = jest.fn();
 const mockGetWalletInstanceStatus = jest.fn();
 const mockGetCurrentWalletInstanceStatus = jest.fn();
 const mockSetWalletInstanceStatus = jest.fn();
-const mockSetCurrentWalletInstanceStatus = jest.fn();
 
 mockGetNonce.mockImplementation(() =>
   t.success({
@@ -56,12 +55,6 @@ mockSetWalletInstanceStatus.mockImplementation(() =>
   })
 );
 
-mockSetCurrentWalletInstanceStatus.mockImplementation(() =>
-  t.success({
-    status: 204,
-  })
-);
-
 const api = {
   getEntityConfiguration: mockGetEntityConfiguration,
   getNonce: mockGetNonce,
@@ -71,7 +64,6 @@ const api = {
   getWalletInstanceStatus: mockGetWalletInstanceStatus,
   getCurrentWalletInstanceStatus: mockGetCurrentWalletInstanceStatus,
   setWalletInstanceStatus: mockSetWalletInstanceStatus,
-  setCurrentWalletInstanceStatus: mockSetCurrentWalletInstanceStatus,
 };
 
 const mockCreateSubscription = jest.fn();
@@ -507,127 +499,6 @@ describe("IoWalletService#setWalletInstanceStatus", () => {
     const service = new IoWalletService(api, trialSystemApi);
 
     const res = await service.setWalletInstanceStatus(aId, status, aFiscalCode);
-
-    expect(res).toMatchObject({
-      kind: "IResponseErrorInternal",
-    });
-  });
-});
-
-describe("IoWalletService#setCurrentWalletInstanceStatus", () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
-  });
-
-  const status = StatusEnum["REVOKED"];
-
-  it("should make the correct api call", async () => {
-    const service = new IoWalletService(api, trialSystemApi);
-
-    await service.setCurrentWalletInstanceStatus(status, aFiscalCode);
-
-    expect(mockSetCurrentWalletInstanceStatus).toHaveBeenCalledWith({
-      body: {
-        status,
-        fiscal_code: aFiscalCode,
-      },
-    });
-  });
-
-  it("should handle a success response", async () => {
-    const service = new IoWalletService(api, trialSystemApi);
-
-    const res = await service.setCurrentWalletInstanceStatus(
-      status,
-      aFiscalCode
-    );
-
-    expect(res).toMatchObject({
-      kind: "IResponseSuccessNoContent",
-    });
-  });
-
-  it("should handle a generic error when the API client returns 422", async () => {
-    mockSetCurrentWalletInstanceStatus.mockImplementationOnce(() =>
-      t.success({ status: 422 })
-    );
-
-    const service = new IoWalletService(api, trialSystemApi);
-
-    const res = await service.setCurrentWalletInstanceStatus(
-      status,
-      aFiscalCode
-    );
-
-    expect(res).toMatchObject({
-      kind: "IResponseErrorGeneric",
-    });
-  });
-
-  it("should handle an internal error when the API client returns 500", async () => {
-    const aGenericProblem = {};
-    mockSetCurrentWalletInstanceStatus.mockImplementationOnce(() =>
-      t.success({ status: 500, value: aGenericProblem })
-    );
-
-    const service = new IoWalletService(api, trialSystemApi);
-
-    const res = await service.setCurrentWalletInstanceStatus(
-      status,
-      aFiscalCode
-    );
-
-    expect(res).toMatchObject({
-      kind: "IResponseErrorInternal",
-    });
-  });
-
-  it("should handle a service unavailable error when the API client returns 503", async () => {
-    const aGenericProblem = {};
-    mockSetCurrentWalletInstanceStatus.mockImplementationOnce(() =>
-      t.success({ status: 503, value: aGenericProblem })
-    );
-
-    const service = new IoWalletService(api, trialSystemApi);
-
-    const res = await service.setCurrentWalletInstanceStatus(
-      status,
-      aFiscalCode
-    );
-
-    expect(res).toMatchObject({
-      kind: "IResponseErrorServiceUnavailable",
-    });
-  });
-
-  it("should handle an internal error when the API client returns a code not specified in spec", async () => {
-    const aGenericProblem = {};
-    mockSetCurrentWalletInstanceStatus.mockImplementationOnce(() =>
-      t.success({ status: 599, value: aGenericProblem })
-    );
-
-    const service = new IoWalletService(api, trialSystemApi);
-
-    const res = await service.setCurrentWalletInstanceStatus(
-      status,
-      aFiscalCode
-    );
-
-    expect(res).toMatchObject({
-      kind: "IResponseErrorInternal",
-    });
-  });
-
-  it("should return an error if the api call throws an error", async () => {
-    mockSetCurrentWalletInstanceStatus.mockImplementationOnce(() => {
-      throw new Error();
-    });
-    const service = new IoWalletService(api, trialSystemApi);
-
-    const res = await service.setCurrentWalletInstanceStatus(
-      status,
-      aFiscalCode
-    );
 
     expect(res).toMatchObject({
       kind: "IResponseErrorInternal",

--- a/src/services/ioWalletService.ts
+++ b/src/services/ioWalletService.ts
@@ -239,48 +239,6 @@ export default class IoWalletService {
     });
 
   /**
-   * Update current Wallet Instance status.
-   */
-  public readonly setCurrentWalletInstanceStatus = (
-    status: SetWalletInstanceStatusWithFiscalCodeData["status"],
-    fiscal_code: SetWalletInstanceStatusWithFiscalCodeData["fiscal_code"]
-  ): Promise<
-    | IResponseErrorInternal
-    | IResponseErrorGeneric
-    | IResponseSuccessNoContent
-    | IResponseErrorServiceUnavailable
-  > =>
-    withCatchAsInternalError(async () => {
-      const validated =
-        await this.ioWalletApiClient.setCurrentWalletInstanceStatus({
-          body: { fiscal_code, status }
-        });
-      return withValidatedOrInternalError(validated, (response) => {
-        switch (response.status) {
-          case 204:
-            return ResponseSuccessNoContent();
-          case 422:
-            return ResponseErrorGeneric(
-              response.status,
-              unprocessableContentError,
-              invalidRequest
-            );
-          case 500:
-            return ResponseErrorInternal(
-              `Internal server error | ${response.value}`
-            );
-          case 503:
-            return ResponseErrorServiceTemporarilyUnavailable(
-              serviceUnavailableDetail,
-              "10"
-            );
-          default:
-            return ResponseErrorStatusNotDefinedInSpec(response);
-        }
-      });
-    });
-
-  /**
    * Get current Wallet Instance status.
    */
   public readonly getWalletInstanceStatus = (


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

I removed the setCurrentWalletInstanceStatus API.

#### Motivation and Context

The PUT /wallet-instances/current/status endpoint is no longer needed and is not used by any client or app.
This PR depends on [this](https://github.com/pagopa/io-wallet/pull/365).

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
