### PR TITLE
[SIW-2079] Added getCurrentWalletInstanceStatus endpoint

### DIFF
--- a/api_io_wallet.yaml
+++ b/api_io_wallet.yaml
@@ -105,6 +105,49 @@ paths:
         "503":
           $ref: "#/components/responses/ServiceUnavailable"
 
+  /wallet-instances/current/status:
+    get:
+      summary: Retrieve the current Wallet Instance status
+      operationId: getWalletInstanceStatus
+      responses:
+        "200":
+          description: Wallet Instance status successfully retrieved
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WalletInstanceData"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "422":
+          $ref: "#/components/responses/UnprocessableContent"
+        "500":
+          $ref: "#/components/responses/Unexpected"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+    put:
+      summary: Revoke a Wallet Instance
+      operationId: setWalletInstanceStatus
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SetWalletInstanceStatusBody"
+      responses:
+        "204":
+          description: Wallet Instance status successfully set
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "500":
+          $ref: "#/components/responses/Unexpected"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+
   /wallet-instances/{id}/status:
     parameters:
     - in: path

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "generate:proxy:api-session": "rimraf generated/session && gen-api-models --api-spec api_session.yaml --out-dir generated/session",
     "generate:lollipop-definitions": "rimraf generated/lollipop && gen-api-models --api-spec openapi/lollipop_definitions.yaml --out-dir generated/lollipop",
     "generate:lollipop-first-sign": "rimraf generated/lollipop-first-consumer && gen-api-models --api-spec openapi/consumed/lollipop_first_consumer.yaml --out-dir generated/lollipop-first-consumer --request-types --response-decoders --client",
-    "generate:api:io-wallet": "rimraf generated/io-wallet-api && gen-api-models --api-spec https://raw.githubusercontent.com/pagopa/io-wallet/io-wallet-user-func@2.0.1/apps/io-wallet-user-func/openapi.yaml --no-strict --out-dir generated/io-wallet-api --request-types --response-decoders --client",
+    "generate:api:io-wallet": "rimraf generated/io-wallet-api && gen-api-models --api-spec https://raw.githubusercontent.com/pagopa/io-wallet/io-wallet-user-func@3.0.3/apps/io-wallet-user-func/openapi.yaml --no-strict --out-dir generated/io-wallet-api --request-types --response-decoders --client",
     "generate:proxy:io-wallet-models": "rimraf generated/io-wallet && gen-api-models --api-spec api_io_wallet.yaml --out-dir generated/io-wallet",
     "postversion": "git push && git push --tags",
     "dist:modules": "modclean -r -n default:safe && yarn install --production",

--- a/src/controllers/ioWalletController.ts
+++ b/src/controllers/ioWalletController.ts
@@ -201,7 +201,7 @@ export default class IoWalletController {
     );
 
   /**
-   * Get current Wallet Instance status.
+   * Get Wallet Instance status by ID.
    */
   public readonly getWalletInstanceStatus = (
     req: express.Request
@@ -228,6 +228,29 @@ export default class IoWalletController {
             walletInstanceId,
             user.fiscal_code
           )
+        ),
+        TE.toUnion
+      )()
+    );
+
+  /**
+   * Get Current Wallet Instance Status
+   */
+  public readonly getCurrentWalletInstanceStatus = (
+    req: express.Request
+  ): Promise<
+    | IResponseErrorInternal
+    | IResponseSuccessJson<WalletInstanceData>
+    | IResponseErrorNotFound
+    | IResponseErrorServiceUnavailable
+    | IResponseErrorValidation
+    | IResponseErrorForbiddenNotAuthorized
+  > =>
+    withUserFromRequest(req, async (user) =>
+      pipe(
+        this.ensureFiscalCodeIsAllowed(user.fiscal_code),
+        TE.map(() =>
+          this.ioWalletService.getCurrentWalletInstanceStatus(user.fiscal_code)
         ),
         TE.toUnion
       )()

--- a/src/routes/ioWalletRoutes.ts
+++ b/src/routes/ioWalletRoutes.ts
@@ -64,6 +64,15 @@ export const registerIoWalletAPIRoutes = (
     )
   );
 
+  app.get(
+    `${basePath}/wallet-instances/current/status`,
+    bearerSessionTokenAuth,
+    toExpressHandler(
+      ioWalletController.getCurrentWalletInstanceStatus,
+      ioWalletController
+    )
+  );
+
   app.put(
     `${basePath}/wallet-instances/:walletInstanceId/status`,
     bearerSessionTokenAuth,

--- a/src/services/__tests__/ioWalletService.test.ts
+++ b/src/services/__tests__/ioWalletService.test.ts
@@ -50,6 +50,16 @@ mockGetWalletInstanceStatus.mockImplementation(() =>
   })
 );
 
+mockGetCurrentWalletInstanceStatus.mockImplementation(() =>
+  t.success({
+    status: 200,
+    value: {
+      id: "bar",
+      is_revoked: "false",
+    },
+  })
+);
+
 mockSetWalletInstanceStatus.mockImplementation(() =>
   t.success({
     status: 204,
@@ -62,6 +72,8 @@ mockSetCurrentWalletInstanceStatus.mockImplementation(() =>
   })
 );
 
+const mockDeleteWalletInstances = jest.fn();
+
 const api = {
   getEntityConfiguration: mockGetEntityConfiguration,
   getNonce: mockGetNonce,
@@ -72,6 +84,7 @@ const api = {
   getCurrentWalletInstanceStatus: mockGetCurrentWalletInstanceStatus,
   setWalletInstanceStatus: mockSetWalletInstanceStatus,
   setCurrentWalletInstanceStatus: mockSetCurrentWalletInstanceStatus,
+  deleteWalletInstances: mockDeleteWalletInstances,
 };
 
 const mockCreateSubscription = jest.fn();
@@ -755,6 +768,133 @@ describe("IoWalletService#getWalletInstanceStatus", () => {
     const service = new IoWalletService(api, trialSystemApi);
 
     const res = await service.getWalletInstanceStatus(aId, aFiscalCode);
+
+    expect(res).toMatchObject({
+      kind: "IResponseErrorInternal",
+    });
+  });
+});
+
+describe("IoWalletService#getCurrentWalletInstanceStatus", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should make the correct api call", async () => {
+    const service = new IoWalletService(api, trialSystemApi);
+
+    await service.getCurrentWalletInstanceStatus(aFiscalCode);
+
+    expect(mockGetWalletInstanceStatus).toHaveBeenCalledWith({
+      id: aId,
+      "fiscal-code": aFiscalCode,
+    });
+  });
+
+  it("should handle a success response", async () => {
+    const service = new IoWalletService(api, trialSystemApi);
+
+    const res = await service.getCurrentWalletInstanceStatus(aFiscalCode);
+
+    expect(res).toMatchObject({
+      kind: "IResponseSuccessJson",
+    });
+  });
+
+  it("should handle an internal error when the API client returns 400", async () => {
+    mockGetWalletInstanceStatus.mockImplementationOnce(() =>
+      t.success({ status: 400 })
+    );
+
+    const service = new IoWalletService(api, trialSystemApi);
+
+    const res = await service.getCurrentWalletInstanceStatus(aFiscalCode);
+
+    expect(res).toMatchObject({
+      kind: "IResponseErrorInternal",
+    });
+  });
+
+  it("should handle a not found error when the API client returns 404", async () => {
+    mockGetWalletInstanceStatus.mockImplementationOnce(() =>
+      t.success({ status: 404 })
+    );
+
+    const service = new IoWalletService(api, trialSystemApi);
+
+    const res = await service.getCurrentWalletInstanceStatus(aFiscalCode);
+
+    expect(res).toMatchObject({
+      kind: "IResponseErrorNotFound",
+    });
+  });
+
+  it("should handle an internal error when the API client returns 422", async () => {
+    mockGetWalletInstanceStatus.mockImplementationOnce(() =>
+      t.success({ status: 422 })
+    );
+
+    const service = new IoWalletService(api, trialSystemApi);
+
+    const res = await service.getCurrentWalletInstanceStatus(aFiscalCode);
+
+    expect(res).toMatchObject({
+      kind: "IResponseErrorInternal",
+    });
+  });
+
+  it("should handle an internal error when the API client returns 500", async () => {
+    const aGenericProblem = {};
+    mockGetWalletInstanceStatus.mockImplementationOnce(() =>
+      t.success({ status: 500, value: aGenericProblem })
+    );
+
+    const service = new IoWalletService(api, trialSystemApi);
+
+    const res = await service.getCurrentWalletInstanceStatus(aFiscalCode);
+
+    expect(res).toMatchObject({
+      kind: "IResponseErrorInternal",
+    });
+  });
+
+  it("should handle a service unavailable error when the API client returns 503", async () => {
+    const aGenericProblem = {};
+    mockGetWalletInstanceStatus.mockImplementationOnce(() =>
+      t.success({ status: 503, value: aGenericProblem })
+    );
+
+    const service = new IoWalletService(api, trialSystemApi);
+
+    const res = await service.getCurrentWalletInstanceStatus(aFiscalCode);
+
+    expect(res).toMatchObject({
+      kind: "IResponseErrorServiceUnavailable",
+    });
+  });
+
+  it("should handle an internal error when the API client returns a code not specified in spec", async () => {
+    const aGenericProblem = {};
+    mockGetWalletInstanceStatus.mockImplementationOnce(() =>
+      t.success({ status: 599, value: aGenericProblem })
+    );
+
+    const service = new IoWalletService(api, trialSystemApi);
+
+    const res = await service.getCurrentWalletInstanceStatus(aFiscalCode);
+
+    expect(res).toMatchObject({
+      kind: "IResponseErrorInternal",
+    });
+  });
+
+  it("should return an error if the api call throws an error", async () => {
+    mockGetWalletInstanceStatus.mockImplementationOnce(() => {
+      throw new Error();
+    });
+    const service = new IoWalletService(api, trialSystemApi);
+
+    const res = await service.getCurrentWalletInstanceStatus(aFiscalCode);
 
     expect(res).toMatchObject({
       kind: "IResponseErrorInternal",

--- a/src/services/ioWalletService.ts
+++ b/src/services/ioWalletService.ts
@@ -281,7 +281,7 @@ export default class IoWalletService {
     });
 
   /**
-   * Get current Wallet Instance status.
+   * Get Wallet Instance status by ID.
    */
   public readonly getWalletInstanceStatus = (
     id: NonEmptyString,
@@ -297,6 +297,48 @@ export default class IoWalletService {
         "fiscal-code": fiscal_code,
         id
       });
+      return withValidatedOrInternalError(validated, (response) => {
+        switch (response.status) {
+          case 200:
+            return ResponseSuccessJson(response.value);
+          case 404:
+            return ResponseErrorNotFound(
+              "Not Found",
+              "Wallet instance not found"
+            );
+          case 400:
+          case 422:
+          case 500:
+            return ResponseErrorInternal(
+              `Internal server error | ${response.value}`
+            );
+          case 503:
+            return ResponseErrorServiceTemporarilyUnavailable(
+              serviceUnavailableDetail,
+              "10"
+            );
+          default:
+            return ResponseErrorStatusNotDefinedInSpec(response);
+        }
+      });
+    });
+
+  /**
+   * Get Current Wallet Instance Status
+   */
+  public readonly getCurrentWalletInstanceStatus = (
+    fiscal_code: FiscalCode
+  ): Promise<
+    | IResponseSuccessJson<WalletInstanceData>
+    | IResponseErrorNotFound
+    | IResponseErrorInternal
+    | IResponseErrorServiceUnavailable
+  > =>
+    withCatchAsInternalError(async () => {
+      const validated =
+        await this.ioWalletApiClient.getCurrentWalletInstanceStatus({
+          "fiscal-code": fiscal_code
+        });
       return withValidatedOrInternalError(validated, (response) => {
         switch (response.status) {
           case 200:


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

I added an endpoint in io-backend (`ioWalletRoutes.ts)` that calls the GetCurrentWalletInstanceStatus API, exposed by the `io-wallet-user-func`, into the `io-wallet` repository.  Then, I added the `getCurrentWalletInstanceStatus()` method in `ioWalletController.ts` and `ioWalletService.ts`.

#### Motivation and Context

The current `WalletInstance` is required on the mobile app side, however there was no endpoint in `io-backend` that returned it yet.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

- [ ] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
