### PR TITLE
[SIW-2188] Added the isFiscalCodeWhitelisted() endpoint to check if the fiscal code is whitelisted

### DIFF
--- a/.changeset/quick-radios-brush.md
+++ b/.changeset/quick-radios-brush.md
@@ -2,4 +2,4 @@
 "@pagopa/io-backend": minor
 ---
 
-Added GET /whitelisted-fiscal-code/{fiscalCode} endpoint to check if the fiscal code is whitelisted
+Added GET /whitelisted-fiscal-code/{fiscalCode} IO Wallet endpoint to check if the fiscal code is whitelisted

--- a/.changeset/quick-radios-brush.md
+++ b/.changeset/quick-radios-brush.md
@@ -1,0 +1,5 @@
+---
+"@pagopa/io-backend": minor
+---
+
+Added GET /whitelisted-fiscal-code/{fiscalCode} endpoint to check if the fiscal code is whitelisted

--- a/api_io_wallet.yaml
+++ b/api_io_wallet.yaml
@@ -152,6 +152,22 @@ paths:
           $ref: "#/components/responses/Unexpected"
         "503":
           $ref: "#/components/responses/ServiceUnavailable"
+  
+  /whitelist-TODO:
+    get:
+      operationId: IsFiscalCodeWhitelisted
+      summary: Used to check if the fiscal code is in the whitelist
+      responses:
+        "200":
+          description: Returned when no issues were found in either case (fiscal code whitelisted, or not)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WhitelistedFiscalCodeData"
+        "500":
+          $ref: "#/components/responses/Unexpected"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
 
 components:
   securitySchemes:
@@ -286,6 +302,26 @@ components:
       required:
         - id
         - is_revoked
+
+    WhitelistedFiscalCodeData:
+      type: object
+      required:
+        - whitelisted
+        - fiscalCode
+      properties:
+        whitelisted:
+          type: boolean
+          description: |-
+            Boolean value that specifies whether the tax code is whitelisted or not.
+        whitelistedAt:
+          type: string
+          description: |-
+            Date, expressed in ISO 8601 format, when the fiscal code was added to the whitelist.
+            Only present if the fiscal code is whitelisted.
+        fiscalCode:
+          type: string
+          description: |-
+            The fiscal code, the same one passed in input.
 
     RevocationReason:
       type: string

--- a/api_io_wallet.yaml
+++ b/api_io_wallet.yaml
@@ -153,7 +153,7 @@ paths:
         "503":
           $ref: "#/components/responses/ServiceUnavailable"
   
-  /whitelist-TODO:
+  /whitelisted-fiscal-code/{fiscalCode}:
     get:
       operationId: IsFiscalCodeWhitelisted
       summary: Used to check if the fiscal code is in the whitelist

--- a/api_io_wallet.yaml
+++ b/api_io_wallet.yaml
@@ -153,13 +153,7 @@ paths:
         "503":
           $ref: "#/components/responses/ServiceUnavailable"
   
-  /whitelisted-fiscal-code/{fiscalCode}:
-    parameters:
-      - in: path
-        name: fiscalCode
-        required: true
-        schema:
-          $ref: "#/components/schemas/FiscalCode"
+  /whitelisted-fiscal-code:
     get:
       operationId: isFiscalCodeWhitelisted
       summary: Used to check if the fiscal code is in the whitelist
@@ -378,10 +372,3 @@ components:
             An absolute URI that identifies the specific occurrence of the
             problem. It may or may not yield further information if
             dereferenced.
-
-    FiscalCode:
-        type: string
-        description: User's fiscal code.
-        format: FiscalCode
-        x-import: "@pagopa/ts-commons/lib/strings"
-        example: SPNDNL80R13C555X

--- a/api_io_wallet.yaml
+++ b/api_io_wallet.yaml
@@ -154,6 +154,12 @@ paths:
           $ref: "#/components/responses/ServiceUnavailable"
   
   /whitelisted-fiscal-code/{fiscalCode}:
+    parameters:
+      - in: path
+        name: fiscalCode
+        required: true
+        schema:
+          $ref: "#/components/schemas/FiscalCode"
     get:
       operationId: IsFiscalCodeWhitelisted
       summary: Used to check if the fiscal code is in the whitelist
@@ -372,3 +378,10 @@ components:
             An absolute URI that identifies the specific occurrence of the
             problem. It may or may not yield further information if
             dereferenced.
+
+    FiscalCode:
+        type: string
+        description: User's fiscal code.
+        format: FiscalCode
+        x-import: "@pagopa/ts-commons/lib/strings"
+        example: SPNDNL80R13C555X

--- a/api_io_wallet.yaml
+++ b/api_io_wallet.yaml
@@ -161,7 +161,7 @@ paths:
         schema:
           $ref: "#/components/schemas/FiscalCode"
     get:
-      operationId: IsFiscalCodeWhitelisted
+      operationId: isFiscalCodeWhitelisted
       summary: Used to check if the fiscal code is in the whitelist
       responses:
         "200":

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "generate:proxy:api-session": "rimraf generated/session && gen-api-models --api-spec api_session.yaml --out-dir generated/session",
     "generate:lollipop-definitions": "rimraf generated/lollipop && gen-api-models --api-spec openapi/lollipop_definitions.yaml --out-dir generated/lollipop",
     "generate:lollipop-first-sign": "rimraf generated/lollipop-first-consumer && gen-api-models --api-spec openapi/consumed/lollipop_first_consumer.yaml --out-dir generated/lollipop-first-consumer --request-types --response-decoders --client",
-    "generate:api:io-wallet": "rimraf generated/io-wallet-api && gen-api-models --api-spec https://raw.githubusercontent.com/pagopa/io-wallet/io-wallet-user-func@3.2.0/apps/io-wallet-user-func/openapi.yaml --no-strict --out-dir generated/io-wallet-api --request-types --response-decoders --client",
+    "generate:api:io-wallet": "rimraf generated/io-wallet-api && gen-api-models --api-spec https://raw.githubusercontent.com/pagopa/io-wallet/io-wallet-user-func@3.2.1/apps/io-wallet-user-func/openapi.yaml --no-strict --out-dir generated/io-wallet-api --request-types --response-decoders --client",
     "generate:proxy:io-wallet-models": "rimraf generated/io-wallet && gen-api-models --api-spec api_io_wallet.yaml --out-dir generated/io-wallet",
     "dist:modules": "modclean -r -n default:safe && yarn install --production",
     "predeploy": "npm-run-all generate build dist:modules",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "generate:proxy:api-session": "rimraf generated/session && gen-api-models --api-spec api_session.yaml --out-dir generated/session",
     "generate:lollipop-definitions": "rimraf generated/lollipop && gen-api-models --api-spec openapi/lollipop_definitions.yaml --out-dir generated/lollipop",
     "generate:lollipop-first-sign": "rimraf generated/lollipop-first-consumer && gen-api-models --api-spec openapi/consumed/lollipop_first_consumer.yaml --out-dir generated/lollipop-first-consumer --request-types --response-decoders --client",
-    "generate:api:io-wallet": "rimraf generated/io-wallet-api && gen-api-models --api-spec https://raw.githubusercontent.com/pagopa/io-wallet/io-wallet-user-func@3.0.4/apps/io-wallet-user-func/openapi.yaml --no-strict --out-dir generated/io-wallet-api --request-types --response-decoders --client",
+    "generate:api:io-wallet": "rimraf generated/io-wallet-api && gen-api-models --api-spec https://raw.githubusercontent.com/pagopa/io-wallet/io-wallet-user-func@3.2.0/apps/io-wallet-user-func/openapi.yaml --no-strict --out-dir generated/io-wallet-api --request-types --response-decoders --client",
     "generate:proxy:io-wallet-models": "rimraf generated/io-wallet && gen-api-models --api-spec api_io_wallet.yaml --out-dir generated/io-wallet",
     "dist:modules": "modclean -r -n default:safe && yarn install --production",
     "predeploy": "npm-run-all generate build dist:modules",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "generate:proxy:api-session": "rimraf generated/session && gen-api-models --api-spec api_session.yaml --out-dir generated/session",
     "generate:lollipop-definitions": "rimraf generated/lollipop && gen-api-models --api-spec openapi/lollipop_definitions.yaml --out-dir generated/lollipop",
     "generate:lollipop-first-sign": "rimraf generated/lollipop-first-consumer && gen-api-models --api-spec openapi/consumed/lollipop_first_consumer.yaml --out-dir generated/lollipop-first-consumer --request-types --response-decoders --client",
-    "generate:api:io-wallet": "rimraf generated/io-wallet-api && gen-api-models --api-spec https://raw.githubusercontent.com/pagopa/io-wallet/io-wallet-user-func@3.2.1/apps/io-wallet-user-func/openapi.yaml --no-strict --out-dir generated/io-wallet-api --request-types --response-decoders --client",
+    "generate:api:io-wallet": "rimraf generated/io-wallet-api && gen-api-models --api-spec https://raw.githubusercontent.com/pagopa/io-wallet/io-wallet-user-func@3.2.2/apps/io-wallet-user-func/openapi.yaml --no-strict --out-dir generated/io-wallet-api --request-types --response-decoders --client",
     "generate:proxy:io-wallet-models": "rimraf generated/io-wallet && gen-api-models --api-spec api_io_wallet.yaml --out-dir generated/io-wallet",
     "dist:modules": "modclean -r -n default:safe && yarn install --production",
     "predeploy": "npm-run-all generate build dist:modules",

--- a/src/controllers/ioWalletController.ts
+++ b/src/controllers/ioWalletController.ts
@@ -235,7 +235,7 @@ export default class IoWalletController {
     );
 
   /**
-   * Check if a fiscal code is whitelisted, or not.
+   * Check if a fiscal code is whitelisted or not.
    */
   public readonly isFiscalCodeWhitelisted = (
     req: express.Request
@@ -244,21 +244,9 @@ export default class IoWalletController {
     | IResponseErrorInternal
     | IResponseErrorServiceUnavailable
     | IResponseErrorValidation
-    | IResponseErrorForbiddenNotAuthorized
   > =>
-    withUserFromRequest(req, async () =>
-      pipe(
-        pipe(
-          req.params.fiscalCode,
-          FiscalCode.decode,
-          E.mapLeft(toValidationError),
-          TE.fromEither
-        ),
-        TE.map((fiscalCode) =>
-          this.ioWalletService.isFiscalCodeWhitelisted(fiscalCode)
-        ),
-        TE.toUnion
-      )()
+    withUserFromRequest(req, async (user) =>
+      this.ioWalletService.isFiscalCodeWhitelisted(user.fiscal_code)
     );
 
   private readonly ensureFiscalCodeIsAllowed = (fiscalCode: FiscalCode) =>

--- a/src/controllers/ioWalletController.ts
+++ b/src/controllers/ioWalletController.ts
@@ -30,7 +30,7 @@ import { NonceDetailView } from "../../generated/io-wallet/NonceDetailView";
 import { SetWalletInstanceStatusBody } from "../../generated/io-wallet/SetWalletInstanceStatusBody";
 import { WalletAttestationView } from "../../generated/io-wallet/WalletAttestationView";
 import { WalletInstanceData } from "../../generated/io-wallet/WalletInstanceData";
-import { WhitelistedFiscalCodeData } from "../../generated/io-wallet-api/WhitelistedFiscalCodeData";
+import { WhitelistedFiscalCodeData } from "../../generated/io-wallet/WhitelistedFiscalCodeData";
 import { FF_IO_WALLET_TRIAL_ENABLED } from "../config";
 import IoWalletService from "../services/ioWalletService";
 import { withUserFromRequest } from "../types/user";

--- a/src/controllers/ioWalletController.ts
+++ b/src/controllers/ioWalletController.ts
@@ -246,16 +246,13 @@ export default class IoWalletController {
     | IResponseErrorValidation
     | IResponseErrorForbiddenNotAuthorized
   > =>
-    withUserFromRequest(req, async (user) =>
+    withUserFromRequest(req, async () =>
       pipe(
-        this.ensureFiscalCodeIsAllowed(user.fiscal_code),
-        TE.chainW(() =>
-          pipe(
-            req.params.fiscalCode,
-            FiscalCode.decode,
-            E.mapLeft(toValidationError),
-            TE.fromEither
-          )
+        pipe(
+          req.params.fiscalCode,
+          FiscalCode.decode,
+          E.mapLeft(toValidationError),
+          TE.fromEither
         ),
         TE.map((fiscalCode) =>
           this.ioWalletService.isFiscalCodeWhitelisted(fiscalCode)

--- a/src/routes/ioWalletRoutes.ts
+++ b/src/routes/ioWalletRoutes.ts
@@ -73,7 +73,7 @@ export const registerIoWalletAPIRoutes = (
   );
 
   app.get(
-    `${basePath}/whitelisted-fiscal-code/:fiscalCode`,
+    `${basePath}/whitelisted-fiscal-code`,
     bearerSessionTokenAuth,
     toExpressHandler(
       ioWalletController.isFiscalCodeWhitelisted,

--- a/src/routes/ioWalletRoutes.ts
+++ b/src/routes/ioWalletRoutes.ts
@@ -71,4 +71,13 @@ export const registerIoWalletAPIRoutes = (
       ioWalletController
     )
   );
+
+  app.get(
+    `${basePath}/whitelisted-fiscal-code/:fiscalCode`,
+    bearerSessionTokenAuth,
+    toExpressHandler(
+      ioWalletController.isFiscalCodeWhitelisted,
+      ioWalletController
+    )
+  );
 };

--- a/src/services/__tests__/ioWalletService.test.ts
+++ b/src/services/__tests__/ioWalletService.test.ts
@@ -911,11 +911,40 @@ describe("IoWalletService#getSubscription", () => {
         kind: "IResponseSuccessJson",
       });
     });
-  
+
     it("should handle an internal error when the API client returns 500", async () => {
       const aGenericProblem = {};
       mockIsFiscalCodeWhitelisted.mockImplementationOnce(() =>
         t.success({ status: 500, value: aGenericProblem })
+      );
+  
+      const service = new IoWalletService(api, trialSystemApi);
+  
+      const res = await service.isFiscalCodeWhitelisted(aFiscalCode);
+  
+      expect(res).toMatchObject({
+        kind: "IResponseErrorInternal",
+      });
+    });
+  
+    it("should handle a bad request when the API client returns 400", async () => {
+      const aGenericProblem = {};
+      mockIsFiscalCodeWhitelisted.mockImplementationOnce(() =>
+        t.success({ status: 400, value: aGenericProblem })
+      );
+  
+      const service = new IoWalletService(api, trialSystemApi);
+  
+      const res = await service.isFiscalCodeWhitelisted(aFiscalCode);
+  
+      expect(res).toMatchObject({
+        kind: "IResponseErrorInternal",
+      });
+    });
+
+    it("should handle a bad request when the API client returns 422", async () => {
+      mockIsFiscalCodeWhitelisted.mockImplementationOnce(() =>
+        t.success({ status: 422 })
       );
   
       const service = new IoWalletService(api, trialSystemApi);

--- a/src/services/__tests__/ioWalletService.test.ts
+++ b/src/services/__tests__/ioWalletService.test.ts
@@ -927,7 +927,7 @@ describe("IoWalletService#getSubscription", () => {
       });
     });
   
-    it("should handle a bad request when the API client returns 400", async () => {
+    it("should handle an internal error when the API client returns 400", async () => {
       const aGenericProblem = {};
       mockIsFiscalCodeWhitelisted.mockImplementationOnce(() =>
         t.success({ status: 400, value: aGenericProblem })
@@ -942,7 +942,7 @@ describe("IoWalletService#getSubscription", () => {
       });
     });
 
-    it("should handle a bad request when the API client returns 422", async () => {
+    it("should handle an internal error when the API client returns 422", async () => {
       mockIsFiscalCodeWhitelisted.mockImplementationOnce(() =>
         t.success({ status: 422 })
       );

--- a/src/services/__tests__/ioWalletService.test.ts
+++ b/src/services/__tests__/ioWalletService.test.ts
@@ -956,7 +956,7 @@ describe("IoWalletService#getSubscription", () => {
       });
     });
 
-    it("should handle a bad request when the API client returns 503", async () => {
+    it("should handle a service unavailable error when the API client returns 503", async () => {
       mockIsFiscalCodeWhitelisted.mockImplementationOnce(() =>
         t.success({ status: 503 })
       );

--- a/src/services/__tests__/ioWalletService.test.ts
+++ b/src/services/__tests__/ioWalletService.test.ts
@@ -895,17 +895,17 @@ describe("IoWalletService#getSubscription", () => {
     it("should make the correct api call", async () => {
       const service = new IoWalletService(api, trialSystemApi);
   
-      await service.isFiscalCodeWhitelisted("fiscalCode" as FiscalCode);
+      await service.isFiscalCodeWhitelisted(aFiscalCode);
   
       expect(mockIsFiscalCodeWhitelisted).toHaveBeenCalledWith({
-        fiscalCode: "fiscalCode",
+        fiscalCode: aFiscalCode,
       });
     });
   
     it("should handle a success response", async () => {
       const service = new IoWalletService(api, trialSystemApi);
   
-      const res = await service.isFiscalCodeWhitelisted("fiscalCode" as FiscalCode);
+      const res = await service.isFiscalCodeWhitelisted(aFiscalCode);
   
       expect(res).toMatchObject({
         kind: "IResponseSuccessJson",
@@ -920,7 +920,7 @@ describe("IoWalletService#getSubscription", () => {
   
       const service = new IoWalletService(api, trialSystemApi);
   
-      const res = await service.isFiscalCodeWhitelisted("fiscalCode" as FiscalCode);
+      const res = await service.isFiscalCodeWhitelisted(aFiscalCode);
   
       expect(res).toMatchObject({
         kind: "IResponseErrorInternal",
@@ -935,7 +935,7 @@ describe("IoWalletService#getSubscription", () => {
   
       const service = new IoWalletService(api, trialSystemApi);
   
-      const res = await service.isFiscalCodeWhitelisted("fiscalCode" as FiscalCode);
+      const res = await service.isFiscalCodeWhitelisted(aFiscalCode);
   
       expect(res).toMatchObject({
         kind: "IResponseErrorInternal",
@@ -948,7 +948,7 @@ describe("IoWalletService#getSubscription", () => {
       });
       const service = new IoWalletService(api, trialSystemApi);
   
-      const res = await service.isFiscalCodeWhitelisted("fiscalCode" as FiscalCode);
+      const res = await service.isFiscalCodeWhitelisted(aFiscalCode);
   
       expect(res).toMatchObject({
         kind: "IResponseErrorInternal",

--- a/src/services/__tests__/ioWalletService.test.ts
+++ b/src/services/__tests__/ioWalletService.test.ts
@@ -955,6 +955,20 @@ describe("IoWalletService#getSubscription", () => {
         kind: "IResponseErrorInternal",
       });
     });
+
+    it("should handle a bad request when the API client returns 503", async () => {
+      mockIsFiscalCodeWhitelisted.mockImplementationOnce(() =>
+        t.success({ status: 503 })
+      );
+  
+      const service = new IoWalletService(api, trialSystemApi);
+  
+      const res = await service.isFiscalCodeWhitelisted(aFiscalCode);
+  
+      expect(res).toMatchObject({
+        kind: "IResponseErrorServiceUnavailable",
+      });
+    });
   
     it("should handle an internal error when the API client returns a code not specified in spec", async () => {
       const aGenericProblem = {};

--- a/src/services/__tests__/ioWalletService.test.ts
+++ b/src/services/__tests__/ioWalletService.test.ts
@@ -788,6 +788,118 @@ describe("IoWalletService#getCurrentWalletInstanceStatus", () => {
   });
 });
 
+describe("IoWalletService#isFiscalCodeWhitelisted", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should make the correct api call", async () => {
+    const service = new IoWalletService(api, trialSystemApi);
+
+    await service.isFiscalCodeWhitelisted(aFiscalCode);
+
+    expect(mockIsFiscalCodeWhitelisted).toHaveBeenCalledWith({
+      fiscalCode: aFiscalCode,
+    });
+  });
+
+  it("should handle a success response", async () => {
+    const service = new IoWalletService(api, trialSystemApi);
+
+    const res = await service.isFiscalCodeWhitelisted(aFiscalCode);
+
+    expect(res).toMatchObject({
+      kind: "IResponseSuccessJson",
+    });
+  });
+
+  it("should handle an internal error when the API client returns 500", async () => {
+    const aGenericProblem = {};
+    mockIsFiscalCodeWhitelisted.mockImplementationOnce(() =>
+      t.success({ status: 500, value: aGenericProblem })
+    );
+
+    const service = new IoWalletService(api, trialSystemApi);
+
+    const res = await service.isFiscalCodeWhitelisted(aFiscalCode);
+
+    expect(res).toMatchObject({
+      kind: "IResponseErrorInternal",
+    });
+  });
+
+  it("should handle an internal error when the API client returns 400", async () => {
+    const aGenericProblem = {};
+    mockIsFiscalCodeWhitelisted.mockImplementationOnce(() =>
+      t.success({ status: 400, value: aGenericProblem })
+    );
+
+    const service = new IoWalletService(api, trialSystemApi);
+
+    const res = await service.isFiscalCodeWhitelisted(aFiscalCode);
+
+    expect(res).toMatchObject({
+      kind: "IResponseErrorInternal",
+    });
+  });
+
+  it("should handle an internal error when the API client returns 422", async () => {
+    mockIsFiscalCodeWhitelisted.mockImplementationOnce(() =>
+      t.success({ status: 422 })
+    );
+
+    const service = new IoWalletService(api, trialSystemApi);
+
+    const res = await service.isFiscalCodeWhitelisted(aFiscalCode);
+
+    expect(res).toMatchObject({
+      kind: "IResponseErrorInternal",
+    });
+  });
+
+  it("should handle a service unavailable error when the API client returns 503", async () => {
+    mockIsFiscalCodeWhitelisted.mockImplementationOnce(() =>
+      t.success({ status: 503 })
+    );
+
+    const service = new IoWalletService(api, trialSystemApi);
+
+    const res = await service.isFiscalCodeWhitelisted(aFiscalCode);
+
+    expect(res).toMatchObject({
+      kind: "IResponseErrorServiceUnavailable",
+    });
+  });
+
+  it("should handle an internal error when the API client returns a code not specified in spec", async () => {
+    const aGenericProblem = {};
+    mockIsFiscalCodeWhitelisted.mockImplementationOnce(() =>
+      t.success({ status: 599, value: aGenericProblem })
+    );
+
+    const service = new IoWalletService(api, trialSystemApi);
+
+    const res = await service.isFiscalCodeWhitelisted(aFiscalCode);
+
+    expect(res).toMatchObject({
+      kind: "IResponseErrorInternal",
+    });
+  });
+
+  it("should return an error if the api call throws an error", async () => {
+    mockIsFiscalCodeWhitelisted.mockImplementationOnce(() => {
+      throw new Error();
+    });
+    const service = new IoWalletService(api, trialSystemApi);
+
+    const res = await service.isFiscalCodeWhitelisted(aFiscalCode);
+
+    expect(res).toMatchObject({
+      kind: "IResponseErrorInternal",
+    });
+  });
+});
+
 describe("IoWalletService#getSubscription", () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -884,118 +996,6 @@ describe("IoWalletService#getSubscription", () => {
 
     expect(res).toMatchObject({
       kind: "IResponseErrorInternal",
-    });
-  });
-
-  describe("IoWalletService#isFiscalCodeWhitelisted", () => {
-    beforeEach(() => {
-      jest.clearAllMocks();
-    });
-  
-    it("should make the correct api call", async () => {
-      const service = new IoWalletService(api, trialSystemApi);
-  
-      await service.isFiscalCodeWhitelisted(aFiscalCode);
-  
-      expect(mockIsFiscalCodeWhitelisted).toHaveBeenCalledWith({
-        fiscalCode: aFiscalCode,
-      });
-    });
-  
-    it("should handle a success response", async () => {
-      const service = new IoWalletService(api, trialSystemApi);
-  
-      const res = await service.isFiscalCodeWhitelisted(aFiscalCode);
-  
-      expect(res).toMatchObject({
-        kind: "IResponseSuccessJson",
-      });
-    });
-
-    it("should handle an internal error when the API client returns 500", async () => {
-      const aGenericProblem = {};
-      mockIsFiscalCodeWhitelisted.mockImplementationOnce(() =>
-        t.success({ status: 500, value: aGenericProblem })
-      );
-  
-      const service = new IoWalletService(api, trialSystemApi);
-  
-      const res = await service.isFiscalCodeWhitelisted(aFiscalCode);
-  
-      expect(res).toMatchObject({
-        kind: "IResponseErrorInternal",
-      });
-    });
-  
-    it("should handle an internal error when the API client returns 400", async () => {
-      const aGenericProblem = {};
-      mockIsFiscalCodeWhitelisted.mockImplementationOnce(() =>
-        t.success({ status: 400, value: aGenericProblem })
-      );
-  
-      const service = new IoWalletService(api, trialSystemApi);
-  
-      const res = await service.isFiscalCodeWhitelisted(aFiscalCode);
-  
-      expect(res).toMatchObject({
-        kind: "IResponseErrorInternal",
-      });
-    });
-
-    it("should handle an internal error when the API client returns 422", async () => {
-      mockIsFiscalCodeWhitelisted.mockImplementationOnce(() =>
-        t.success({ status: 422 })
-      );
-  
-      const service = new IoWalletService(api, trialSystemApi);
-  
-      const res = await service.isFiscalCodeWhitelisted(aFiscalCode);
-  
-      expect(res).toMatchObject({
-        kind: "IResponseErrorInternal",
-      });
-    });
-
-    it("should handle a service unavailable error when the API client returns 503", async () => {
-      mockIsFiscalCodeWhitelisted.mockImplementationOnce(() =>
-        t.success({ status: 503 })
-      );
-  
-      const service = new IoWalletService(api, trialSystemApi);
-  
-      const res = await service.isFiscalCodeWhitelisted(aFiscalCode);
-  
-      expect(res).toMatchObject({
-        kind: "IResponseErrorServiceUnavailable",
-      });
-    });
-  
-    it("should handle an internal error when the API client returns a code not specified in spec", async () => {
-      const aGenericProblem = {};
-      mockIsFiscalCodeWhitelisted.mockImplementationOnce(() =>
-        t.success({ status: 599, value: aGenericProblem })
-      );
-  
-      const service = new IoWalletService(api, trialSystemApi);
-  
-      const res = await service.isFiscalCodeWhitelisted(aFiscalCode);
-  
-      expect(res).toMatchObject({
-        kind: "IResponseErrorInternal",
-      });
-    });
-  
-    it("should return an error if the api call throws an error", async () => {
-      mockIsFiscalCodeWhitelisted.mockImplementationOnce(() => {
-        throw new Error();
-      });
-      const service = new IoWalletService(api, trialSystemApi);
-  
-      const res = await service.isFiscalCodeWhitelisted(aFiscalCode);
-  
-      expect(res).toMatchObject({
-        kind: "IResponseErrorInternal",
-      });
     });
   });
 });

--- a/src/services/__tests__/ioWalletService.test.ts
+++ b/src/services/__tests__/ioWalletService.test.ts
@@ -92,7 +92,7 @@ const api = {
   setWalletInstanceStatus: mockSetWalletInstanceStatus,
   deleteWalletInstances: mockDeleteWalletInstances,
   getCurrentWalletInstanceStatus: mockGetCurrentWalletInstanceStatus,
-  IsFiscalCodeWhitelisted: mockIsFiscalCodeWhitelisted,
+  isFiscalCodeWhitelisted: mockIsFiscalCodeWhitelisted,
 };
 
 const mockCreateSubscription = jest.fn();

--- a/src/services/__tests__/ioWalletService.test.ts
+++ b/src/services/__tests__/ioWalletService.test.ts
@@ -16,6 +16,8 @@ const mockGetWalletInstanceStatus = jest.fn();
 const mockGetCurrentWalletInstanceStatus = jest.fn();
 const mockSetWalletInstanceStatus = jest.fn();
 const mockDeleteWalletInstances = jest.fn();
+const mockIsFiscalCodeWhitelisted = jest.fn();
+const mockCreateWalletAttestationV2 = jest.fn();
 
 mockGetNonce.mockImplementation(() =>
   t.success({
@@ -67,16 +69,30 @@ mockSetWalletInstanceStatus.mockImplementation(() =>
   })
 );
 
+mockIsFiscalCodeWhitelisted.mockImplementation(() =>
+  t.success({
+    status: 200,
+  })
+);
+
+mockCreateWalletAttestationV2.mockImplementation(() =>
+  t.success({
+    status: 201,
+  })
+);
+
 const api = {
   getEntityConfiguration: mockGetEntityConfiguration,
   getNonce: mockGetNonce,
   createWalletInstance: mockCreateWalletInstance,
   createWalletAttestation: mockCreateWalletAttestation,
+  createWalletAttestationV2: mockCreateWalletAttestationV2,
   healthCheck: mockHealthCheck,
   getWalletInstanceStatus: mockGetWalletInstanceStatus,
   setWalletInstanceStatus: mockSetWalletInstanceStatus,
   deleteWalletInstances: mockDeleteWalletInstances,
   getCurrentWalletInstanceStatus: mockGetCurrentWalletInstanceStatus,
+  IsFiscalCodeWhitelisted: mockIsFiscalCodeWhitelisted,
 };
 
 const mockCreateSubscription = jest.fn();
@@ -868,6 +884,75 @@ describe("IoWalletService#getSubscription", () => {
 
     expect(res).toMatchObject({
       kind: "IResponseErrorInternal",
+    });
+  });
+
+  describe("IoWalletService#isFiscalCodeWhitelisted", () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+  
+    it("should make the correct api call", async () => {
+      const service = new IoWalletService(api, trialSystemApi);
+  
+      await service.isFiscalCodeWhitelisted("fiscalCode" as FiscalCode);
+  
+      expect(mockIsFiscalCodeWhitelisted).toHaveBeenCalledWith({
+        fiscalCode: "fiscalCode",
+      });
+    });
+  
+    it("should handle a success response", async () => {
+      const service = new IoWalletService(api, trialSystemApi);
+  
+      const res = await service.isFiscalCodeWhitelisted("fiscalCode" as FiscalCode);
+  
+      expect(res).toMatchObject({
+        kind: "IResponseSuccessJson",
+      });
+    });
+  
+    it("should handle an internal error when the API client returns 500", async () => {
+      const aGenericProblem = {};
+      mockIsFiscalCodeWhitelisted.mockImplementationOnce(() =>
+        t.success({ status: 500, value: aGenericProblem })
+      );
+  
+      const service = new IoWalletService(api, trialSystemApi);
+  
+      const res = await service.isFiscalCodeWhitelisted("fiscalCode" as FiscalCode);
+  
+      expect(res).toMatchObject({
+        kind: "IResponseErrorInternal",
+      });
+    });
+  
+    it("should handle an internal error when the API client returns a code not specified in spec", async () => {
+      const aGenericProblem = {};
+      mockIsFiscalCodeWhitelisted.mockImplementationOnce(() =>
+        t.success({ status: 599, value: aGenericProblem })
+      );
+  
+      const service = new IoWalletService(api, trialSystemApi);
+  
+      const res = await service.isFiscalCodeWhitelisted("fiscalCode" as FiscalCode);
+  
+      expect(res).toMatchObject({
+        kind: "IResponseErrorInternal",
+      });
+    });
+  
+    it("should return an error if the api call throws an error", async () => {
+      mockIsFiscalCodeWhitelisted.mockImplementationOnce(() => {
+        throw new Error();
+      });
+      const service = new IoWalletService(api, trialSystemApi);
+  
+      const res = await service.isFiscalCodeWhitelisted("fiscalCode" as FiscalCode);
+  
+      expect(res).toMatchObject({
+        kind: "IResponseErrorInternal",
+      });
     });
   });
 });

--- a/src/services/ioWalletService.ts
+++ b/src/services/ioWalletService.ts
@@ -21,9 +21,9 @@ import {
 import { FiscalCode, NonEmptyString } from "@pagopa/ts-commons/lib/strings";
 import * as O from "fp-ts/Option";
 import { pipe } from "fp-ts/lib/function";
+import { WhitelistedFiscalCodeData } from "generated/io-wallet/WhitelistedFiscalCodeData";
 import { Grant_typeEnum } from "generated/io-wallet-api/CreateWalletAttestationBody";
 import { NonceDetailView } from "generated/io-wallet-api/NonceDetailView";
-import { WhitelistedFiscalCodeData } from "generated/io-wallet-api/WhitelistedFiscalCodeData";
 
 import { SetWalletInstanceStatusWithFiscalCodeData } from "../../generated/io-wallet-api/SetWalletInstanceStatusWithFiscalCodeData";
 import { WalletAttestationView } from "../../generated/io-wallet-api/WalletAttestationView";

--- a/src/services/ioWalletService.ts
+++ b/src/services/ioWalletService.ts
@@ -392,6 +392,11 @@ export default class IoWalletService {
             return ResponseErrorInternal(
               `Internal server error | ${response.value}`
             );
+          case 503:
+            return ResponseErrorServiceTemporarilyUnavailable(
+              serviceUnavailableDetail,
+              "10"
+            );
           default:
             return ResponseErrorStatusNotDefinedInSpec(response);
         }

--- a/src/services/ioWalletService.ts
+++ b/src/services/ioWalletService.ts
@@ -369,7 +369,7 @@ export default class IoWalletService {
     });
 
   /**
-   * Check if the fiscal code is whitelisted, or not.
+   * Check if the fiscal code is whitelisted or not.
    */
   public readonly isFiscalCodeWhitelisted = (
     fiscalCode: FiscalCode

--- a/src/services/ioWalletService.ts
+++ b/src/services/ioWalletService.ts
@@ -21,9 +21,9 @@ import {
 import { FiscalCode, NonEmptyString } from "@pagopa/ts-commons/lib/strings";
 import * as O from "fp-ts/Option";
 import { pipe } from "fp-ts/lib/function";
-import { WhitelistedFiscalCodeData } from "generated/io-wallet/WhitelistedFiscalCodeData";
 import { Grant_typeEnum } from "generated/io-wallet-api/CreateWalletAttestationBody";
 import { NonceDetailView } from "generated/io-wallet-api/NonceDetailView";
+import { WhitelistedFiscalCodeData } from "generated/io-wallet-api/WhitelistedFiscalCodeData";
 
 import { SetWalletInstanceStatusWithFiscalCodeData } from "../../generated/io-wallet-api/SetWalletInstanceStatusWithFiscalCodeData";
 import { WalletAttestationView } from "../../generated/io-wallet-api/WalletAttestationView";

--- a/src/services/ioWalletService.ts
+++ b/src/services/ioWalletService.ts
@@ -379,7 +379,7 @@ export default class IoWalletService {
     | IResponseErrorServiceUnavailable
   > =>
     withCatchAsInternalError(async () => {
-      const validated = await this.ioWalletApiClient.IsFiscalCodeWhitelisted({
+      const validated = await this.ioWalletApiClient.isFiscalCodeWhitelisted({
         fiscalCode
       });
       return withValidatedOrInternalError(validated, (response) => {


### PR DESCRIPTION
#### List of Changes

I've added:
- A new route in `ioWalletRoutes.ts`.
- A new method in `ioWalletController.ts` called `isFiscalCodeWhitelisted()`.
- A new method in `ioWalletService.ts` called `isFiscalCodeWhitelisted()`.
- The unit tests for the `isFiscalCodeWhitelisted()` in `ioWaleltService.test.ts`.

I've updated:
- The version of `io-wallet-user-func` azure function in `package.json` to generate new API and models.

#### Motivation and Context

The new endpoint is necessary for the simplified trial system development.

#### How Has This Been Tested?

Adding and running unit tests for the new endpoint.

#### Screenshots (if appropriate):

#### Types of changes
- [ ] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.