### PR TITLE
[IOCOM-3013] Remove gcm from platform enum

### DIFF
--- a/.changeset/salty-plums-marry.md
+++ b/.changeset/salty-plums-marry.md
@@ -1,0 +1,5 @@
+---
+"@pagopa/io-backend": patch
+---
+
+remove gcm platform enum from notification api

--- a/api_backend.yaml
+++ b/api_backend.yaml
@@ -534,7 +534,7 @@ paths:
           required: true
           x-examples:
             application/json:
-              platform: "gcm"
+              platform: "fcmv1"
               pushChannel: "push-notification-service-handle"
       responses:
         "200":
@@ -1098,7 +1098,6 @@ definitions:
     description: The platform type where the installation happened.
     x-extensible-enum:
       - apns
-      - gcm
       - fcmv1
   PushChannel:
     type: string

--- a/notification_queue_messages.yaml
+++ b/notification_queue_messages.yaml
@@ -9,7 +9,6 @@ definitions:
     description: The platform type where the installation happened.
     x-extensible-enum:
       - apns
-      - gcm
       - fcmv1
   NotificationMessageKind:
     type: string

--- a/openapi/api_backend.template.yaml
+++ b/openapi/api_backend.template.yaml
@@ -468,7 +468,7 @@ paths:
           required: true
           x-examples:
             application/json:
-              platform: "gcm"
+              platform: "fcmv1"
               pushChannel: "fLKP3EATnBI:APA91bEy4go681jeSEpLkNqhtIrdPnEKu6Dfi-STtUiEnQn8RwMfBiPGYaqdWrmzJyXIh5Yms4017MYRS9O1LGPZwA4sOLCNIoKl4Fwg7cSeOkliAAtlQ0rVg71Kr5QmQiLlDJyxcq3p"
       responses:
         "200":
@@ -1024,7 +1024,6 @@ definitions:
     description: The platform type where the installation happened.
     x-extensible-enum:
       - apns
-      - gcm
       - fcmv1
   PushChannel:
     type: string

--- a/openapi/api_communication.template.yaml
+++ b/openapi/api_communication.template.yaml
@@ -438,7 +438,7 @@ paths:
             schema:
               $ref: "#/components/schemas/Installation"
             example:
-              platform: "gcm"
+              platform: "fcmv1"
               pushChannel: "push-notification-service-handle"
       responses:
         "200":
@@ -731,7 +731,6 @@ components:
       description: The platform type where the installation happened.
       enum:
         - apns
-        - gcm
         - fcmv1
     PushChannel:
       type: string

--- a/openapi/generated/api_backend.yaml
+++ b/openapi/generated/api_backend.yaml
@@ -260,9 +260,9 @@ paths:
                 subject: "my subject ............",
                 third_party_data: [{id: "aThirdPartyMessageId"}]
               },
-              third_party_message: { 
-                attachments: [], 
-                custom_property: "a custom property" 
+              third_party_message: {
+                attachments: [],
+                custom_property: "a custom property"
               },
               created_at: "2018-06-06T12:22:24.523Z",
               fiscal_code: "LSSLCU79B24L219P",
@@ -488,7 +488,7 @@ paths:
           required: true
           x-examples:
             application/json:
-              platform: gcm
+              platform: fcmv1
               pushChannel: >-
                 fLKP3EATnBI:APA91bEy4go681jeSEpLkNqhtIrdPnEKu6Dfi-STtUiEnQn8RwMfBiPGYaqdWrmzJyXIh5Yms4017MYRS9O1LGPZwA4sOLCNIoKl4Fwg7cSeOkliAAtlQ0rVg71Kr5QmQiLlDJyxcq3p
       responses:
@@ -1217,7 +1217,7 @@ definitions:
     example: '2018-10-13T00:00:00.000Z'
   PaymentNoticeNumber:
     description: >-
-      The field "Numero Avviso" of pagoPa, needed to identify the payment. 
+      The field "Numero Avviso" of pagoPa, needed to identify the payment.
       Format is `<aux digit(1n)>[<application code> (2n)]<codice IUV (15|17n)>`.
       See [pagoPa
       specs](https://docs.pagopa.it/saci/specifiche-attuative-dei-codici-identificativi-di-versamento-riversamento-e-rendicontazione/premessa)
@@ -2493,7 +2493,6 @@ definitions:
     description: The platform type where the installation happened.
     x-extensible-enum:
       - apns
-      - gcm
       - fcmv1
   PushChannel:
     type: string

--- a/openapi/generated/api_backend.yaml
+++ b/openapi/generated/api_backend.yaml
@@ -260,9 +260,9 @@ paths:
                 subject: "my subject ............",
                 third_party_data: [{id: "aThirdPartyMessageId"}]
               },
-              third_party_message: {
-                attachments: [],
-                custom_property: "a custom property"
+              third_party_message: { 
+                attachments: [], 
+                custom_property: "a custom property" 
               },
               created_at: "2018-06-06T12:22:24.523Z",
               fiscal_code: "LSSLCU79B24L219P",
@@ -1217,7 +1217,7 @@ definitions:
     example: '2018-10-13T00:00:00.000Z'
   PaymentNoticeNumber:
     description: >-
-      The field "Numero Avviso" of pagoPa, needed to identify the payment.
+      The field "Numero Avviso" of pagoPa, needed to identify the payment. 
       Format is `<aux digit(1n)>[<application code> (2n)]<codice IUV (15|17n)>`.
       See [pagoPa
       specs](https://docs.pagopa.it/saci/specifiche-attuative-dei-codici-identificativi-di-versamento-riversamento-e-rendicontazione/premessa)

--- a/openapi/generated/api_communication.yaml
+++ b/openapi/generated/api_communication.yaml
@@ -209,11 +209,11 @@ paths:
                   Aprire il messaggio su IO equivale infatti a firmare la
                   ricevuta di ritorno di una raccomandata tradizionale.
 
-                  **Mittente**: Comune di Xxxxxxx  
+                  **Mittente**: Comune di Xxxxxxx
 
-                  **Oggetto**: Infrazione al codice della strada  
+                  **Oggetto**: Infrazione al codice della strada
 
-                  **Data e ora**: 12 Luglio 2022 - 12.36  
+                  **Data e ora**: 12 Luglio 2022 - 12.36
 
                   **Codice IUN**: YYYYMM-1-ABCD-EFGH-X
         '204':
@@ -455,7 +455,7 @@ paths:
             schema:
               $ref: '#/components/schemas/Installation'
             example:
-              platform: gcm
+              platform: fcmv1
               pushChannel: push-notification-service-handle
       responses:
         '200':
@@ -1229,7 +1229,6 @@ components:
       description: The platform type where the installation happened.
       enum:
         - apns
-        - gcm
         - fcmv1
     PushChannel:
       type: string

--- a/openapi/generated/api_communication.yaml
+++ b/openapi/generated/api_communication.yaml
@@ -209,11 +209,11 @@ paths:
                   Aprire il messaggio su IO equivale infatti a firmare la
                   ricevuta di ritorno di una raccomandata tradizionale.
 
-                  **Mittente**: Comune di Xxxxxxx
+                  **Mittente**: Comune di Xxxxxxx  
 
-                  **Oggetto**: Infrazione al codice della strada
+                  **Oggetto**: Infrazione al codice della strada  
 
-                  **Data e ora**: 12 Luglio 2022 - 12.36
+                  **Data e ora**: 12 Luglio 2022 - 12.36  
 
                   **Codice IUN**: YYYYMM-1-ABCD-EFGH-X
         '204':

--- a/public/device.html
+++ b/public/device.html
@@ -29,7 +29,7 @@
       <label for="platform">Platform:</label>
       <select id="platform" class="form-control" required>
         <option value="apns">Apple</option>
-        <option value="gcm">Google</option>
+        <option value="fcmv1">Google (FCMv1)</option>
       </select>
     </div>
     <div class="form-group">

--- a/src/services/__tests__/notificationService.test.ts
+++ b/src/services/__tests__/notificationService.test.ts
@@ -28,13 +28,13 @@ const anAppleInstallation: CreateOrUpdateInstallationMessage = {
   tags: [aFiscalCodeHash] // This is the sha256 of "GRBGPP87L04L741X"
 };
 const aGoogleDevice = {
-  platform: PlatformEnum.gcm,
+  platform: PlatformEnum.fcmv1,
   pushChannel: aPushChannel
 };
 const aGoogleInstallation: CreateOrUpdateInstallationMessage = {
   installationId: toFiscalCodeHash(aFiscalCode),
   kind: CreateOrUpdateKind.CreateOrUpdateInstallation,
-  platform: PlatformEnum.gcm,
+  platform: PlatformEnum.fcmv1,
   pushChannel: aPushChannel,
   tags: [aFiscalCodeHash] // This is the sha256 of "GRBGPP87L04L741X"
 };
@@ -75,7 +75,7 @@ describe("NotificationService#createOrUpdateInstallation", () => {
     );
   });
 
-  it("should submit a correct installation to the Queue Storage, Google platform", async () => {
+  it("should submit a correct installation to the Queue Storage, FCMv1 platform", async () => {
     mockSendMessage.mockImplementation((_) => Promise.resolve());
 
     const service = new NotificationService("", "");


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->


#### List of Changes
<!--- Describe your changes in detail -->
Remove the gcm platform from the notification API allowing apns and fcmv1 only. 
Update api_backend  swagger

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Following the AppIO minimum version bump, the api_backend notifications endpoint must be updated accordingly.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a changeset, which I've added.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
