### PR TITLE
[#IEG-2711] Removed legacy TEST_CGN_FISCAL_CODES

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -53,8 +53,6 @@ CGN_API_KEY=put_your_api_key_here
 CGN_API_URL=http://host.docker.internal:7073
 CGN_API_BASE_PATH="/api/v1/cgn"
 
-TEST_CGN_FISCAL_CODES=
-
 CGN_OPERATOR_SEARCH_API_KEY=put_your_api_key_here
 CGN_OPERATOR_SEARCH_API_URL=http://host.docker.internal:7074
 CGN_OPERATOR_SEARCH_API_BASE_PATH="/api/v1/cgn/operator-search"

--- a/src/config.ts
+++ b/src/config.ts
@@ -396,16 +396,6 @@ export const FF_CDC_ENABLED = process.env.FF_CDC_ENABLED === "1";
 export const FF_IO_SIGN_ENABLED = process.env.FF_IO_SIGN_ENABLED === "1";
 export const FF_IO_FIMS_ENABLED = process.env.FF_IO_FIMS_ENABLED === "1";
 
-export const TEST_CGN_FISCAL_CODES = pipe(
-  process.env.TEST_CGN_FISCAL_CODES || "",
-  CommaSeparatedListOf(FiscalCode).decode,
-  E.getOrElseW((err) => {
-    throw new Error(
-      `Invalid TEST_CGN_FISCAL_CODES value: ${readableReport(err)}`
-    );
-  })
-);
-
 // PEC SERVER config
 export const PecServerConfig = t.interface({
   basePath: t.string,

--- a/src/controllers/__tests__/cgnController.test.ts
+++ b/src/controllers/__tests__/cgnController.test.ts
@@ -2,7 +2,7 @@ import {
   ResponseSuccessAccepted,
   ResponseSuccessJson
 } from "@pagopa/ts-commons/lib/responses";
-import { NonEmptyString, FiscalCode } from "@pagopa/ts-commons/lib/strings";
+import { NonEmptyString } from "@pagopa/ts-commons/lib/strings";
 import mockReq from "../../__mocks__/request";
 import mockRes from "../../__mocks__/response";
 import { mockedUser } from "../../__mocks__/user_mock";
@@ -75,7 +75,6 @@ const anEycaActivationDetail: EycaActivationDetail = {
   status: ActivationStatusEnum.COMPLETED
 };
 
-const allowedTestFiscalCodesMock = jest.fn().mockImplementation(() => []);
 const aGeneratedOtp: Otp = {
   code: "AAAAAA12312" as OtpCode,
   expires_at: new Date(),
@@ -93,8 +92,7 @@ describe("CgnController#getCgnStatus", () => {
   it("should make the correct service method call", async () => {
     const req = { ...mockReq(), user: mockedUser };
     const controller = new CgnController(
-      cgnService,
-      allowedTestFiscalCodesMock()
+      cgnService
     );
     await controller.getCgnStatus(req);
 
@@ -108,8 +106,7 @@ describe("CgnController#getCgnStatus", () => {
       Promise.resolve(ResponseSuccessJson(aPendingCgn))
     );
     const controller = new CgnController(
-      cgnService,
-      allowedTestFiscalCodesMock()
+      cgnService
     );
 
     const response = await controller.getCgnStatus(req);
@@ -126,8 +123,7 @@ describe("CgnController#getCgnStatus", () => {
     const res = mockRes();
 
     const controller = new CgnController(
-      cgnService,
-      allowedTestFiscalCodesMock()
+      cgnService
     );
 
     const response = await controller.getCgnStatus(req);
@@ -138,26 +134,6 @@ describe("CgnController#getCgnStatus", () => {
     expect(mockGetCgnStatus).not.toBeCalled();
     // http output is correct
     expect(res.json).toHaveBeenCalledWith(badRequestErrorResponse);
-  });
-
-  it("should not call getCgnStatus method on the CgnService with Not allowed user", async () => {
-    const req = { ...mockReq(), user: mockedUser };
-
-    allowedTestFiscalCodesMock.mockImplementationOnce(() => [
-      "GRBGPP87L04L741Z" as FiscalCode
-    ]);
-    const controller = new CgnController(
-      cgnService,
-      allowedTestFiscalCodesMock()
-    );
-
-    const response = await controller.getCgnStatus(req);
-
-    // service method is not called
-    expect(mockGetCgnStatus).not.toBeCalled();
-    expect(response).toMatchObject({
-      kind: "IResponseErrorForbiddenNotAuthorized"
-    });
   });
 });
 
@@ -170,8 +146,7 @@ describe("CgnController#getEycaStatus", () => {
     const req = { ...mockReq(), user: mockedUser };
 
     const controller = new CgnController(
-      cgnService,
-      allowedTestFiscalCodesMock()
+      cgnService
     );
     await controller.getEycaStatus(req);
 
@@ -186,8 +161,7 @@ describe("CgnController#getEycaStatus", () => {
     );
 
     const controller = new CgnController(
-      cgnService,
-      allowedTestFiscalCodesMock()
+      cgnService
     );
 
     const response = await controller.getEycaStatus(req);
@@ -204,8 +178,7 @@ describe("CgnController#getEycaStatus", () => {
     const res = mockRes();
 
     const controller = new CgnController(
-      cgnService,
-      allowedTestFiscalCodesMock()
+      cgnService
     );
 
     const response = await controller.getEycaStatus(req);
@@ -218,26 +191,6 @@ describe("CgnController#getEycaStatus", () => {
     // http output is correct
     expect(res.json).toHaveBeenCalledWith(badRequestErrorResponse);
   });
-
-  it("should not call getEycaStatus method on the CgnService with Not allowed user", async () => {
-    const req = { ...mockReq(), user: mockedUser };
-
-    allowedTestFiscalCodesMock.mockImplementationOnce(() => [
-      "GRBGPP87L04L741Z" as FiscalCode
-    ]);
-    const controller = new CgnController(
-      cgnService,
-      allowedTestFiscalCodesMock()
-    );
-
-    const response = await controller.getEycaStatus(req);
-
-    // service method is not called
-    expect(mockGetEycaStatus).not.toBeCalled();
-    expect(response).toMatchObject({
-      kind: "IResponseErrorForbiddenNotAuthorized"
-    });
-  });
 });
 
 describe("CgnController#startCgnActivation", () => {
@@ -249,8 +202,7 @@ describe("CgnController#startCgnActivation", () => {
     const req = { ...mockReq(), user: mockedUser };
 
     const controller = new CgnController(
-      cgnService,
-      allowedTestFiscalCodesMock()
+      cgnService
     );
     await controller.startCgnActivation(req);
 
@@ -265,8 +217,7 @@ describe("CgnController#startCgnActivation", () => {
     );
 
     const controller = new CgnController(
-      cgnService,
-      allowedTestFiscalCodesMock()
+      cgnService
     );
 
     const response = await controller.startCgnActivation(req);
@@ -283,8 +234,7 @@ describe("CgnController#startCgnActivation", () => {
     const res = mockRes();
 
     const controller = new CgnController(
-      cgnService,
-      allowedTestFiscalCodesMock()
+      cgnService
     );
 
     const response = await controller.startCgnActivation(req);
@@ -295,26 +245,6 @@ describe("CgnController#startCgnActivation", () => {
     expect(mockStartCgnActivation).not.toBeCalled();
     // http output is correct
     expect(res.json).toHaveBeenCalledWith(badRequestErrorResponse);
-  });
-
-  it("should not call startCgnActivation method on the CgnService with Not allowed user", async () => {
-    const req = { ...mockReq(), user: mockedUser };
-
-    allowedTestFiscalCodesMock.mockImplementationOnce(() => [
-      "GRBGPP87L04L741Z" as FiscalCode
-    ]);
-    const controller = new CgnController(
-      cgnService,
-      allowedTestFiscalCodesMock()
-    );
-
-    const response = await controller.startCgnActivation(req);
-
-    // service method is not called
-    expect(mockStartCgnActivation).not.toBeCalled();
-    expect(response).toMatchObject({
-      kind: "IResponseErrorForbiddenNotAuthorized"
-    });
   });
 });
 
@@ -327,8 +257,7 @@ describe("CgnController#getCgnActivation", () => {
     const req = { ...mockReq(), user: mockedUser };
 
     const controller = new CgnController(
-      cgnService,
-      allowedTestFiscalCodesMock()
+      cgnService
     );
     await controller.getCgnActivation(req);
 
@@ -343,8 +272,7 @@ describe("CgnController#getCgnActivation", () => {
     );
 
     const controller = new CgnController(
-      cgnService,
-      allowedTestFiscalCodesMock()
+      cgnService
     );
 
     const response = await controller.getCgnActivation(req);
@@ -361,8 +289,7 @@ describe("CgnController#getCgnActivation", () => {
     const res = mockRes();
 
     const controller = new CgnController(
-      cgnService,
-      allowedTestFiscalCodesMock()
+      cgnService
     );
 
     const response = await controller.getCgnActivation(req);
@@ -373,25 +300,6 @@ describe("CgnController#getCgnActivation", () => {
     expect(mockGetCgnActivation).not.toBeCalled();
     // http output is correct
     expect(res.json).toHaveBeenCalledWith(badRequestErrorResponse);
-  });
-  it("should not call getCgnActivation method on the CgnService with Not allowed user", async () => {
-    const req = { ...mockReq(), user: mockedUser };
-
-    allowedTestFiscalCodesMock.mockImplementationOnce(() => [
-      "GRBGPP87L04L741Z" as FiscalCode
-    ]);
-    const controller = new CgnController(
-      cgnService,
-      allowedTestFiscalCodesMock()
-    );
-
-    const response = await controller.getCgnActivation(req);
-
-    // service method is not called
-    expect(mockGetCgnActivation).not.toBeCalled();
-    expect(response).toMatchObject({
-      kind: "IResponseErrorForbiddenNotAuthorized"
-    });
   });
 });
 
@@ -404,8 +312,7 @@ describe("CgnController#getEycaActivation", () => {
     const req = { ...mockReq(), user: mockedUser };
 
     const controller = new CgnController(
-      cgnService,
-      allowedTestFiscalCodesMock()
+      cgnService
     );
     await controller.getEycaActivation(req);
 
@@ -420,8 +327,7 @@ describe("CgnController#getEycaActivation", () => {
     );
 
     const controller = new CgnController(
-      cgnService,
-      allowedTestFiscalCodesMock()
+      cgnService
     );
 
     const response = await controller.getEycaActivation(req);
@@ -438,8 +344,7 @@ describe("CgnController#getEycaActivation", () => {
     const res = mockRes();
 
     const controller = new CgnController(
-      cgnService,
-      allowedTestFiscalCodesMock()
+      cgnService
     );
 
     const response = await controller.getEycaActivation(req);
@@ -450,26 +355,6 @@ describe("CgnController#getEycaActivation", () => {
     expect(mockGetEycaActivation).not.toBeCalled();
     // http output is correct
     expect(res.json).toHaveBeenCalledWith(badRequestErrorResponse);
-  });
-
-  it("should not call getEycaActivation method on the CgnService with Not allowed user", async () => {
-    const req = { ...mockReq(), user: mockedUser };
-
-    allowedTestFiscalCodesMock.mockImplementationOnce(() => [
-      "GRBGPP87L04L741Z" as FiscalCode
-    ]);
-    const controller = new CgnController(
-      cgnService,
-      allowedTestFiscalCodesMock()
-    );
-
-    const response = await controller.getEycaActivation(req);
-
-    // service method is not called
-    expect(mockGetEycaActivation).not.toBeCalled();
-    expect(response).toMatchObject({
-      kind: "IResponseErrorForbiddenNotAuthorized"
-    });
   });
 });
 
@@ -482,8 +367,7 @@ describe("CgnController#startEycaActivation", () => {
     const req = { ...mockReq(), user: mockedUser };
 
     const controller = new CgnController(
-      cgnService,
-      allowedTestFiscalCodesMock()
+      cgnService
     );
     await controller.startEycaActivation(req);
 
@@ -498,8 +382,7 @@ describe("CgnController#startEycaActivation", () => {
     );
 
     const controller = new CgnController(
-      cgnService,
-      allowedTestFiscalCodesMock()
+      cgnService
     );
 
     const response = await controller.startEycaActivation(req);
@@ -516,8 +399,7 @@ describe("CgnController#startEycaActivation", () => {
     const res = mockRes();
 
     const controller = new CgnController(
-      cgnService,
-      allowedTestFiscalCodesMock()
+      cgnService
     );
 
     const response = await controller.startEycaActivation(req);
@@ -528,25 +410,6 @@ describe("CgnController#startEycaActivation", () => {
     expect(mockStartEycaActivation).not.toBeCalled();
     // http output is correct
     expect(res.json).toHaveBeenCalledWith(badRequestErrorResponse);
-  });
-  it("should not call startEycaActivation method on the CgnService with Not allowed user", async () => {
-    const req = { ...mockReq(), user: mockedUser };
-
-    allowedTestFiscalCodesMock.mockImplementationOnce(() => [
-      "GRBGPP87L04L741Z" as FiscalCode
-    ]);
-    const controller = new CgnController(
-      cgnService,
-      allowedTestFiscalCodesMock()
-    );
-
-    const response = await controller.startEycaActivation(req);
-
-    // service method is not called
-    expect(mockStartEycaActivation).not.toBeCalled();
-    expect(response).toMatchObject({
-      kind: "IResponseErrorForbiddenNotAuthorized"
-    });
   });
 });
 
@@ -559,8 +422,7 @@ describe("CgnController#startCgnUnsubscription", () => {
     const req = { ...mockReq(), user: mockedUser };
 
     const controller = new CgnController(
-      cgnService,
-      allowedTestFiscalCodesMock()
+      cgnService
     );
 
     await controller.startCgnUnsubscription(req);
@@ -576,8 +438,7 @@ describe("CgnController#startCgnUnsubscription", () => {
     );
 
     const controller = new CgnController(
-      cgnService,
-      allowedTestFiscalCodesMock()
+      cgnService
     );
 
     const response = await controller.startCgnUnsubscription(req);
@@ -594,8 +455,7 @@ describe("CgnController#startCgnUnsubscription", () => {
     const res = mockRes();
 
     const controller = new CgnController(
-      cgnService,
-      allowedTestFiscalCodesMock()
+      cgnService
     );
 
     const response = await controller.startCgnUnsubscription(req);
@@ -606,27 +466,6 @@ describe("CgnController#startCgnUnsubscription", () => {
     expect(mockStartCgnUnsubscription).not.toBeCalled();
     // http output is correct
     expect(res.json).toHaveBeenCalledWith(badRequestErrorResponse);
-  });
-
-  it("should not call startCgnUnsubscription method on the CgnService with Not allowed user", async () => {
-    const req = { ...mockReq(), user: mockedUser };
-
-    allowedTestFiscalCodesMock.mockImplementationOnce(() => [
-      "GRBGPP87L04L741Z" as FiscalCode
-    ]);
-
-    const controller = new CgnController(
-      cgnService,
-      allowedTestFiscalCodesMock()
-    );
-
-    const response = await controller.startCgnUnsubscription(req);
-
-    // service method is not called
-    expect(mockStartCgnUnsubscription).not.toBeCalled();
-    expect(response).toMatchObject({
-      kind: "IResponseErrorForbiddenNotAuthorized"
-    });
   });
 });
 
@@ -639,8 +478,7 @@ describe("CgnController#generateOtp", () => {
     const req = { ...mockReq(), user: mockedUser };
 
     const controller = new CgnController(
-      cgnService,
-      allowedTestFiscalCodesMock()
+      cgnService
     );
     await controller.generateOtp(req);
 
@@ -655,8 +493,7 @@ describe("CgnController#generateOtp", () => {
     );
 
     const controller = new CgnController(
-      cgnService,
-      allowedTestFiscalCodesMock()
+      cgnService
     );
 
     const response = await controller.generateOtp(req);
@@ -673,8 +510,7 @@ describe("CgnController#generateOtp", () => {
     const res = mockRes();
 
     const controller = new CgnController(
-      cgnService,
-      allowedTestFiscalCodesMock()
+      cgnService
     );
 
     const response = await controller.generateOtp(req);

--- a/src/controllers/cgnController.ts
+++ b/src/controllers/cgnController.ts
@@ -14,33 +14,18 @@ import {
   IResponseErrorValidation,
   IResponseSuccessAccepted,
   IResponseSuccessJson,
-  IResponseSuccessRedirectToResource,
-  ResponseErrorForbiddenNotAuthorized
+  IResponseSuccessRedirectToResource
 } from "@pagopa/ts-commons/lib/responses";
-import { FiscalCode } from "@pagopa/ts-commons/lib/strings";
 import * as express from "express";
 import { Otp } from "generated/cgn-card-platform/Otp";
 
 import { Card } from "../../generated/cgn-card-platform/Card";
 import { InstanceId } from "../../generated/cgn-card-platform/InstanceId";
 import CgnService from "../../src/services/cgnService";
-import { User, withUserFromRequest } from "../types/user";
-
-export const withAllowedUser = async <T>(
-  user: User,
-  allowedFiscalCodes: ReadonlyArray<FiscalCode>,
-  f: (user: User) => Promise<T>
-) =>
-  allowedFiscalCodes.length === 0 ||
-  allowedFiscalCodes.includes(user.fiscal_code)
-    ? f(user)
-    : ResponseErrorForbiddenNotAuthorized;
+import { withUserFromRequest } from "../types/user";
 
 export default class CgnController {
-  constructor(
-    private readonly cgnService: CgnService,
-    private readonly allowedFiscalCodes: ReadonlyArray<FiscalCode>
-  ) {}
+  constructor(private readonly cgnService: CgnService) {}
 
   /**
    * Get the Cgn status for the current user.
@@ -53,14 +38,7 @@ export default class CgnController {
     | IResponseErrorNotFound
     | IResponseErrorForbiddenNotAuthorized
     | IResponseSuccessJson<Card>
-  > =>
-    withUserFromRequest(req, (user) =>
-      withAllowedUser(
-        user,
-        this.allowedFiscalCodes,
-        this.cgnService.getCgnStatus
-      )
-    );
+  > => withUserFromRequest(req, this.cgnService.getCgnStatus);
 
   /**
    * Get the Eyca Card status for the current user.
@@ -74,14 +52,7 @@ export default class CgnController {
     | IResponseErrorForbiddenNotAuthorized
     | IResponseErrorConflict
     | IResponseSuccessJson<EycaCard>
-  > =>
-    withUserFromRequest(req, (user) =>
-      withAllowedUser(
-        user,
-        this.allowedFiscalCodes,
-        this.cgnService.getEycaStatus
-      )
-    );
+  > => withUserFromRequest(req, this.cgnService.getEycaStatus);
 
   /**
    * Start a Cgn activation for the current user.
@@ -95,14 +66,7 @@ export default class CgnController {
     | IResponseErrorConflict
     | IResponseSuccessRedirectToResource<InstanceId, InstanceId>
     | IResponseSuccessAccepted
-  > =>
-    withUserFromRequest(req, (user) =>
-      withAllowedUser(
-        user,
-        this.allowedFiscalCodes,
-        this.cgnService.startCgnActivation
-      )
-    );
+  > => withUserFromRequest(req, this.cgnService.startCgnActivation);
 
   /**
    * Get Cgn activation's process status for the current user.
@@ -115,14 +79,7 @@ export default class CgnController {
     | IResponseErrorNotFound
     | IResponseErrorForbiddenNotAuthorized
     | IResponseSuccessJson<CgnActivationDetail>
-  > =>
-    withUserFromRequest(req, (user) =>
-      withAllowedUser(
-        user,
-        this.allowedFiscalCodes,
-        this.cgnService.getCgnActivation
-      )
-    );
+  > => withUserFromRequest(req, this.cgnService.getCgnActivation);
 
   /**
    * Get EYCA card activation's process status for the current user.
@@ -135,14 +92,7 @@ export default class CgnController {
     | IResponseErrorNotFound
     | IResponseErrorForbiddenNotAuthorized
     | IResponseSuccessJson<EycaActivationDetail>
-  > =>
-    withUserFromRequest(req, (user) =>
-      withAllowedUser(
-        user,
-        this.allowedFiscalCodes,
-        this.cgnService.getEycaActivation
-      )
-    );
+  > => withUserFromRequest(req, this.cgnService.getEycaActivation);
 
   /**
    * Start an EYCA activation for the current user.
@@ -156,14 +106,7 @@ export default class CgnController {
     | IResponseErrorConflict
     | IResponseSuccessRedirectToResource<InstanceId, InstanceId>
     | IResponseSuccessAccepted
-  > =>
-    withUserFromRequest(req, (user) =>
-      withAllowedUser(
-        user,
-        this.allowedFiscalCodes,
-        this.cgnService.startEycaActivation
-      )
-    );
+  > => withUserFromRequest(req, this.cgnService.startEycaActivation);
 
   /**
    * Start a Cgn unsubscription for the current user.
@@ -177,14 +120,7 @@ export default class CgnController {
     | IResponseErrorConflict
     | IResponseSuccessRedirectToResource<InstanceId, InstanceId>
     | IResponseSuccessAccepted
-  > =>
-    withUserFromRequest(req, (user) =>
-      withAllowedUser(
-        user,
-        this.allowedFiscalCodes,
-        this.cgnService.startCgnUnsubscription
-      )
-    );
+  > => withUserFromRequest(req, this.cgnService.startCgnUnsubscription);
 
   /**
    * Generate a CGN OTP for the current user.
@@ -196,12 +132,5 @@ export default class CgnController {
     | IResponseErrorValidation
     | IResponseErrorForbiddenNotAuthorized
     | IResponseSuccessJson<Otp>
-  > =>
-    withUserFromRequest(req, (user) =>
-      withAllowedUser(
-        user,
-        this.allowedFiscalCodes,
-        this.cgnService.generateOtp
-      )
-    );
+  > => withUserFromRequest(req, this.cgnService.generateOtp);
 }

--- a/src/routes/cgnRoutes.ts
+++ b/src/routes/cgnRoutes.ts
@@ -2,7 +2,6 @@ import { Express } from "express";
 import * as express from "express";
 import * as passport from "passport";
 
-import { TEST_CGN_FISCAL_CODES } from "../config";
 import CgnController from "../controllers/cgnController";
 import CgnOperatorSearchController from "../controllers/cgnOperatorSearchController";
 import CgnOperatorSearchService from "../services/cgnOperatorSearchService";
@@ -38,10 +37,7 @@ export const registerLegacyCgnAPIRoutes = (
   cgnService: CgnService,
   bearerSessionTokenAuth: ReturnType<passport.Authenticator["authenticate"]>
 ): void => {
-  const cgnController: CgnController = new CgnController(
-    cgnService,
-    TEST_CGN_FISCAL_CODES
-  );
+  const cgnController: CgnController = new CgnController(cgnService);
 
   app.get(
     `${basePath}/status`,
@@ -105,10 +101,7 @@ export const registerCgnCardAPIRoutes = (
   authMiddleware: express.RequestHandler
 ): void => {
   const basePath = CGN_PLATFORM_API_BASE_PATH;
-  const cgnController: CgnController = new CgnController(
-    cgnService,
-    TEST_CGN_FISCAL_CODES
-  );
+  const cgnController: CgnController = new CgnController(cgnService);
 
   app.get(
     `${basePath}/status`,


### PR DESCRIPTION
#### List of Changes
- Removed legacy TEST_CGN_FISCAL_CODES config variable
- Refactored CGN controller and routes to not use test cf.

#### Motivation and Context
This was a switch to allow ONLY test users to be able to access CGN.
It was not used from starting tests.

#### How Has This Been Tested?
- build
- lint
- tests

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

