### PR TITLE
[#IOCOM-3094] chore: Third party attachment_url can be a base64 encoded url

### DIFF
--- a/.changeset/famous-paws-heal.md
+++ b/.changeset/famous-paws-heal.md
@@ -1,0 +1,5 @@
+---
+"@pagopa/io-backend": patch
+---
+
+third-party-message attachments_url can be a base64 encoded uri

--- a/src/controllers/__tests__/communicationController.test.ts
+++ b/src/controllers/__tests__/communicationController.test.ts
@@ -370,7 +370,7 @@ describe("CommunicationController#getThirdPartyAttachment", () => {
     req.user = mockedUser;
     req.params = {
       id: aValidMessageId,
-      attachment_url: Buffer.from(anAttachmentUrl).toString("base64url")
+      attachment_url: anAttachmentUrl
     };
 
     const controller = new CommunicationController(
@@ -382,7 +382,7 @@ describe("CommunicationController#getThirdPartyAttachment", () => {
 
     expect(mockGetThirdPartyAttachment).toHaveBeenCalledWith(
       proxyThirdPartyMessageResponse,
-      anAttachmentUrl,
+      req.params.attachment_url,
       aRemoteContentConfigurationWithBothEnv,
       undefined // we expect lollipopLocals to be undefined because lollipop is disabled here
     );
@@ -405,12 +405,13 @@ describe("CommunicationController#getThirdPartyAttachment", () => {
       Promise.resolve(ResponseSuccessOctet(buffer))
     );
 
-    const urlWithQuery = `${anAttachmentUrl}?attachmentIdx=${anAttachmentIdx}`;
-
     req.user = mockedUser;
     req.params = {
       id: aValidMessageId,
-      attachment_url: Buffer.from(urlWithQuery).toString("base64url")
+      attachment_url: anAttachmentUrl
+    };
+    req.query = {
+      attachmentIdx: anAttachmentIdx
     };
 
     const controller = new CommunicationController(
@@ -422,7 +423,7 @@ describe("CommunicationController#getThirdPartyAttachment", () => {
 
     expect(mockGetThirdPartyAttachment).toHaveBeenCalledWith(
       proxyThirdPartyMessageResponse,
-      urlWithQuery,
+      `${req.params.attachment_url}?attachmentIdx=${anAttachmentIdx}`,
       aRemoteContentConfigurationWithBothEnv,
       undefined // we expect lollipopLocals to be undefined because lollipop is disabled here
     );

--- a/src/controllers/__tests__/communicationController.test.ts
+++ b/src/controllers/__tests__/communicationController.test.ts
@@ -1,6 +1,7 @@
 import { ResponseSuccessJson } from "@pagopa/ts-commons/lib/responses";
 
 import mockReq from "../../__mocks__/request";
+import { resolveAttachmentUrl } from "../communicationController";
 import mockRes from "../../__mocks__/response";
 import NewMessagesService from "../../services/newMessagesService";
 import CommunicationController from "../communicationController";
@@ -369,7 +370,7 @@ describe("CommunicationController#getThirdPartyAttachment", () => {
     req.user = mockedUser;
     req.params = {
       id: aValidMessageId,
-      attachment_url: anAttachmentUrl
+      attachment_url: Buffer.from(anAttachmentUrl).toString("base64url")
     };
 
     const controller = new CommunicationController(
@@ -381,7 +382,7 @@ describe("CommunicationController#getThirdPartyAttachment", () => {
 
     expect(mockGetThirdPartyAttachment).toHaveBeenCalledWith(
       proxyThirdPartyMessageResponse,
-      req.params.attachment_url,
+      anAttachmentUrl,
       aRemoteContentConfigurationWithBothEnv,
       undefined // we expect lollipopLocals to be undefined because lollipop is disabled here
     );
@@ -404,13 +405,12 @@ describe("CommunicationController#getThirdPartyAttachment", () => {
       Promise.resolve(ResponseSuccessOctet(buffer))
     );
 
+    const urlWithQuery = `${anAttachmentUrl}?attachmentIdx=${anAttachmentIdx}`;
+
     req.user = mockedUser;
     req.params = {
       id: aValidMessageId,
-      attachment_url: anAttachmentUrl
-    };
-    req.query = {
-      attachmentIdx: anAttachmentIdx
+      attachment_url: Buffer.from(urlWithQuery).toString("base64url")
     };
 
     const controller = new CommunicationController(
@@ -422,7 +422,7 @@ describe("CommunicationController#getThirdPartyAttachment", () => {
 
     expect(mockGetThirdPartyAttachment).toHaveBeenCalledWith(
       proxyThirdPartyMessageResponse,
-      `${req.params.attachment_url}?attachmentIdx=${anAttachmentIdx}`,
+      urlWithQuery,
       aRemoteContentConfigurationWithBothEnv,
       undefined // we expect lollipopLocals to be undefined because lollipop is disabled here
     );
@@ -458,6 +458,88 @@ describe("CommunicationController#getThirdPartyAttachment", () => {
 
     expect(mockGetThirdPartyAttachment).not.toBeCalled();
     expect(res.json).toHaveBeenCalledWith(badRequestErrorResponse);
+  });
+
+  it("should decode a base64url-encoded attachment_url with embedded query string", async () => {
+    const req = mockReq();
+
+    mockGetThirdPartyMessageFnApp.mockReturnValue(
+      TE.of(proxyThirdPartyMessageResponse)
+    );
+
+    mockGetThirdPartyAttachment.mockReturnValue(
+      Promise.resolve(ResponseSuccessOctet(buffer))
+    );
+
+    const plainUrl = `/an/attachment/url/?attachmentIdx=1`;
+    const encodedUrl = Buffer.from(plainUrl).toString("base64url");
+
+    req.user = mockedUser;
+    req.params = {
+      id: aValidMessageId,
+      attachment_url: encodedUrl
+    };
+
+    const controller = new CommunicationController(
+      newMessageService,
+      mockLollipopApiClient
+    );
+
+    const response = await controller.getRemoteContentAttachment(req);
+
+    expect(mockGetThirdPartyAttachment).toHaveBeenCalledWith(
+      proxyThirdPartyMessageResponse,
+      plainUrl,
+      aRemoteContentConfigurationWithBothEnv,
+      undefined
+    );
+
+    expect(response).toEqual({
+      apply: expect.any(Function),
+      kind: "IResponseSuccessOctet",
+      value: buffer
+    });
+  });
+
+  it("should decode a base64url-encoded attachment_url without query string", async () => {
+    const req = mockReq();
+
+    mockGetThirdPartyMessageFnApp.mockReturnValue(
+      TE.of(proxyThirdPartyMessageResponse)
+    );
+
+    mockGetThirdPartyAttachment.mockReturnValue(
+      Promise.resolve(ResponseSuccessOctet(buffer))
+    );
+
+    const plainUrl = `/an/attachment/url/`;
+    const encodedUrl = Buffer.from(plainUrl).toString("base64url");
+
+    req.user = mockedUser;
+    req.params = {
+      id: aValidMessageId,
+      attachment_url: encodedUrl
+    };
+
+    const controller = new CommunicationController(
+      newMessageService,
+      mockLollipopApiClient
+    );
+
+    const response = await controller.getRemoteContentAttachment(req);
+
+    expect(mockGetThirdPartyAttachment).toHaveBeenCalledWith(
+      proxyThirdPartyMessageResponse,
+      plainUrl,
+      aRemoteContentConfigurationWithBothEnv,
+      undefined
+    );
+
+    expect(response).toEqual({
+      apply: expect.any(Function),
+      kind: "IResponseSuccessOctet",
+      value: buffer
+    });
   });
 });
 
@@ -627,4 +709,56 @@ describe("CommunicationController#upsertMessageStatus", () => {
       expect(res.json).toHaveBeenCalledWith(badRequestErrorResponse);
     }
   );
+});
+
+describe("resolveAttachmentUrl", () => {
+  it("decodes a base64url-encoded URL without a query string", () => {
+    const plainUrl = "pagopa-docx-b087e832-ba6d-4e6c-ae34-df8f7318ec6e.pdf";
+    const req = mockReq();
+    req.params = { attachment_url: Buffer.from(plainUrl).toString("base64url") };
+
+    expect(resolveAttachmentUrl(req)).toBe(plainUrl);
+  });
+
+  it("decodes a base64url-encoded URL with an embedded query string", () => {
+    const plainUrl = "delivery/notifications/received/SOME-ID/attachments/documents/0?attachmentIdx=1&foo=bar";
+    const req = mockReq();
+    req.params = { attachment_url: Buffer.from(plainUrl).toString("base64url") };
+
+    expect(resolveAttachmentUrl(req)).toBe(plainUrl);
+  });
+
+  it("decodes a URL-percent-encoded base64url value", () => {
+    const plainUrl = "delivery/notifications/received/SOME-ID/attachments/documents/0";
+    const base64urlEncoded = Buffer.from(plainUrl).toString("base64url");
+    const percentEncoded = encodeURIComponent(base64urlEncoded);
+    const req = mockReq();
+    req.params = { attachment_url: percentEncoded };
+
+    expect(resolveAttachmentUrl(req)).toBe(plainUrl);
+  });
+
+  it("falls back to raw param when value is not valid base64", () => {
+    const rawUrl = "delivery/notifications/received/b087e832-ba6d-4e6c-ae34-df8f7318ec6e/attachments/documents/0";
+    const req = mockReq();
+    req.params = { attachment_url: rawUrl };
+
+    expect(resolveAttachmentUrl(req)).toBe(rawUrl);
+  });
+
+  it("appends req.query to raw param in the fallback path", () => {
+    const rawUrl = "delivery/notifications/received/b087e832-ba6d-4e6c-ae34-df8f7318ec6e/attachments/documents/0";
+    const req = mockReq();
+    req.params = { attachment_url: rawUrl };
+    req.query = { attachmentIdx: "0", foo: "bar" };
+
+    expect(resolveAttachmentUrl(req)).toBe(`${rawUrl}?attachmentIdx=0&foo=bar`);
+  });
+
+  it("returns an empty string when the base64url-encoded input decodes to empty", () => {
+    const req = mockReq();
+    req.params = { attachment_url: Buffer.from("").toString("base64url") };
+
+    expect(resolveAttachmentUrl(req)).toBe("");
+  });
 });

--- a/src/controllers/__tests__/communicationController.test.ts
+++ b/src/controllers/__tests__/communicationController.test.ts
@@ -356,84 +356,71 @@ describe("CommunicationController#getThirdPartyAttachment", () => {
 
   const buffer = Buffer.from(base64File);
 
-  it("should call the getThirdPartyAttachment on the CommunicationController with valid values with no query params", async () => {
-    const req = mockReq();
+  it.each([
+    [
+      "with valid values with no query params",
+      anAttachmentUrl,
+      undefined as Record<string, unknown> | undefined,
+      anAttachmentUrl
+    ],
+    [
+      "with valid values and transfer query params",
+      anAttachmentUrl,
+      { attachmentIdx: anAttachmentIdx } as Record<string, unknown>,
+      `${anAttachmentUrl}?attachmentIdx=${anAttachmentIdx}`
+    ],
+    [
+      "with a base64url-encoded attachment_url with embedded query string",
+      Buffer.from(`/an/attachment/url/?attachmentIdx=1`).toString("base64url"),
+      undefined as Record<string, unknown> | undefined,
+      `/an/attachment/url/?attachmentIdx=1`
+    ],
+    [
+      "with a base64url-encoded attachment_url without query string",
+      Buffer.from(`/an/attachment/url/`).toString("base64url"),
+      undefined as Record<string, unknown> | undefined,
+      `/an/attachment/url/`
+    ]
+  ])(
+    "should call the getThirdPartyAttachment on the CommunicationController %s",
+    async (_, attachmentUrl, query, expectedUrl) => {
+      const req = mockReq();
 
-    mockGetThirdPartyMessageFnApp.mockReturnValue(
-      TE.of(proxyThirdPartyMessageResponse)
-    );
+      mockGetThirdPartyMessageFnApp.mockReturnValue(
+        TE.of(proxyThirdPartyMessageResponse)
+      );
 
-    mockGetThirdPartyAttachment.mockReturnValue(
-      Promise.resolve(ResponseSuccessOctet(buffer))
-    );
+      mockGetThirdPartyAttachment.mockReturnValue(
+        Promise.resolve(ResponseSuccessOctet(buffer))
+      );
 
-    req.user = mockedUser;
-    req.params = {
-      id: aValidMessageId,
-      attachment_url: anAttachmentUrl
-    };
+      req.user = mockedUser;
+      req.params = { id: aValidMessageId, attachment_url: attachmentUrl };
+      if (query !== undefined) {
+        req.query = query;
+      }
 
-    const controller = new CommunicationController(
-      newMessageService,
-      mockLollipopApiClient
-    );
+      const controller = new CommunicationController(
+        newMessageService,
+        mockLollipopApiClient
+      );
 
-    const response = await controller.getRemoteContentAttachment(req);
+      const response = await controller.getRemoteContentAttachment(req);
 
-    expect(mockGetThirdPartyAttachment).toHaveBeenCalledWith(
-      proxyThirdPartyMessageResponse,
-      req.params.attachment_url,
-      aRemoteContentConfigurationWithBothEnv,
-      undefined // we expect lollipopLocals to be undefined because lollipop is disabled here
-    );
+      expect(mockGetThirdPartyAttachment).toHaveBeenCalledWith(
+        proxyThirdPartyMessageResponse,
+        expectedUrl,
+        aRemoteContentConfigurationWithBothEnv,
+        undefined // we expect lollipopLocals to be undefined because lollipop is disabled here
+      );
 
-    expect(response).toEqual({
-      apply: expect.any(Function),
-      kind: "IResponseSuccessOctet",
-      value: buffer
-    });
-  });
-
-  it("should call the getThirdPartyAttachment on the CommunicationController with valid values and transfer query params", async () => {
-    const req = mockReq();
-
-    mockGetThirdPartyMessageFnApp.mockReturnValue(
-      TE.of(proxyThirdPartyMessageResponse)
-    );
-
-    mockGetThirdPartyAttachment.mockReturnValue(
-      Promise.resolve(ResponseSuccessOctet(buffer))
-    );
-
-    req.user = mockedUser;
-    req.params = {
-      id: aValidMessageId,
-      attachment_url: anAttachmentUrl
-    };
-    req.query = {
-      attachmentIdx: anAttachmentIdx
-    };
-
-    const controller = new CommunicationController(
-      newMessageService,
-      mockLollipopApiClient
-    );
-
-    const response = await controller.getRemoteContentAttachment(req);
-
-    expect(mockGetThirdPartyAttachment).toHaveBeenCalledWith(
-      proxyThirdPartyMessageResponse,
-      `${req.params.attachment_url}?attachmentIdx=${anAttachmentIdx}`,
-      aRemoteContentConfigurationWithBothEnv,
-      undefined // we expect lollipopLocals to be undefined because lollipop is disabled here
-    );
-
-    expect(response).toEqual({
-      apply: expect.any(Function),
-      kind: "IResponseSuccessOctet",
-      value: buffer
-    });
-  });
+      expect(response).toEqual({
+        apply: expect.any(Function),
+        kind: "IResponseSuccessOctet",
+        value: buffer
+      });
+    }
+  );
 
   it("should not call the getThirdPartyAttachment on the CommunicationController with empty user", async () => {
     const req = mockReq();
@@ -459,88 +446,6 @@ describe("CommunicationController#getThirdPartyAttachment", () => {
 
     expect(mockGetThirdPartyAttachment).not.toBeCalled();
     expect(res.json).toHaveBeenCalledWith(badRequestErrorResponse);
-  });
-
-  it("should decode a base64url-encoded attachment_url with embedded query string", async () => {
-    const req = mockReq();
-
-    mockGetThirdPartyMessageFnApp.mockReturnValue(
-      TE.of(proxyThirdPartyMessageResponse)
-    );
-
-    mockGetThirdPartyAttachment.mockReturnValue(
-      Promise.resolve(ResponseSuccessOctet(buffer))
-    );
-
-    const plainUrl = `/an/attachment/url/?attachmentIdx=1`;
-    const encodedUrl = Buffer.from(plainUrl).toString("base64url");
-
-    req.user = mockedUser;
-    req.params = {
-      id: aValidMessageId,
-      attachment_url: encodedUrl
-    };
-
-    const controller = new CommunicationController(
-      newMessageService,
-      mockLollipopApiClient
-    );
-
-    const response = await controller.getRemoteContentAttachment(req);
-
-    expect(mockGetThirdPartyAttachment).toHaveBeenCalledWith(
-      proxyThirdPartyMessageResponse,
-      plainUrl,
-      aRemoteContentConfigurationWithBothEnv,
-      undefined
-    );
-
-    expect(response).toEqual({
-      apply: expect.any(Function),
-      kind: "IResponseSuccessOctet",
-      value: buffer
-    });
-  });
-
-  it("should decode a base64url-encoded attachment_url without query string", async () => {
-    const req = mockReq();
-
-    mockGetThirdPartyMessageFnApp.mockReturnValue(
-      TE.of(proxyThirdPartyMessageResponse)
-    );
-
-    mockGetThirdPartyAttachment.mockReturnValue(
-      Promise.resolve(ResponseSuccessOctet(buffer))
-    );
-
-    const plainUrl = `/an/attachment/url/`;
-    const encodedUrl = Buffer.from(plainUrl).toString("base64url");
-
-    req.user = mockedUser;
-    req.params = {
-      id: aValidMessageId,
-      attachment_url: encodedUrl
-    };
-
-    const controller = new CommunicationController(
-      newMessageService,
-      mockLollipopApiClient
-    );
-
-    const response = await controller.getRemoteContentAttachment(req);
-
-    expect(mockGetThirdPartyAttachment).toHaveBeenCalledWith(
-      proxyThirdPartyMessageResponse,
-      plainUrl,
-      aRemoteContentConfigurationWithBothEnv,
-      undefined
-    );
-
-    expect(response).toEqual({
-      apply: expect.any(Function),
-      kind: "IResponseSuccessOctet",
-      value: buffer
-    });
   });
 });
 

--- a/src/controllers/communicationController.ts
+++ b/src/controllers/communicationController.ts
@@ -57,17 +57,16 @@ import {
 export const resolveAttachmentUrl = (req: express.Request): string => {
   const rawAttachmentParam = decodeURIComponent(req.params.attachment_url);
   try {
-    const decodedAttachmentParam = decodeURIComponent(rawAttachmentParam);
-    const decodedAttachmentUrl = atob(decodedAttachmentParam);
+    const decodedAttachmentUrl = atob(rawAttachmentParam);
     if (
       btoa(decodedAttachmentUrl).replace(/=+$/, "") !==
-      decodedAttachmentParam.replace(/=+$/, "")
+      rawAttachmentParam.replace(/=+$/, "")
     ) {
-      return `${req.params.attachment_url}${QueryString.stringify(req.query, { addQueryPrefix: true })}`;
+      return `${rawAttachmentParam}${QueryString.stringify(req.query, { addQueryPrefix: true })}`;
     }
     return decodedAttachmentUrl;
   } catch (e) {
-    return `${req.params.attachment_url}${QueryString.stringify(req.query, { addQueryPrefix: true })}`;
+    return `${rawAttachmentParam}${QueryString.stringify(req.query, { addQueryPrefix: true })}`;
   }
 };
 

--- a/src/controllers/communicationController.ts
+++ b/src/controllers/communicationController.ts
@@ -56,17 +56,18 @@ import {
 
 export const resolveAttachmentUrl = (req: express.Request): string => {
   const rawAttachmentParam = decodeURIComponent(req.params.attachment_url);
+  const fallback = `${rawAttachmentParam}${QueryString.stringify(req.query, { addQueryPrefix: true })}`;
   try {
     const decodedAttachmentUrl = atob(rawAttachmentParam);
     if (
       btoa(decodedAttachmentUrl).replace(/=+$/, "") !==
       rawAttachmentParam.replace(/=+$/, "")
     ) {
-      return `${rawAttachmentParam}${QueryString.stringify(req.query, { addQueryPrefix: true })}`;
+      return fallback;
     }
     return decodedAttachmentUrl;
   } catch (e) {
-    return `${rawAttachmentParam}${QueryString.stringify(req.query, { addQueryPrefix: true })}`;
+    return fallback;
   }
 };
 

--- a/src/controllers/communicationController.ts
+++ b/src/controllers/communicationController.ts
@@ -54,17 +54,23 @@ import {
   withValidatedOrValidationError
 } from "../utils/responses";
 
+export const resolveAttachmentUrl = (req: express.Request): string => {
+  const rawAttachmentParam = req.params.attachment_url;
+  try {
+    const decodedAttachmentParam = decodeURIComponent(rawAttachmentParam);
+    return atob(decodedAttachmentParam);
+  } catch (e) {
+    return `${rawAttachmentParam}${QueryString.stringify(req.query, { addQueryPrefix: true })}`;
+  }
+};
+
 export const withGetThirdPartyAttachmentParams = async <T>(
   req: express.Request,
   f: (id: Ulid, attachment_url: NonEmptyString) => Promise<T>
 ) =>
   withValidatedOrValidationError(Ulid.decode(req.params.id), (id) =>
     withValidatedOrValidationError(
-      pipe(
-        QueryString.stringify(req.query, { addQueryPrefix: true }),
-        (queryString) => `${req.params.attachment_url}${queryString}`,
-        NonEmptyString.decode
-      ),
+      NonEmptyString.decode(resolveAttachmentUrl(req)),
       (attachment_url) => f(id, attachment_url)
     )
   );

--- a/src/controllers/communicationController.ts
+++ b/src/controllers/communicationController.ts
@@ -60,8 +60,8 @@ export const resolveAttachmentUrl = (req: express.Request): string => {
   try {
     const decodedAttachmentUrl = atob(rawAttachmentParam);
     if (
-      btoa(decodedAttachmentUrl).replace(/=+$/, "") !==
-      rawAttachmentParam.replace(/=+$/, "")
+      btoa(decodedAttachmentUrl).split("=")[0] !==
+      rawAttachmentParam.split("=")[0]
     ) {
       return fallback;
     }

--- a/src/controllers/communicationController.ts
+++ b/src/controllers/communicationController.ts
@@ -55,12 +55,19 @@ import {
 } from "../utils/responses";
 
 export const resolveAttachmentUrl = (req: express.Request): string => {
-  const rawAttachmentParam = req.params.attachment_url;
+  const rawAttachmentParam = decodeURIComponent(req.params.attachment_url);
   try {
     const decodedAttachmentParam = decodeURIComponent(rawAttachmentParam);
-    return atob(decodedAttachmentParam);
+    const decodedAttachmentUrl = atob(decodedAttachmentParam);
+    if (
+      btoa(decodedAttachmentUrl).replace(/=+$/, "") !==
+      decodedAttachmentParam.replace(/=+$/, "")
+    ) {
+      return `${req.params.attachment_url}${QueryString.stringify(req.query, { addQueryPrefix: true })}`;
+    }
+    return decodedAttachmentUrl;
   } catch (e) {
-    return `${rawAttachmentParam}${QueryString.stringify(req.query, { addQueryPrefix: true })}`;
+    return `${req.params.attachment_url}${QueryString.stringify(req.query, { addQueryPrefix: true })}`;
   }
 };
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->
The new `${basePath}/third-party-messages/:id/attachments/:attachment_url(*)` API can now accept a base64 encoded url as attachment_url. 
If the attachement_url is not a base64 than the logic fallback to the actual behavior .
 
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
AppIO will pass a base64 for all the attachment_url but right now we need to ensure backward compatibility for both behaviors. 

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Added new unit tests.

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a changeset, which I've added.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
